### PR TITLE
feat: display command name in worktree list

### DIFF
--- a/src/utils/worktreeUtils.test.ts
+++ b/src/utils/worktreeUtils.test.ts
@@ -192,11 +192,13 @@ describe('column alignment', () => {
 			fileChanges: '\x1b[32m+10\x1b[0m \x1b[31m-5\x1b[0m',
 			aheadBehind: '\x1b[33m↑2 ↓3\x1b[0m',
 			parentBranch: '',
+			commandName: 'claude',
 			lengths: {
 				base: 19, // 'feature/test-branch'.length
 				fileChanges: 6, // '+10 -5'.length
 				aheadBehind: 5, // '↑2 ↓3'.length
 				parentBranch: 0,
+				commandName: 6, // 'claude'.length
 			},
 		},
 		{
@@ -205,18 +207,20 @@ describe('column alignment', () => {
 			fileChanges: '\x1b[32m+2\x1b[0m \x1b[31m-1\x1b[0m',
 			aheadBehind: '\x1b[33m↑1\x1b[0m',
 			parentBranch: '',
+			commandName: 'claude',
 			lengths: {
 				base: 4, // 'main'.length
 				fileChanges: 5, // '+2 -1'.length
 				aheadBehind: 2, // '↑1'.length
 				parentBranch: 0,
+				commandName: 6, // 'claude'.length
 			},
 		},
 	];
 
 	it('should calculate column positions from items', () => {
 		const positions = calculateColumnPositions(mockItems);
-		expect(positions.fileChanges).toBe(21); // 19 + 2 padding
+		expect(positions.fileChanges).toBe(29); // 19 + 2 padding + 6 (commandName) + 2 padding
 		expect(positions.aheadBehind).toBeGreaterThan(positions.fileChanges);
 		expect(positions.parentBranch).toBeGreaterThan(positions.aheadBehind);
 	});
@@ -232,6 +236,6 @@ describe('column alignment', () => {
 
 		// Check alignment by stripping ANSI codes
 		const plain = result.replace(/\x1b\[[0-9;]*m/g, '');
-		expect(plain.indexOf('+10 -5')).toBe(21); // Should start at column 21
+		expect(plain.indexOf('+10 -5')).toBe(29); // Should start at column 29 (updated for commandName column)
 	});
 });

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -24,6 +24,7 @@ interface WorktreeItem {
 	fileChanges: string;
 	aheadBehind: string;
 	parentBranch: string;
+	commandName: string;
 	error?: string;
 	// Visible lengths (without ANSI codes) for alignment calculation
 	lengths: {
@@ -31,6 +32,7 @@ interface WorktreeItem {
 		fileChanges: number;
 		aheadBehind: number;
 		parentBranch: number;
+		commandName: number;
 	};
 }
 
@@ -99,7 +101,17 @@ export function prepareWorktreeItems(
 		let fileChanges = '';
 		let aheadBehind = '';
 		let parentBranch = '';
+		let commandName = '';
 		let error = '';
+
+		// Get command name from session
+		if (session && session.commandConfig) {
+			const command = session.commandConfig.command;
+			const strategy = session.detectionStrategy || 'claude';
+			// Avoid duplicate display when command and strategy are the same
+			const displayName = command === strategy ? command : `${command}:${strategy}`;
+			commandName = `\x1b[36m[${displayName}]\x1b[0m`; // Cyan color for command info
+		}
 
 		if (wt.gitStatus) {
 			fileChanges = formatGitFileChanges(wt.gitStatus);
@@ -123,12 +135,14 @@ export function prepareWorktreeItems(
 			fileChanges,
 			aheadBehind,
 			parentBranch,
+			commandName,
 			error,
 			lengths: {
 				base: stripAnsi(baseLabel).length,
 				fileChanges: stripAnsi(fileChanges).length,
 				aheadBehind: stripAnsi(aheadBehind).length,
 				parentBranch: stripAnsi(parentBranch).length,
+				commandName: stripAnsi(commandName).length,
 			},
 		};
 	});
@@ -142,6 +156,7 @@ export function calculateColumnPositions(items: WorktreeItem[]) {
 	let maxBranchLength = 0;
 	let maxFileChangesLength = 0;
 	let maxAheadBehindLength = 0;
+	let maxCommandNameLength = 0;
 
 	items.forEach(item => {
 		// Skip items with errors for alignment calculation
@@ -156,16 +171,22 @@ export function calculateColumnPositions(items: WorktreeItem[]) {
 			maxAheadBehindLength,
 			item.lengths.aheadBehind,
 		);
+		maxCommandNameLength = Math.max(
+			maxCommandNameLength,
+			item.lengths.commandName,
+		);
 	});
 
 	// Simple column positioning
-	const fileChangesColumn = maxBranchLength + MIN_COLUMN_PADDING;
+	const commandNameColumn = maxBranchLength + MIN_COLUMN_PADDING;
+	const fileChangesColumn = commandNameColumn + maxCommandNameLength + MIN_COLUMN_PADDING;
 	const aheadBehindColumn =
 		fileChangesColumn + maxFileChangesLength + MIN_COLUMN_PADDING + 2;
 	const parentBranchColumn =
 		aheadBehindColumn + maxAheadBehindLength + MIN_COLUMN_PADDING + 2;
 
 	return {
+		commandName: commandNameColumn,
 		fileChanges: fileChangesColumn,
 		aheadBehind: aheadBehindColumn,
 		parentBranch: parentBranchColumn,
@@ -192,6 +213,10 @@ export function assembleWorktreeLabel(
 	let label = item.baseLabel;
 	let currentLength = item.lengths.base;
 
+	if (item.commandName) {
+		label = padTo(label, currentLength, columns.commandName) + item.commandName;
+		currentLength = columns.commandName + item.lengths.commandName;
+	}
 	if (item.fileChanges) {
 		label = padTo(label, currentLength, columns.fileChanges) + item.fileChanges;
 		currentLength = columns.fileChanges + item.lengths.fileChanges;


### PR DESCRIPTION
- Add commandName field to WorktreeItem interface
- Show command/strategy info in cyan color in worktree display
- Avoid duplicate display when command and strategy are the same
- Update column positioning to accommodate command name display
- Adjust test expectations for new column layout
- Update dependencies in package-lock.json

This enhancement improves visibility of which command (claude/gemini) is being used for each session in the worktree list.