### PR TITLE
feat: add branch selection when creating new worktree

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -134,7 +134,7 @@ const App: React.FC = () => {
 	const handleCreateWorktree = async (
 		path: string,
 		branch: string,
-		baseBranch?: string,
+		baseBranch: string,
 	) => {
 		setView('creating-worktree');
 		setError(null);

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -8,7 +8,7 @@ import {generateWorktreeDirectory} from '../utils/worktreeUtils.js';
 import {WorktreeService} from '../services/worktreeService.js';
 
 interface NewWorktreeProps {
-	onComplete: (path: string, branch: string, baseBranch?: string) => void;
+	onComplete: (path: string, branch: string, baseBranch: string) => void;
 	onCancel: () => void;
 }
 

--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -158,6 +158,7 @@ origin/feature/test
 			const result = service.createWorktree(
 				'/path/to/worktree',
 				'existing-feature',
+				'main', // Base branch is required but not used when branch exists
 			);
 
 			expect(result).toEqual({success: true});
@@ -167,7 +168,7 @@ origin/feature/test
 			);
 		});
 
-		it('should create worktree from HEAD when no base branch specified', () => {
+		it('should create worktree from specified base branch when branch does not exist', () => {
 			mockedExecSync.mockImplementation((cmd, _options) => {
 				if (typeof cmd === 'string') {
 					if (cmd === 'git rev-parse --git-common-dir') {
@@ -181,11 +182,15 @@ origin/feature/test
 				throw new Error('Unexpected command');
 			});
 
-			const result = service.createWorktree('/path/to/worktree', 'new-feature');
+			const result = service.createWorktree(
+				'/path/to/worktree',
+				'new-feature',
+				'main',
+			);
 
 			expect(result).toEqual({success: true});
 			expect(execSync).toHaveBeenCalledWith(
-				'git worktree add -b "new-feature" "/path/to/worktree"',
+				'git worktree add -b "new-feature" "/path/to/worktree" "main"',
 				expect.any(Object),
 			);
 		});

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -172,7 +172,7 @@ export class WorktreeService {
 	createWorktree(
 		worktreePath: string,
 		branch: string,
-		baseBranch?: string,
+		baseBranch: string,
 	): {success: boolean; error?: string} {
 		try {
 			// Resolve the worktree path relative to the git repository root
@@ -196,12 +196,9 @@ export class WorktreeService {
 			let command: string;
 			if (branchExists) {
 				command = `git worktree add "${resolvedPath}" "${branch}"`;
-			} else if (baseBranch) {
+			} else {
 				// Create new branch from specified base branch
 				command = `git worktree add -b "${branch}" "${resolvedPath}" "${baseBranch}"`;
-			} else {
-				// Create new branch from current HEAD
-				command = `git worktree add -b "${branch}" "${resolvedPath}"`;
 			}
 
 			execSync(command, {


### PR DESCRIPTION
## Summary

This PR adds a branch selection feature when creating new worktrees, allowing users to choose which branch to base their new branch on. It also fixes a critical path resolution issue that was causing worktree creation to fail when run from within an existing worktree.

## Description

### Branch Selection Feature

When creating a new worktree, users are now presented with an additional step to select the base branch for their new branch. This provides better control over the branching strategy and makes it easier to create feature branches from specific release branches or other feature branches.

Key improvements:
- Added a new "base-branch" step in the worktree creation flow
- Automatically detects and displays the repository's default branch (main/master) at the top of the list
- Shows all available branches (both local and remote) for selection
- The default branch is pre-selected and clearly marked with "(default)" label
- Uses the existing `SelectInput` component for a consistent UI experience

### Worktree Path Resolution Fix

Fixed a critical issue where creating worktrees would fail with the error "could not create leading directories of '.git/tasks/test5/.git': Not a directory" when running ccmanager from within an existing worktree.

The fix:
- Added `getGitRepositoryRoot()` method that uses `git rev-parse --git-common-dir` to find the actual repository root
- Modified `createWorktree()` to resolve paths relative to the git repository root instead of the current working directory
- This ensures worktrees are created in the correct location regardless of where ccmanager is run from

### New Git Helper Methods

Added utility methods to the WorktreeService:
- `getDefaultBranch()`: Detects the repository's default branch (with fallbacks for main/master)
- `getAllBranches()`: Retrieves all available branches, both local and remote, with deduplication

### Tests

Added comprehensive test coverage for all new functionality:
- Tests for default branch detection with various fallback scenarios
- Tests for branch listing and deduplication
- Tests for worktree creation with and without base branch specification
- All tests use proper mocking to ensure reliability