### PR TITLE
feat: Add Claude session data copying for worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://github.com/user-attachments/assets/a6d80e73-dc06-4ef8-849d-e3857f6c7024
 - Switch between sessions seamlessly
 - Visual status indicators for session states (busy, waiting, idle)
 - Create, merge, and delete worktrees from within the app
+- **Copy Claude Code session data** between worktrees to maintain conversation context
 - Configurable keyboard shortcuts
 - Command configuration with automatic fallback support
 - Status change hooks for automation and notifications
@@ -131,6 +132,41 @@ CCManager supports configuring the command and arguments used to run Claude Code
 4. Save changes
 
 For detailed configuration options and examples, see [docs/command-config.md](docs/command-config.md).
+
+
+## Session Data Copying
+
+CCManager can copy Claude Code session data (conversation history, context, and project state) when creating new worktrees, allowing you to maintain context across different branches.
+
+### Features
+
+- **Seamless Context Transfer**: Continue conversations in new worktrees without losing context
+- **Configurable Default**: Set whether to copy session data by default
+- **Per-Creation Choice**: Decide on each worktree creation whether to copy data
+- **Safe Operation**: Copying is non-fatal - worktree creation succeeds even if copying fails
+
+### How It Works
+
+When creating a new worktree, CCManager:
+1. Asks whether to copy session data from the current worktree
+2. Copies all session files from `~/.claude/projects/[source-path]` to `~/.claude/projects/[target-path]`
+3. Preserves conversation history, project context, and Claude Code state
+4. Allows immediate continuation of conversations in the new worktree
+
+### Configuration
+
+1. Navigate to **Configuration** → **Configure Worktree**
+2. Toggle **Copy Session Data** to set the default behavior
+3. Save changes
+
+The default choice (copy or start fresh) will be pre-selected when creating new worktrees.
+
+### Use Cases
+
+- **Feature Development**: Copy session data when creating feature branches to maintain project context
+- **Experimentation**: Start fresh when testing unrelated changes
+- **Collaboration**: Share session state across team worktrees
+- **Context Preservation**: Maintain long conversations across multiple development branches
 
 
 ## Status Change Hooks

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -140,12 +140,18 @@ const App: React.FC = () => {
 		path: string,
 		branch: string,
 		baseBranch: string,
+		copySessionData: boolean,
 	) => {
 		setView('creating-worktree');
 		setError(null);
 
 		// Create the worktree
-		const result = worktreeService.createWorktree(path, branch, baseBranch);
+		const result = worktreeService.createWorktree(
+			path,
+			branch,
+			baseBranch,
+			copySessionData,
+		);
 
 		if (result.success) {
 			// Success - return to menu

--- a/src/components/ConfigureWorktree.tsx
+++ b/src/components/ConfigureWorktree.tsx
@@ -24,6 +24,9 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 	const [pattern, setPattern] = useState(
 		worktreeConfig.autoDirectoryPattern || '../{branch}',
 	);
+	const [copySessionData, setCopySessionData] = useState(
+		worktreeConfig.copySessionData ?? true,
+	);
 	const [editMode, setEditMode] = useState<EditMode>('menu');
 	const [tempPattern, setTempPattern] = useState(pattern);
 
@@ -46,6 +49,10 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 			value: 'pattern',
 		},
 		{
+			label: `Copy Session Data: ${copySessionData ? '✅ Enabled' : '❌ Disabled'}`,
+			value: 'toggleCopy',
+		},
+		{
 			label: '💾 Save Changes',
 			value: 'save',
 		},
@@ -64,11 +71,15 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 				setTempPattern(pattern);
 				setEditMode('pattern');
 				break;
+			case 'toggleCopy':
+				setCopySessionData(!copySessionData);
+				break;
 			case 'save':
 				// Save the configuration
 				configurationManager.setWorktreeConfig({
 					autoDirectory,
 					autoDirectoryPattern: pattern,
+					copySessionData,
 				});
 				onComplete();
 				break;
@@ -130,7 +141,7 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 			</Box>
 
 			<Box marginBottom={1}>
-				<Text dimColor>Configure automatic worktree directory generation</Text>
+				<Text dimColor>Configure worktree creation settings</Text>
 			</Box>
 
 			{autoDirectory && (

--- a/src/services/configurationManager.ts
+++ b/src/services/configurationManager.ts
@@ -67,7 +67,16 @@ export class ConfigurationManager {
 		if (!this.config.worktree) {
 			this.config.worktree = {
 				autoDirectory: false,
+				copySessionData: true,
 			};
+		}
+		if (
+			!Object.prototype.hasOwnProperty.call(
+				this.config.worktree,
+				'copySessionData',
+			)
+		) {
+			this.config.worktree.copySessionData = true;
 		}
 		if (!this.config.command) {
 			this.config.command = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,7 @@ export interface StatusHookConfig {
 export interface WorktreeConfig {
 	autoDirectory: boolean;
 	autoDirectoryPattern?: string; // Optional pattern for directory generation
+	copySessionData?: boolean; // Whether to copy Claude session data by default
 }
 
 export interface CommandConfig {


### PR DESCRIPTION
It would be nice if Claude session data is copied over to a newly created worktree to allow for a conversation to be forked in addition to the worktree. This will add an option to do that when creating a new worktree.

- Add copySessionData configuration option
- Implement session data copying in worktree creation
- Update UI to support toggling session data copy
- Add documentation for the new feature

Cross-Platform Compatibility Analysis

  The session data copying feature should work across platforms:

  ✅ Linux/macOS

  - Claude stores data in ~/.claude/projects/
  - Tested and working afaict

  ⚠️ Windows

  - Claude likely stores data in %USERPROFILE%\.claude\projects\ or %APPDATA%\claude\projects\
  - Paths use backslashes (\)
  - The regex /[/\\.]/g should handle both forward slashes and backslashes

  🔧 Key Cross-Platform Considerations

  1. Path separators: Fixed to handle both / and \
  2. Home directory: Using os.homedir() which works on all platforms
  3. Path joining: Using path.join() for proper platform-specific paths
  4. Directory operations: fs methods (mkdirSync, cpSync) work cross-platform

  The feature should now work on Windows, but the exact Claude project directory location on Windows needs verification. Claude Code might use:
  - %USERPROFILE%\.claude\ (same as Linux/macOS pattern)
  - %APPDATA%\claude\ (Windows-specific location)
  - %LOCALAPPDATA%\claude\ (less likely)
 