### PR TITLE
Fix terminal rendering issues when re-entering sessions after resize

### DIFF
--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -60,6 +60,16 @@ const Session: React.FC<SessionProps> = ({
 		// Mark session as active (this will trigger the restore event)
 		sessionManager.setSessionActive(session.worktreePath, true);
 
+		// Immediately resize the PTY and terminal to current dimensions
+		// This fixes rendering issues when terminal width changed while in menu
+		// https://github.com/kbwo/ccmanager/issues/2
+		const currentCols = process.stdout.columns || 80;
+		const currentRows = process.stdout.rows || 24;
+		session.process.resize(currentCols, currentRows);
+		if (session.terminal) {
+			session.terminal.resize(currentCols, currentRows);
+		}
+
 		// Listen for session data events
 		const handleSessionData = (activeSession: SessionType, data: string) => {
 			// Only handle data for our session


### PR DESCRIPTION
## Summary

Fixed terminal rendering issues that occurred when re-entering a worktree session after changing terminal width in the menu view.

## Description

### Terminal Resize Synchronization

When users switched to the menu view, changed their terminal window width, and then re-entered a worktree session, the PTY process retained the old terminal dimensions. This caused cursor positioning and line clearing operations to malfunction, resulting in repeated output lines that couldn't be properly updated.

The fix adds immediate PTY and virtual terminal resizing when a session becomes active, ensuring dimensions are synchronized with the current terminal size before any content restoration or new output processing occurs.

### Implementation Details

- Added resize logic immediately after `setSessionActive()` call in Session component
- Resizes both the PTY process and virtual terminal to match `process.stdout.columns/rows`
- Ensures proper rendering regardless of terminal size changes while in menu view
- Preserves existing resize handling for changes that occur while session is active