### PR TITLE
fix: prevent TextInput from capturing j/k keys during base branch selection

### DIFF
--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -131,7 +131,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 						/>
 					</Box>
 				</Box>
-			) : (
+			) : step === 'branch' ? (
 				<Box flexDirection="column">
 					<Box marginBottom={1}>
 						<Text>Enter branch name (directory will be auto-generated):</Text>
@@ -154,7 +154,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 						</Box>
 					)}
 				</Box>
-			)}
+			) : null}
 
 			{step === 'base-branch' && (
 				<Box flexDirection="column">


### PR DESCRIPTION
## Summary

Fixes keyboard navigation issue where j/k keys were being captured by the branch name TextInput component even when selecting the base branch with SelectInput.

## Description

### Problem

When creating a new worktree, users go through multiple steps:
1. Enter branch name (TextInput)
2. Select base branch (SelectInput)

During step 2 (base branch selection), the j/k keys that should navigate the SelectInput menu were instead being captured by the TextInput component from step 1, causing text to appear in the branch name field instead of navigating the branch list.

### Solution

Modified the conditional rendering logic in `NewWorktree.tsx` to ensure the TextInput component is only rendered when actively in the 'branch' step. This prevents the TextInput from intercepting keyboard input meant for the SelectInput during base branch selection.

The change adds an explicit check `step === 'branch'` and returns `null` for any other step, ensuring clean separation between form steps.

### Testing

- Create a new worktree using the UI
- Enter a branch name and proceed to base branch selection
- Verify that j/k keys now properly navigate the branch list instead of adding text to the branch name input
EOF < /dev/null