### PR TITLE
fix: handle detached HEAD state in worktree operations

### DIFF
--- a/src/components/DeleteWorktree.tsx
+++ b/src/components/DeleteWorktree.tsx
@@ -100,7 +100,8 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 					<Text>You are about to delete the following worktrees:</Text>
 					{selectedWorktrees.map(wt => (
 						<Text key={wt.path} color="red">
-							• {wt.branch.replace('refs/heads/', '')} ({wt.path})
+							• {wt.branch ? wt.branch.replace('refs/heads/', '') : 'detached'}{' '}
+							({wt.path})
 						</Text>
 					))}
 				</Box>
@@ -134,7 +135,9 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 			{worktrees.map((worktree, index) => {
 				const isSelected = selectedIndices.has(index);
 				const isFocused = index === focusedIndex;
-				const branchName = worktree.branch.replace('refs/heads/', '');
+				const branchName = worktree.branch
+					? worktree.branch.replace('refs/heads/', '')
+					: 'detached';
 
 				return (
 					<Box key={worktree.path}>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -69,7 +69,9 @@ const Menu: React.FC<MenuProps> = ({sessionManager, onSelectWorktree}) => {
 				status = ` [${getStatusDisplay(session.state)}]`;
 			}
 
-			const branchName = wt.branch.replace('refs/heads/', '');
+			const branchName = wt.branch
+				? wt.branch.replace('refs/heads/', '')
+				: 'detached';
 			const isMain = wt.isMainWorktree ? ' (main)' : '';
 
 			return {

--- a/src/components/MergeWorktree.tsx
+++ b/src/components/MergeWorktree.tsx
@@ -45,9 +45,9 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 		// Create branch items for selection
 		const items = loadedWorktrees.map(wt => ({
 			label:
-				wt.branch.replace('refs/heads/', '') +
+				(wt.branch ? wt.branch.replace('refs/heads/', '') : 'detached') +
 				(wt.isMainWorktree ? ' (main)' : ''),
-			value: wt.branch.replace('refs/heads/', ''),
+			value: wt.branch ? wt.branch.replace('refs/heads/', '') : 'detached',
 		}));
 		setBranchItems(items);
 	}, []);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export type SessionState = 'idle' | 'busy' | 'waiting_input';
 
 export interface Worktree {
 	path: string;
-	branch: string;
+	branch?: string;
 	isMainWorktree: boolean;
 	hasSession: boolean;
 }


### PR DESCRIPTION
## Summary

This PR fixes a crash that occurs when CCManager encounters Git worktrees in a detached HEAD state (no branch). The application now properly handles these cases by making the branch property optional and adding appropriate null checks throughout the codebase.

## Description

### Type System Update

Made the `branch` property optional in the `Worktree` interface to accurately represent that worktrees can exist without an associated branch (detached HEAD state).

### UI Component Updates

Updated all UI components that display branch information to handle the optional branch property:
- **DeleteWorktree**: Shows "detached" instead of branch name when no branch exists
- **Menu**: Displays "detached" for worktrees without branches in the main menu
- **MergeWorktree**: Properly handles branch selection for detached worktrees

### Worktree Service Improvements

Enhanced the worktree parsing logic in `worktreeService.ts`:
- Improved the parsing algorithm to better handle Git's worktree output format
- Added proper null checks when accessing branch properties
- Updated branch deletion logic to handle detached HEAD state gracefully

### Error Prevention

These changes prevent runtime errors when:
- Listing worktrees that are in detached HEAD state
- Attempting to delete worktrees without branches
- Merging or rebasing operations involving detached worktrees

Fixes #26
EOF < /dev/null