### PR TITLE
Fix: Prevent text input from capturing j/k keys during base branch selection

### DIFF
--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -131,7 +131,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 						/>
 					</Box>
 				</Box>
-			) : (
+			) : step === 'branch' ? (
 				<Box flexDirection="column">
 					<Box marginBottom={1}>
 						<Text>Enter branch name (directory will be auto-generated):</Text>
@@ -154,7 +154,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 						</Box>
 					)}
 				</Box>
-			)}
+			) : null}
 
 			{step === 'base-branch' && (
 				<Box flexDirection="column">


### PR DESCRIPTION
## Summary

Fix keyboard navigation issue in the new worktree creation form where j/k keys were being captured by the text input field instead of navigating the base branch selection list.

## Description

### Problem

When creating a new worktree and reaching the base branch selection step, pressing j or k keys would insert text into the branch name input field instead of navigating up/down through the branch list. This occurred because the text input component was still being rendered even during the base branch selection phase.

### Solution

Modified the conditional rendering logic in `NewWorktree.tsx` to ensure that the text input is only displayed during the branch name input step. When the user reaches the base branch selection step (`step === 'base-branch'`), only the `SelectInput` component is rendered, allowing j/k keys to properly navigate the branch list as expected.

The fix adds an explicit check for `step === 'branch'` and returns `null` for any other step that isn't explicitly handled, preventing the text input from capturing keyboard events during branch selection.
EOF < /dev/null