### PR TITLE
feat: add automatic worktree directory generation

### DIFF
--- a/src/components/Configuration.tsx
+++ b/src/components/Configuration.tsx
@@ -3,12 +3,13 @@ import {Box, Text} from 'ink';
 import SelectInput from 'ink-select-input';
 import ConfigureShortcuts from './ConfigureShortcuts.js';
 import ConfigureHooks from './ConfigureHooks.js';
+import ConfigureWorktree from './ConfigureWorktree.js';
 
 interface ConfigurationProps {
 	onComplete: () => void;
 }
 
-type ConfigView = 'menu' | 'shortcuts' | 'hooks';
+type ConfigView = 'menu' | 'shortcuts' | 'hooks' | 'worktree';
 
 interface MenuItem {
 	label: string;
@@ -28,6 +29,10 @@ const Configuration: React.FC<ConfigurationProps> = ({onComplete}) => {
 			value: 'hooks',
 		},
 		{
+			label: '📁  Configure Worktree Settings',
+			value: 'worktree',
+		},
+		{
 			label: '← Back to Main Menu',
 			value: 'back',
 		},
@@ -40,6 +45,8 @@ const Configuration: React.FC<ConfigurationProps> = ({onComplete}) => {
 			setView('shortcuts');
 		} else if (item.value === 'hooks') {
 			setView('hooks');
+		} else if (item.value === 'worktree') {
+			setView('worktree');
 		}
 	};
 
@@ -53,6 +60,10 @@ const Configuration: React.FC<ConfigurationProps> = ({onComplete}) => {
 
 	if (view === 'hooks') {
 		return <ConfigureHooks onComplete={handleSubMenuComplete} />;
+	}
+
+	if (view === 'worktree') {
+		return <ConfigureWorktree onComplete={handleSubMenuComplete} />;
 	}
 
 	return (

--- a/src/components/ConfigureWorktree.tsx
+++ b/src/components/ConfigureWorktree.tsx
@@ -1,0 +1,157 @@
+import React, {useState} from 'react';
+import {Box, Text, useInput} from 'ink';
+import SelectInput from 'ink-select-input';
+import TextInput from 'ink-text-input';
+import {configurationManager} from '../services/configurationManager.js';
+import {shortcutManager} from '../services/shortcutManager.js';
+
+interface ConfigureWorktreeProps {
+	onComplete: () => void;
+}
+
+type EditMode = 'menu' | 'pattern';
+
+interface MenuItem {
+	label: string;
+	value: string;
+}
+
+const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
+	const worktreeConfig = configurationManager.getWorktreeConfig();
+	const [autoDirectory, setAutoDirectory] = useState(worktreeConfig.autoDirectory);
+	const [pattern, setPattern] = useState(
+		worktreeConfig.autoDirectoryPattern || '../{branch}',
+	);
+	const [editMode, setEditMode] = useState<EditMode>('menu');
+	const [tempPattern, setTempPattern] = useState(pattern);
+
+	useInput((input, key) => {
+		if (
+			editMode === 'menu' &&
+			shortcutManager.matchesShortcut('cancel', input, key)
+		) {
+			onComplete();
+		}
+	});
+
+	const menuItems: MenuItem[] = [
+		{
+			label: `Auto Directory: ${autoDirectory ? '✅ Enabled' : '❌ Disabled'}`,
+			value: 'toggle',
+		},
+		{
+			label: `Pattern: ${pattern}`,
+			value: 'pattern',
+		},
+		{
+			label: '💾 Save Changes',
+			value: 'save',
+		},
+		{
+			label: '← Cancel',
+			value: 'cancel',
+		},
+	];
+
+	const handleMenuSelect = (item: MenuItem) => {
+		switch (item.value) {
+			case 'toggle':
+				setAutoDirectory(!autoDirectory);
+				break;
+			case 'pattern':
+				setTempPattern(pattern);
+				setEditMode('pattern');
+				break;
+			case 'save':
+				// Save the configuration
+				configurationManager.setWorktreeConfig({
+					autoDirectory,
+					autoDirectoryPattern: pattern,
+				});
+				onComplete();
+				break;
+			case 'cancel':
+				onComplete();
+				break;
+		}
+	};
+
+	const handlePatternSubmit = (value: string) => {
+		if (value.trim()) {
+			setPattern(value.trim());
+		}
+		setEditMode('menu');
+	};
+
+	if (editMode === 'pattern') {
+		return (
+			<Box flexDirection="column">
+				<Box marginBottom={1}>
+					<Text bold color="green">
+						Configure Directory Pattern
+					</Text>
+				</Box>
+
+				<Box marginBottom={1}>
+					<Text>
+						Enter the pattern for automatic directory generation:
+					</Text>
+				</Box>
+
+				<Box marginBottom={1}>
+					<Text dimColor>
+						Available placeholders: {'{branch}'} - full branch name
+					</Text>
+				</Box>
+
+				<Box>
+					<Text color="cyan">{'> '}</Text>
+					<TextInput
+						value={tempPattern}
+						onChange={setTempPattern}
+						onSubmit={handlePatternSubmit}
+						placeholder="../{branch}"
+					/>
+				</Box>
+
+				<Box marginTop={1}>
+					<Text dimColor>Press Enter to save or Escape to cancel</Text>
+				</Box>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Box marginBottom={1}>
+				<Text bold color="green">
+					Configure Worktree Settings
+				</Text>
+			</Box>
+
+			<Box marginBottom={1}>
+				<Text dimColor>
+					Configure automatic worktree directory generation
+				</Text>
+			</Box>
+
+			{autoDirectory && (
+				<Box marginBottom={1}>
+					<Text>
+						Example: branch "feature/my-feature" → directory "{pattern.replace('{branch}', 'feature-my-feature')}"
+					</Text>
+				</Box>
+			)}
+
+			<SelectInput items={menuItems} onSelect={handleMenuSelect} isFocused={true} />
+
+			<Box marginTop={1}>
+				<Text dimColor>
+					Press {shortcutManager.getShortcutDisplay('cancel')} to cancel without saving
+				</Text>
+			</Box>
+		</Box>
+	);
+};
+
+export default ConfigureWorktree;

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -5,6 +5,7 @@ import {
 	ConfigurationData,
 	StatusHookConfig,
 	ShortcutConfig,
+	WorktreeConfig,
 	DEFAULT_SHORTCUTS,
 } from '../types/index.js';
 
@@ -62,6 +63,11 @@ export class ConfigurationManager {
 		if (!this.config.statusHooks) {
 			this.config.statusHooks = {};
 		}
+		if (!this.config.worktree) {
+			this.config.worktree = {
+				autoDirectory: false,
+			};
+		}
 	}
 
 	private migrateLegacyShortcuts(): void {
@@ -117,6 +123,19 @@ export class ConfigurationManager {
 
 	setConfiguration(config: ConfigurationData): void {
 		this.config = config;
+		this.saveConfig();
+	}
+
+	getWorktreeConfig(): WorktreeConfig {
+		return (
+			this.config.worktree || {
+				autoDirectory: false,
+			}
+		);
+	}
+
+	setWorktreeConfig(worktreeConfig: WorktreeConfig): void {
+		this.config.worktree = worktreeConfig;
 		this.saveConfig();
 	}
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,7 +61,13 @@ export interface StatusHookConfig {
 	waiting_input?: StatusHook;
 }
 
+export interface WorktreeConfig {
+	autoDirectory: boolean;
+	autoDirectoryPattern?: string; // Optional pattern for directory generation
+}
+
 export interface ConfigurationData {
 	shortcuts?: ShortcutConfig;
 	statusHooks?: StatusHookConfig;
+	worktree?: WorktreeConfig;
 }

--- a/src/utils/worktreeUtils.test.ts
+++ b/src/utils/worktreeUtils.test.ts
@@ -1,0 +1,107 @@
+import {describe, it, expect} from 'vitest';
+import {generateWorktreeDirectory, extractBranchParts} from './worktreeUtils.js';
+
+describe('generateWorktreeDirectory', () => {
+	describe('with default pattern', () => {
+		it('should generate directory with sanitized branch name', () => {
+			expect(generateWorktreeDirectory('feature/my-feature')).toBe(
+				'../feature-my-feature',
+			);
+			expect(generateWorktreeDirectory('bugfix/fix-123')).toBe(
+				'../bugfix-fix-123',
+			);
+			expect(generateWorktreeDirectory('release/v1.0.0')).toBe(
+				'../release-v1.0.0',
+			);
+		});
+
+		it('should handle branch names without slashes', () => {
+			expect(generateWorktreeDirectory('main')).toBe('../main');
+			expect(generateWorktreeDirectory('develop')).toBe('../develop');
+			expect(generateWorktreeDirectory('my-feature')).toBe('../my-feature');
+		});
+
+		it('should remove special characters', () => {
+			expect(generateWorktreeDirectory('feature/my@feature!')).toBe(
+				'../feature-myfeature',
+			);
+			expect(generateWorktreeDirectory('bugfix/#123')).toBe('../bugfix-123');
+			expect(generateWorktreeDirectory('release/v1.0.0-beta')).toBe(
+				'../release-v1.0.0-beta',
+			);
+		});
+
+		it('should handle edge cases', () => {
+			expect(generateWorktreeDirectory('//feature//')).toBe('../feature');
+			expect(generateWorktreeDirectory('-feature-')).toBe('../feature');
+			expect(generateWorktreeDirectory('FEATURE/UPPERCASE')).toBe(
+				'../feature-uppercase',
+			);
+		});
+	});
+
+	describe('with custom patterns', () => {
+		it('should use custom pattern with {branch} placeholder', () => {
+			expect(
+				generateWorktreeDirectory('feature/my-feature', '../worktrees/{branch}'),
+			).toBe('../worktrees/feature-my-feature');
+			expect(
+				generateWorktreeDirectory('bugfix/123', '/tmp/{branch}-wt'),
+			).toBe('/tmp/bugfix-123-wt');
+		});
+
+		it('should handle patterns without placeholders', () => {
+			expect(
+				generateWorktreeDirectory('feature/test', '../fixed-directory'),
+			).toBe('../fixed-directory');
+		});
+
+		it('should normalize paths', () => {
+			expect(
+				generateWorktreeDirectory('feature/test', '../foo/../bar/{branch}'),
+			).toBe('../bar/feature-test');
+			expect(
+				generateWorktreeDirectory('feature/test', './worktrees/{branch}'),
+			).toBe('worktrees/feature-test');
+		});
+	});
+});
+
+describe('extractBranchParts', () => {
+	it('should extract prefix and name from branch with slash', () => {
+		expect(extractBranchParts('feature/my-feature')).toEqual({
+			prefix: 'feature',
+			name: 'my-feature',
+		});
+		expect(extractBranchParts('bugfix/fix-123')).toEqual({
+			prefix: 'bugfix',
+			name: 'fix-123',
+		});
+	});
+
+	it('should handle branches with multiple slashes', () => {
+		expect(extractBranchParts('feature/user/profile-page')).toEqual({
+			prefix: 'feature',
+			name: 'user/profile-page',
+		});
+		expect(extractBranchParts('release/v1.0/final')).toEqual({
+			prefix: 'release',
+			name: 'v1.0/final',
+		});
+	});
+
+	it('should handle branches without slashes', () => {
+		expect(extractBranchParts('main')).toEqual({
+			name: 'main',
+		});
+		expect(extractBranchParts('develop')).toEqual({
+			name: 'develop',
+		});
+	});
+
+	it('should handle empty branch name', () => {
+		expect(extractBranchParts('')).toEqual({
+			name: '',
+		});
+	});
+});

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+
+export function generateWorktreeDirectory(
+	branchName: string,
+	pattern?: string,
+): string {
+	// Default pattern if not specified
+	const defaultPattern = '../{branch}';
+	const activePattern = pattern || defaultPattern;
+
+	// Sanitize branch name for filesystem
+	// Replace slashes with dashes, remove special characters
+	const sanitizedBranch = branchName
+		.replace(/\//g, '-') // Replace forward slashes with dashes
+		.replace(/[^a-zA-Z0-9-_.]/g, '') // Remove special characters except dash, dot, underscore
+		.replace(/^-+|-+$/g, '') // Remove leading/trailing dashes
+		.toLowerCase(); // Convert to lowercase for consistency
+
+	// Replace placeholders in pattern
+	const directory = activePattern
+		.replace('{branch}', sanitizedBranch)
+		.replace('{branch-name}', sanitizedBranch);
+
+	// Ensure the path is relative to the repository root
+	return path.normalize(directory);
+}
+
+export function extractBranchParts(branchName: string): {
+	prefix?: string;
+	name: string;
+} {
+	const parts = branchName.split('/');
+	if (parts.length > 1) {
+		return {
+			prefix: parts[0],
+			name: parts.slice(1).join('/'),
+		};
+	}
+	return {name: branchName};
+}


### PR DESCRIPTION
## Summary

- Adds automatic worktree directory generation feature
- Allows users to configure whether worktree directories are automatically generated from branch names
- Supports customizable directory patterns with branch name placeholders

## Description

### Automatic Directory Generation

This feature enables automatic generation of worktree directory paths based on branch names. When enabled, users only need to enter the branch name when creating a new worktree, and the directory path is automatically generated using a configurable pattern.

By default, the pattern is `../{branch}`, which creates worktrees in the parent directory with sanitized branch names. For example:
- Branch `feature/my-feature` → Directory `../feature-my-feature`
- Branch `bugfix/fix-123` → Directory `../bugfix-fix-123`

### Configuration UI

Added a new "Configure Worktree Settings" section in the Configuration menu that allows users to:
- Toggle automatic directory generation on/off
- Customize the directory pattern (e.g., `../worktrees/{branch}`, `/tmp/{branch}-wt`)
- Preview how branch names will be converted to directory paths

### Branch Name Sanitization

Branch names are automatically sanitized for filesystem compatibility:
- Forward slashes (`/`) are replaced with dashes (`-`)
- Special characters are removed (except dash, dot, underscore)
- Names are converted to lowercase for consistency
- Leading/trailing dashes are removed

### Implementation Details

- Added `WorktreeConfig` type to store worktree configuration
- Created `worktreeUtils.ts` with utilities for directory generation and branch name sanitization
- Updated `NewWorktree` component to skip path input when auto-directory is enabled
- Added comprehensive tests for the directory generation logic
- Configuration is persisted in the same config file as shortcuts and hooks