### PR TITLE
feat(session): env variable support for Claude command args

### DIFF
--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -83,7 +83,12 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			.toString(36)
 			.substr(2, 9)}`;
 
-		const ptyProcess = spawn('claude', [], {
+		// Parse Claude command arguments from environment variable
+		const claudeArgs = process.env['CCMANAGER_CLAUDE_ARGS']
+			? process.env['CCMANAGER_CLAUDE_ARGS'].split(' ')
+			: [];
+
+		const ptyProcess = spawn('claude', claudeArgs, {
 			name: 'xterm-color',
 			cols: process.stdout.columns || 80,
 			rows: process.stdout.rows || 24,


### PR DESCRIPTION
Allow customization of Claude command arguments via CCMANAGER_CLAUDE_ARGS environment variable. Arguments are space-separated and passed directly to the Claude spawn command.