### PR TITLE
feat: add status change hooks with configurable commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Claude Code states are detected by advanced output analysis in `promptDetector.t
 
 ### Keyboard Shortcuts
 
-- Fully configurable shortcuts stored in `~/.config/ccmanager/shortcuts.json`
+- Fully configurable shortcuts stored in `~/.config/ccmanager/config.json`
 - Platform-aware configuration paths (Windows uses `%APPDATA%`)
 - Default shortcuts for common actions (back, quit, refresh, etc.)
 - Visual configuration UI accessible from main menu

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ https://github.com/user-attachments/assets/a6d80e73-dc06-4ef8-849d-e3857f6c7024
 - Visual status indicators for session states (busy, waiting, idle)
 - Create, merge, and delete worktrees from within the app
 - Configurable keyboard shortcuts
+- Status change hooks for automation and notifications
 
 ## Why CCManager over Claude Squad?
 
@@ -76,22 +77,20 @@ The arguments are applied to all Claude Code sessions started by CCManager.
 
 You can customize keyboard shortcuts in two ways:
 
-1. **Through the UI**: Select "Configure Shortcuts" from the main menu
-2. **Configuration file**: Edit `~/.config/ccmanager/shortcuts.json`
+1. **Through the UI**: Select "Configuration" → "Configure Shortcuts" from the main menu
+2. **Configuration file**: Edit `~/.config/ccmanager/config.json`
 
 Example configuration:
 ```json
 {
-  "returnToMenu": {
-    "ctrl": true,
-    "key": "r"
-  },
-  "exitApp": {
-    "ctrl": true,
-    "key": "x"
-  },
-  "cancel": {
-    "key": "escape"
+  "shortcuts": {
+    "returnToMenu": {
+      "ctrl": true,
+      "key": "r"
+    },
+    "cancel": {
+      "key": "escape"
+    }
   }
 }
 ```
@@ -103,6 +102,46 @@ Example configuration:
   - Ctrl+C
   - Ctrl+D
   - Ctrl+[ (equivalent to Escape)
+
+## Status Change Hooks
+
+CCManager can execute custom commands when Claude Code session status changes. This enables powerful automation workflows like desktop notifications, logging, or integration with other tools.
+
+### Overview
+
+Status hooks allow you to:
+- Get notified when Claude needs your input
+- Track time spent in different states
+- Trigger automations based on session activity
+- Integrate with notification systems like [noti](https://github.com/variadico/noti)
+
+### Configuration
+
+Configure hooks through the UI:
+1. Select "Configuration" from the main menu
+2. Choose "Configure Status Hooks"
+3. Set commands for each state (idle, busy, waiting_input)
+
+### Available Environment Variables
+
+Your hook commands have access to these environment variables:
+- `CCMANAGER_OLD_STATE`: Previous state
+- `CCMANAGER_NEW_STATE`: New state (idle, busy, or waiting_input)
+- `CCMANAGER_WORKTREE`: Path to the worktree
+- `CCMANAGER_WORKTREE_BRANCH`: Git branch name
+- `CCMANAGER_SESSION_ID`: Unique session identifier
+
+### Example: Desktop Notifications
+
+```bash
+# Notify when Claude needs input
+noti -t "Claude Code" -m "Needs your input on $CCMANAGER_WORKTREE_BRANCH"
+
+# Alert when task completes
+[ "$CCMANAGER_OLD_STATE" = "busy" ] && noti -t "Claude Done" -m "Task complete!"
+```
+
+For more examples and detailed setup instructions, see [docs/state-hooks.md](docs/state-hooks.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ The arguments are applied to all Claude Code sessions started by CCManager.
 You can customize keyboard shortcuts in two ways:
 
 1. **Through the UI**: Select "Configuration" → "Configure Shortcuts" from the main menu
-2. **Configuration file**: Edit `~/.config/ccmanager/config.json`
+2. **Configuration file**: Edit `~/.config/ccmanager/config.json` (or legacy `~/.config/ccmanager/shortcuts.json`)
 
 Example configuration:
 ```json
+// config.json (new format)
 {
   "shortcuts": {
     "returnToMenu": {
@@ -93,7 +94,20 @@ Example configuration:
     }
   }
 }
+
+// shortcuts.json (legacy format, still supported)
+{
+  "returnToMenu": {
+    "ctrl": true,
+    "key": "r"
+  },
+  "cancel": {
+    "key": "escape"
+  }
+}
 ```
+
+Note: Shortcuts from `shortcuts.json` will be automatically migrated to `config.json` on first use.
 
 ### Restrictions
 

--- a/README.md
+++ b/README.md
@@ -115,33 +115,7 @@ Status hooks allow you to:
 - Trigger automations based on session activity
 - Integrate with notification systems like [noti](https://github.com/variadico/noti)
 
-### Configuration
-
-Configure hooks through the UI:
-1. Select "Configuration" from the main menu
-2. Choose "Configure Status Hooks"
-3. Set commands for each state (idle, busy, waiting_input)
-
-### Available Environment Variables
-
-Your hook commands have access to these environment variables:
-- `CCMANAGER_OLD_STATE`: Previous state
-- `CCMANAGER_NEW_STATE`: New state (idle, busy, or waiting_input)
-- `CCMANAGER_WORKTREE`: Path to the worktree
-- `CCMANAGER_WORKTREE_BRANCH`: Git branch name
-- `CCMANAGER_SESSION_ID`: Unique session identifier
-
-### Example: Desktop Notifications
-
-```bash
-# Notify when Claude needs input
-noti -t "Claude Code" -m "Needs your input on $CCMANAGER_WORKTREE_BRANCH"
-
-# Alert when task completes
-[ "$CCMANAGER_OLD_STATE" = "busy" ] && noti -t "Claude Done" -m "Task complete!"
-```
-
-For more examples and detailed setup instructions, see [docs/state-hooks.md](docs/state-hooks.md).
+For detailed setup instructions, see [docs/state-hooks.md](docs/state-hooks.md).
 
 ## Development
 

--- a/docs/state-hooks.md
+++ b/docs/state-hooks.md
@@ -1,4 +1,4 @@
-# Status Change Hooks Example with Noti
+# Status Change Hooks Guide
 
 This example demonstrates how to use [noti](https://github.com/variadico/noti) to receive desktop notifications when Claude Code session status changes.
 

--- a/docs/state-hooks.md
+++ b/docs/state-hooks.md
@@ -1,25 +1,10 @@
 # Status Change Hooks Guide
 
-This example demonstrates how to use [noti](https://github.com/variadico/noti) to receive desktop notifications when Claude Code session status changes.
-
-## Prerequisites
-
-First, install noti:
-
-```bash
-# macOS
-brew install noti
-
-# Linux
-go install github.com/variadico/noti/cmd/noti@latest
-
-# Or download from releases
-# https://github.com/variadico/noti/releases
-```
-
 ## Configuration Examples
 
-### Basic Notifications
+### Notifications
+
+Below, I'll provide an example using the [noti](https://github.com/variadico/noti) command. You don't necessarily have to use `noti`. Please customize it as needed.
 
 Configure CCManager to send notifications for each status:
 
@@ -42,45 +27,6 @@ noti -t "Claude Code" -m "Session is now busy on branch $CCMANAGER_WORKTREE_BRAN
 noti -t "Claude Code" -m "Claude is waiting for your input in $CCMANAGER_WORKTREE_BRANCH branch"
 ```
 
-### Advanced Examples
-
-#### Play Sound on Status Change
-
-**Idle Hook (with sound):**
-```bash
-noti -t "Claude Code" -m "Session idle" && afplay /System/Library/Sounds/Glass.aiff
-```
-
-**Waiting for Input (urgent):**
-```bash
-noti -t "Claude Code - Action Required" -m "Claude needs your input!" && afplay /System/Library/Sounds/Ping.aiff
-```
-
-#### Log Status Changes
-
-Create a status change logger:
-
-```bash
-echo "$(date): $CCMANAGER_NEW_STATE (from $CCMANAGER_OLD_STATE) in $CCMANAGER_WORKTREE" >> ~/.ccmanager/status.log && noti -t "CCManager" -m "Status: $CCMANAGER_NEW_STATE"
-```
-
-#### Smart Notifications (only notify on specific transitions)
-
-**Notify only when Claude becomes idle after being busy:**
-```bash
-[ "$CCMANAGER_OLD_STATE" = "busy" ] && noti -t "Claude Code Complete" -m "Task finished on $CCMANAGER_WORKTREE_BRANCH branch"
-```
-
-**Notify only when waiting for input after being busy:**
-```bash
-[ "$CCMANAGER_OLD_STATE" = "busy" ] && noti -t "Claude Code" -m "Claude needs your decision on $CCMANAGER_WORKTREE_BRANCH" -s
-```
-
-**Branch-specific notifications:**
-```bash
-[[ "$CCMANAGER_WORKTREE_BRANCH" == "main" ]] && noti -t "⚠️ Main Branch" -m "Claude is $CCMANAGER_NEW_STATE on main!"
-```
-
 #### Integration with Other Tools
 
 **Send to Slack (using webhook):**
@@ -93,62 +39,10 @@ curl -X POST -H 'Content-type: application/json' --data '{"text":"Claude is now 
 tmux set -g status-right "Claude: $CCMANAGER_NEW_STATE" && noti -t "Claude Status" -m "$CCMANAGER_NEW_STATE"
 ```
 
-## Platform-Specific Examples
-
-### macOS with Native Notifications
-
-```bash
-# Using osascript for more control
-osascript -e 'display notification "Session is '"$CCMANAGER_NEW_STATE"'" with title "Claude Code" subtitle "'"$CCMANAGER_WORKTREE"'"'
-```
-
-### Linux with notify-send
-
-```bash
-# If you prefer notify-send over noti
-notify-send "Claude Code" "Status: $CCMANAGER_NEW_STATE in $CCMANAGER_WORKTREE" --icon=dialog-information
-```
-
-### Windows with PowerShell
-
-```bash
-# For Windows users
-powershell -Command "New-BurntToastNotification -Text 'Claude Code', 'Status: $env:CCMANAGER_NEW_STATE'"
-```
-
-## Best Practices
-
-1. **Don't Over-Notify**: Consider which transitions actually need your attention
-2. **Use Sounds Sparingly**: Only for important status changes like "waiting_input"
-3. **Log for Analysis**: Keep logs to understand your Claude usage patterns
-4. **Test Your Hooks**: Use simple echo commands first to ensure they work
-
-## Example Workflow
-
-Here's a complete setup for a productive workflow:
-
-1. **Idle Hook**: Log only (no notification needed)
-   ```bash
-   echo "$(date): Idle" >> ~/.ccmanager/status.log
-   ```
-
-2. **Busy Hook**: Visual indicator only
-   ```bash
-   noti -t "Claude Code" -m "Working..." || true
-   ```
-
-3. **Waiting Input Hook**: Urgent notification with sound
-   ```bash
-   noti -t "Claude Code - Action Required" -m "Needs your input in $CCMANAGER_WORKTREE" && afplay /System/Library/Sounds/Ping.aiff
-   ```
-
-This setup ensures you're notified when Claude needs attention without being overwhelmed by status updates.
-
 ## Troubleshooting
 
-- Ensure noti is in your PATH
+- Ensure commands is in your PATH
 - Test commands in terminal first before adding to CCManager
-- Check CCManager logs if hooks aren't firing
 - Remember that hooks run in the worktree directory context
 
 ## Environment Variables Reference

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,7 +5,7 @@ import Session from './Session.js';
 import NewWorktree from './NewWorktree.js';
 import DeleteWorktree from './DeleteWorktree.js';
 import MergeWorktree from './MergeWorktree.js';
-import ConfigureShortcuts from './ConfigureShortcuts.js';
+import Configuration from './Configuration.js';
 import {SessionManager} from '../services/sessionManager.js';
 import {WorktreeService} from '../services/worktreeService.js';
 import {Worktree, Session as SessionType} from '../types/index.js';
@@ -20,7 +20,7 @@ type View =
 	| 'deleting-worktree'
 	| 'merge-worktree'
 	| 'merging-worktree'
-	| 'configure-shortcuts';
+	| 'configuration';
 
 const App: React.FC = () => {
 	const {exit} = useApp();
@@ -82,9 +82,9 @@ const App: React.FC = () => {
 			return;
 		}
 
-		// Check if this is the configure shortcuts option
-		if (worktree.path === 'CONFIGURE_SHORTCUTS') {
-			setView('configure-shortcuts');
+		// Check if this is the configuration option
+		if (worktree.path === 'CONFIGURATION') {
+			setView('configuration');
 			return;
 		}
 
@@ -321,8 +321,8 @@ const App: React.FC = () => {
 		);
 	}
 
-	if (view === 'configure-shortcuts') {
-		return <ConfigureShortcuts onComplete={handleReturnToMenu} />;
+	if (view === 'configuration') {
+		return <Configuration onComplete={handleReturnToMenu} />;
 	}
 
 	return null;

--- a/src/components/Configuration.tsx
+++ b/src/components/Configuration.tsx
@@ -1,0 +1,75 @@
+import React, {useState} from 'react';
+import {Box, Text} from 'ink';
+import SelectInput from 'ink-select-input';
+import ConfigureShortcuts from './ConfigureShortcuts.js';
+import ConfigureHooks from './ConfigureHooks.js';
+
+interface ConfigurationProps {
+	onComplete: () => void;
+}
+
+type ConfigView = 'menu' | 'shortcuts' | 'hooks';
+
+interface MenuItem {
+	label: string;
+	value: string;
+}
+
+const Configuration: React.FC<ConfigurationProps> = ({onComplete}) => {
+	const [view, setView] = useState<ConfigView>('menu');
+
+	const menuItems: MenuItem[] = [
+		{
+			label: '⌨  Configure Shortcuts',
+			value: 'shortcuts',
+		},
+		{
+			label: '🔧  Configure Status Hooks',
+			value: 'hooks',
+		},
+		{
+			label: '← Back to Main Menu',
+			value: 'back',
+		},
+	];
+
+	const handleSelect = (item: MenuItem) => {
+		if (item.value === 'back') {
+			onComplete();
+		} else if (item.value === 'shortcuts') {
+			setView('shortcuts');
+		} else if (item.value === 'hooks') {
+			setView('hooks');
+		}
+	};
+
+	const handleSubMenuComplete = () => {
+		setView('menu');
+	};
+
+	if (view === 'shortcuts') {
+		return <ConfigureShortcuts onComplete={handleSubMenuComplete} />;
+	}
+
+	if (view === 'hooks') {
+		return <ConfigureHooks onComplete={handleSubMenuComplete} />;
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Box marginBottom={1}>
+				<Text bold color="green">
+					Configuration
+				</Text>
+			</Box>
+
+			<Box marginBottom={1}>
+				<Text dimColor>Select a configuration option:</Text>
+			</Box>
+
+			<SelectInput items={menuItems} onSelect={handleSelect} isFocused={true} />
+		</Box>
+	);
+};
+
+export default Configuration;

--- a/src/components/ConfigureHooks.tsx
+++ b/src/components/ConfigureHooks.tsx
@@ -1,0 +1,202 @@
+import React, {useState, useEffect} from 'react';
+import {Box, Text, useInput} from 'ink';
+import TextInput from 'ink-text-input';
+import SelectInput from 'ink-select-input';
+import {configurationManager} from '../services/configurationManager.js';
+import {StatusHookConfig, SessionState} from '../types/index.js';
+
+interface ConfigureHooksProps {
+	onComplete: () => void;
+}
+
+type View = 'menu' | 'edit';
+
+interface MenuItem {
+	label: string;
+	value: string;
+}
+
+const STATUS_LABELS: Record<SessionState, string> = {
+	idle: 'Idle',
+	busy: 'Busy',
+	waiting_input: 'Waiting for Input',
+};
+
+const ConfigureHooks: React.FC<ConfigureHooksProps> = ({onComplete}) => {
+	const [view, setView] = useState<View>('menu');
+	const [selectedStatus, setSelectedStatus] = useState<SessionState>('idle');
+	const [hooks, setHooks] = useState<StatusHookConfig>({});
+	const [currentCommand, setCurrentCommand] = useState('');
+	const [currentEnabled, setCurrentEnabled] = useState(false);
+	const [showSaveMessage, setShowSaveMessage] = useState(false);
+
+	useEffect(() => {
+		setHooks(configurationManager.getStatusHooks());
+	}, []);
+
+	useInput((input, key) => {
+		if (key.escape) {
+			if (view === 'edit') {
+				setView('menu');
+			} else {
+				onComplete();
+			}
+		} else if (key.tab && view === 'edit') {
+			toggleEnabled();
+		}
+	});
+
+	const getMenuItems = (): MenuItem[] => {
+		const items: MenuItem[] = [];
+
+		// Add status hook items
+		(['idle', 'busy', 'waiting_input'] as SessionState[]).forEach(status => {
+			const hook = hooks[status];
+			const enabled = hook?.enabled ? '✓' : '✗';
+			const command = hook?.command || '(not set)';
+			items.push({
+				label: `${STATUS_LABELS[status]}: ${enabled} ${command}`,
+				value: status,
+			});
+		});
+
+		items.push({
+			label: '─────────────',
+			value: 'separator',
+		});
+
+		items.push({
+			label: '💾 Save and Return',
+			value: 'save',
+		});
+
+		items.push({
+			label: '← Cancel',
+			value: 'cancel',
+		});
+
+		return items;
+	};
+
+	const handleMenuSelect = (item: MenuItem) => {
+		if (item.value === 'save') {
+			configurationManager.setStatusHooks(hooks);
+			setShowSaveMessage(true);
+			setTimeout(() => {
+				onComplete();
+			}, 1000);
+		} else if (item.value === 'cancel') {
+			onComplete();
+		} else if (item.value !== 'separator') {
+			const status = item.value as SessionState;
+			setSelectedStatus(status);
+			const hook = hooks[status];
+			setCurrentCommand(hook?.command || '');
+			setCurrentEnabled(hook?.enabled ?? true); // Default to true if not set
+			setView('edit');
+		}
+	};
+
+	const handleCommandSubmit = (value: string) => {
+		setHooks(prev => ({
+			...prev,
+			[selectedStatus]: {
+				command: value,
+				enabled: currentEnabled,
+			},
+		}));
+		setView('menu');
+	};
+
+	const toggleEnabled = () => {
+		setCurrentEnabled(prev => !prev);
+	};
+
+	if (showSaveMessage) {
+		return (
+			<Box flexDirection="column">
+				<Text color="green">✓ Configuration saved successfully!</Text>
+			</Box>
+		);
+	}
+
+	if (view === 'edit') {
+		return (
+			<Box flexDirection="column">
+				<Box marginBottom={1}>
+					<Text bold color="green">
+						Configure {STATUS_LABELS[selectedStatus]} Hook
+					</Text>
+				</Box>
+
+				<Box marginBottom={1}>
+					<Text>
+						Command to execute when status changes to{' '}
+						{STATUS_LABELS[selectedStatus]}:
+					</Text>
+				</Box>
+
+				<Box marginBottom={1}>
+					<TextInput
+						value={currentCommand}
+						onChange={setCurrentCommand}
+						onSubmit={handleCommandSubmit}
+						placeholder="Enter command (e.g., notify-send 'Claude is idle')"
+					/>
+				</Box>
+
+				<Box marginBottom={1}>
+					<Text>
+						Enabled: {currentEnabled ? '✓' : '✗'} (Press Tab to toggle)
+					</Text>
+				</Box>
+
+				<Box marginTop={1}>
+					<Text dimColor>
+						Environment variables available: CCMANAGER_OLD_STATE,
+						CCMANAGER_NEW_STATE,
+					</Text>
+				</Box>
+				<Box>
+					<Text dimColor>
+						CCMANAGER_WORKTREE, CCMANAGER_WORKTREE_BRANCH, CCMANAGER_SESSION_ID
+					</Text>
+				</Box>
+
+				<Box marginTop={1}>
+					<Text dimColor>
+						Press Enter to save, Tab to toggle enabled, Esc to cancel
+					</Text>
+				</Box>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Box marginBottom={1}>
+				<Text bold color="green">
+					Configure Status Change Hooks
+				</Text>
+			</Box>
+
+			<Box marginBottom={1}>
+				<Text dimColor>
+					Set commands to run when Claude Code session status changes:
+				</Text>
+			</Box>
+
+			<SelectInput
+				items={getMenuItems()}
+				onSelect={handleMenuSelect}
+				isFocused={true}
+			/>
+
+			<Box marginTop={1}>
+				<Text dimColor>Press Esc to go back</Text>
+			</Box>
+		</Box>
+	);
+};
+
+export default ConfigureHooks;

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -97,8 +97,8 @@ const Menu: React.FC<MenuProps> = ({sessionManager, onSelectWorktree}) => {
 			value: 'delete-worktree',
 		});
 		menuItems.push({
-			label: `${MENU_ICONS.CONFIGURE_SHORTCUTS} Configure Shortcuts`,
-			value: 'configure-shortcuts',
+			label: `${MENU_ICONS.CONFIGURE_SHORTCUTS} Configuration`,
+			value: 'configuration',
 		});
 		menuItems.push({
 			label: `${MENU_ICONS.EXIT} Exit`,
@@ -134,10 +134,10 @@ const Menu: React.FC<MenuProps> = ({sessionManager, onSelectWorktree}) => {
 				isMainWorktree: false,
 				hasSession: false,
 			});
-		} else if (item.value === 'configure-shortcuts') {
+		} else if (item.value === 'configuration') {
 			// Handle in parent component - use special marker
 			onSelectWorktree({
-				path: 'CONFIGURE_SHORTCUTS',
+				path: 'CONFIGURATION',
 				branch: '',
 				isMainWorktree: false,
 				hasSession: false,

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -1,0 +1,91 @@
+import {homedir} from 'os';
+import {join} from 'path';
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'fs';
+import {
+	ConfigurationData,
+	StatusHookConfig,
+	ShortcutConfig,
+	DEFAULT_SHORTCUTS,
+} from '../types/index.js';
+
+export class ConfigurationManager {
+	private configPath: string;
+	private config: ConfigurationData = {};
+
+	constructor() {
+		// Determine config directory based on platform
+		const homeDir = homedir();
+		const configDir =
+			process.platform === 'win32'
+				? join(
+						process.env['APPDATA'] || join(homeDir, 'AppData', 'Roaming'),
+						'ccmanager',
+					)
+				: join(homeDir, '.config', 'ccmanager');
+
+		// Ensure config directory exists
+		if (!existsSync(configDir)) {
+			mkdirSync(configDir, {recursive: true});
+		}
+
+		this.configPath = join(configDir, 'config.json');
+		this.loadConfig();
+	}
+
+	private loadConfig(): void {
+		if (existsSync(this.configPath)) {
+			try {
+				const configData = readFileSync(this.configPath, 'utf-8');
+				this.config = JSON.parse(configData);
+			} catch (error) {
+				console.error('Failed to load configuration:', error);
+				this.config = {};
+			}
+		}
+
+		// Ensure default values
+		if (!this.config.shortcuts) {
+			this.config.shortcuts = DEFAULT_SHORTCUTS;
+		}
+		if (!this.config.statusHooks) {
+			this.config.statusHooks = {};
+		}
+	}
+
+	private saveConfig(): void {
+		try {
+			writeFileSync(this.configPath, JSON.stringify(this.config, null, 2));
+		} catch (error) {
+			console.error('Failed to save configuration:', error);
+		}
+	}
+
+	getShortcuts(): ShortcutConfig {
+		return this.config.shortcuts || DEFAULT_SHORTCUTS;
+	}
+
+	setShortcuts(shortcuts: ShortcutConfig): void {
+		this.config.shortcuts = shortcuts;
+		this.saveConfig();
+	}
+
+	getStatusHooks(): StatusHookConfig {
+		return this.config.statusHooks || {};
+	}
+
+	setStatusHooks(hooks: StatusHookConfig): void {
+		this.config.statusHooks = hooks;
+		this.saveConfig();
+	}
+
+	getConfiguration(): ConfigurationData {
+		return this.config;
+	}
+
+	setConfiguration(config: ConfigurationData): void {
+		this.config = config;
+		this.saveConfig();
+	}
+}
+
+export const configurationManager = new ConfigurationManager();

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -10,6 +10,7 @@ import {
 
 export class ConfigurationManager {
 	private configPath: string;
+	private legacyShortcutsPath: string;
 	private config: ConfigurationData = {};
 
 	constructor() {
@@ -29,10 +30,12 @@ export class ConfigurationManager {
 		}
 
 		this.configPath = join(configDir, 'config.json');
+		this.legacyShortcutsPath = join(configDir, 'shortcuts.json');
 		this.loadConfig();
 	}
 
 	private loadConfig(): void {
+		// Try to load the new config file
 		if (existsSync(this.configPath)) {
 			try {
 				const configData = readFileSync(this.configPath, 'utf-8');
@@ -41,6 +44,15 @@ export class ConfigurationManager {
 				console.error('Failed to load configuration:', error);
 				this.config = {};
 			}
+		} else {
+			// If new config doesn't exist, check for legacy shortcuts.json
+			this.migrateLegacyShortcuts();
+		}
+
+		// Check if shortcuts need to be loaded from legacy file
+		// This handles the case where config.json exists but doesn't have shortcuts
+		if (!this.config.shortcuts && existsSync(this.legacyShortcutsPath)) {
+			this.migrateLegacyShortcuts();
 		}
 
 		// Ensure default values
@@ -49,6 +61,25 @@ export class ConfigurationManager {
 		}
 		if (!this.config.statusHooks) {
 			this.config.statusHooks = {};
+		}
+	}
+
+	private migrateLegacyShortcuts(): void {
+		if (existsSync(this.legacyShortcutsPath)) {
+			try {
+				const shortcutsData = readFileSync(this.legacyShortcutsPath, 'utf-8');
+				const shortcuts = JSON.parse(shortcutsData);
+				
+				// Validate that it's a valid shortcuts config
+				if (shortcuts && typeof shortcuts === 'object') {
+					this.config.shortcuts = shortcuts;
+					// Save to new config format
+					this.saveConfig();
+					console.log('Migrated shortcuts from legacy shortcuts.json to config.json');
+				}
+			} catch (error) {
+				console.error('Failed to migrate legacy shortcuts:', error);
+			}
 		}
 	}
 

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -69,13 +69,15 @@ export class ConfigurationManager {
 			try {
 				const shortcutsData = readFileSync(this.legacyShortcutsPath, 'utf-8');
 				const shortcuts = JSON.parse(shortcutsData);
-				
+
 				// Validate that it's a valid shortcuts config
 				if (shortcuts && typeof shortcuts === 'object') {
 					this.config.shortcuts = shortcuts;
 					// Save to new config format
 					this.saveConfig();
-					console.log('Migrated shortcuts from legacy shortcuts.json to config.json');
+					console.log(
+						'Migrated shortcuts from legacy shortcuts.json to config.json',
+					);
 				}
 			} catch (error) {
 				console.error('Failed to migrate legacy shortcuts:', error);

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -33,7 +33,12 @@ export class WorktreeService {
 						hasSession: false,
 					};
 				} else if (line.startsWith('branch ')) {
-					currentWorktree.branch = line.substring(7);
+					let branch = line.substring(7);
+					// Remove refs/heads/ prefix if present
+					if (branch.startsWith('refs/heads/')) {
+						branch = branch.substring(11);
+					}
+					currentWorktree.branch = branch;
 				} else if (line === 'bare') {
 					currentWorktree.isMainWorktree = true;
 				}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,3 +49,19 @@ export const DEFAULT_SHORTCUTS: ShortcutConfig = {
 	returnToMenu: {ctrl: true, key: 'e'},
 	cancel: {key: 'escape'},
 };
+
+export interface StatusHook {
+	command: string;
+	enabled: boolean;
+}
+
+export interface StatusHookConfig {
+	idle?: StatusHook;
+	busy?: StatusHook;
+	waiting_input?: StatusHook;
+}
+
+export interface ConfigurationData {
+	shortcuts?: ShortcutConfig;
+	statusHooks?: StatusHookConfig;
+}

--- a/status-hooks-example.md
+++ b/status-hooks-example.md
@@ -1,0 +1,160 @@
+# Status Change Hooks Example with Noti
+
+This example demonstrates how to use [noti](https://github.com/variadico/noti) to receive desktop notifications when Claude Code session status changes.
+
+## Prerequisites
+
+First, install noti:
+
+```bash
+# macOS
+brew install noti
+
+# Linux
+go install github.com/variadico/noti/cmd/noti@latest
+
+# Or download from releases
+# https://github.com/variadico/noti/releases
+```
+
+## Configuration Examples
+
+### Basic Notifications
+
+Configure CCManager to send notifications for each status:
+
+1. Run `ccmanager`
+2. Navigate to **Configuration** → **Configure Status Hooks**
+3. Set up the following hooks:
+
+**Idle Hook:**
+```bash
+noti -t "Claude Code" -m "Session is now idle in $CCMANAGER_WORKTREE_BRANCH"
+```
+
+**Busy Hook:**
+```bash
+noti -t "Claude Code" -m "Session is now busy on branch $CCMANAGER_WORKTREE_BRANCH"
+```
+
+**Waiting for Input Hook:**
+```bash
+noti -t "Claude Code" -m "Claude is waiting for your input in $CCMANAGER_WORKTREE_BRANCH branch"
+```
+
+### Advanced Examples
+
+#### Play Sound on Status Change
+
+**Idle Hook (with sound):**
+```bash
+noti -t "Claude Code" -m "Session idle" && afplay /System/Library/Sounds/Glass.aiff
+```
+
+**Waiting for Input (urgent):**
+```bash
+noti -t "Claude Code - Action Required" -m "Claude needs your input!" && afplay /System/Library/Sounds/Ping.aiff
+```
+
+#### Log Status Changes
+
+Create a status change logger:
+
+```bash
+echo "$(date): $CCMANAGER_NEW_STATE (from $CCMANAGER_OLD_STATE) in $CCMANAGER_WORKTREE" >> ~/.ccmanager/status.log && noti -t "CCManager" -m "Status: $CCMANAGER_NEW_STATE"
+```
+
+#### Smart Notifications (only notify on specific transitions)
+
+**Notify only when Claude becomes idle after being busy:**
+```bash
+[ "$CCMANAGER_OLD_STATE" = "busy" ] && noti -t "Claude Code Complete" -m "Task finished on $CCMANAGER_WORKTREE_BRANCH branch"
+```
+
+**Notify only when waiting for input after being busy:**
+```bash
+[ "$CCMANAGER_OLD_STATE" = "busy" ] && noti -t "Claude Code" -m "Claude needs your decision on $CCMANAGER_WORKTREE_BRANCH" -s
+```
+
+**Branch-specific notifications:**
+```bash
+[[ "$CCMANAGER_WORKTREE_BRANCH" == "main" ]] && noti -t "⚠️ Main Branch" -m "Claude is $CCMANAGER_NEW_STATE on main!"
+```
+
+#### Integration with Other Tools
+
+**Send to Slack (using webhook):**
+```bash
+curl -X POST -H 'Content-type: application/json' --data '{"text":"Claude is now '"$CCMANAGER_NEW_STATE"' in '"$CCMANAGER_WORKTREE"'"}' YOUR_SLACK_WEBHOOK_URL
+```
+
+**Update tmux status:**
+```bash
+tmux set -g status-right "Claude: $CCMANAGER_NEW_STATE" && noti -t "Claude Status" -m "$CCMANAGER_NEW_STATE"
+```
+
+## Platform-Specific Examples
+
+### macOS with Native Notifications
+
+```bash
+# Using osascript for more control
+osascript -e 'display notification "Session is '"$CCMANAGER_NEW_STATE"'" with title "Claude Code" subtitle "'"$CCMANAGER_WORKTREE"'"'
+```
+
+### Linux with notify-send
+
+```bash
+# If you prefer notify-send over noti
+notify-send "Claude Code" "Status: $CCMANAGER_NEW_STATE in $CCMANAGER_WORKTREE" --icon=dialog-information
+```
+
+### Windows with PowerShell
+
+```bash
+# For Windows users
+powershell -Command "New-BurntToastNotification -Text 'Claude Code', 'Status: $env:CCMANAGER_NEW_STATE'"
+```
+
+## Best Practices
+
+1. **Don't Over-Notify**: Consider which transitions actually need your attention
+2. **Use Sounds Sparingly**: Only for important status changes like "waiting_input"
+3. **Log for Analysis**: Keep logs to understand your Claude usage patterns
+4. **Test Your Hooks**: Use simple echo commands first to ensure they work
+
+## Example Workflow
+
+Here's a complete setup for a productive workflow:
+
+1. **Idle Hook**: Log only (no notification needed)
+   ```bash
+   echo "$(date): Idle" >> ~/.ccmanager/status.log
+   ```
+
+2. **Busy Hook**: Visual indicator only
+   ```bash
+   noti -t "Claude Code" -m "Working..." || true
+   ```
+
+3. **Waiting Input Hook**: Urgent notification with sound
+   ```bash
+   noti -t "Claude Code - Action Required" -m "Needs your input in $CCMANAGER_WORKTREE" && afplay /System/Library/Sounds/Ping.aiff
+   ```
+
+This setup ensures you're notified when Claude needs attention without being overwhelmed by status updates.
+
+## Troubleshooting
+
+- Ensure noti is in your PATH
+- Test commands in terminal first before adding to CCManager
+- Check CCManager logs if hooks aren't firing
+- Remember that hooks run in the worktree directory context
+
+## Environment Variables Reference
+
+- `CCMANAGER_OLD_STATE`: Previous state (idle, busy, waiting_input)
+- `CCMANAGER_NEW_STATE`: New state (idle, busy, waiting_input)
+- `CCMANAGER_WORKTREE`: Path to the worktree where status changed
+- `CCMANAGER_WORKTREE_BRANCH`: Git branch name of the worktree
+- `CCMANAGER_SESSION_ID`: Unique session identifier


### PR DESCRIPTION
## Summary

Add status change hooks feature that allows users to run custom commands when Claude Code session status changes between idle, busy, and waiting states. This enables powerful automation workflows like desktop notifications, logging, and integration with external tools.

## Description

### Status Change Hooks

- Added ability to configure and execute commands when session status changes
- Three hook types available: `idle`, `busy`, and `waiting_input`
- Commands are executed with environment variables:
  - `CCMANAGER_OLD_STATE`: Previous state
  - `CCMANAGER_NEW_STATE`: New state
  - `CCMANAGER_WORKTREE`: Worktree path
  - `CCMANAGER_WORKTREE_BRANCH`: Git branch name (with refs/heads/ prefix removed)
  - `CCMANAGER_SESSION_ID`: Unique session identifier
- Hooks are enabled by default when configured
- Commands execute in the worktree directory context

### Unified Configuration System

- Created new `ConfigurationManager` service to handle both shortcuts and status hooks
- Configuration stored in `~/.config/ccmanager/config.json`
- Backward compatibility with legacy `shortcuts.json` (automatic migration)
- Updated menu from "Configure Shortcuts" to "Configuration" with submenu options

### UI Components

- New `Configuration` component as main configuration menu
- New `ConfigureHooks` component for status hook configuration
- Interactive UI for enabling/disabling hooks and setting commands
- Tab key toggles enabled state in hook configuration

### Documentation

- Comprehensive guide in `docs/state-hooks.md` with noti integration examples
- Updated README with status hooks section
- Examples for desktop notifications, logging, and conditional hooks

### Technical Improvements

- Fixed branch name extraction to show clean names (e.g., "main" instead of "refs/heads/main")
- Improved state detection logic in `sessionManager`
- Proper cleanup of configuration resources