### PR TITLE
fix: add merge step after rebase in worktree merge operation

### DIFF
--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -206,6 +206,12 @@ export class WorktreeService {
 					cwd: sourceWorktree.path,
 					encoding: 'utf8',
 				});
+
+				// After rebase, merge the rebased source branch into target branch
+				execSync(`git merge --ff-only "${sourceBranch}"`, {
+					cwd: targetWorktree.path,
+					encoding: 'utf8',
+				});
 			} else {
 				// Regular merge
 				execSync(`git merge --no-ff "${sourceBranch}"`, {


### PR DESCRIPTION
When rebase is selected, the rebased branch needs to be merged into the target branch to complete the operation.

🤖 Generated with [Claude Code](https://claude.ai/code)