### PR TITLE
update: add vim-like j/k moving shortcut on some views

### DIFF
--- a/src/components/ConfigureCommand.tsx
+++ b/src/components/ConfigureCommand.tsx
@@ -290,7 +290,7 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 			// SelectInput handles navigation and selection
 			return;
 		} else if (viewMode === 'delete-confirm') {
-			if (key.upArrow || key.downArrow) {
+			if (key.upArrow || input === 'k' || key.downArrow || input === 'j') {
 				setSelectedIndex(prev => (prev === 0 ? 1 : 0));
 			} else if (key.return) {
 				handleDeleteConfirm();
@@ -507,7 +507,7 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 				</Box>
 
 				<Box marginTop={1}>
-					<Text dimColor>Press ↑↓ to navigate, Enter to confirm</Text>
+					<Text dimColor>Press ↑↓ or j/k to navigate, Enter to confirm</Text>
 				</Box>
 			</Box>
 		);

--- a/src/components/DeleteConfirmation.tsx
+++ b/src/components/DeleteConfirmation.tsx
@@ -77,9 +77,9 @@ const DeleteConfirmation: React.FC<DeleteConfirmationProps> = ({
 	};
 
 	useInput((input, key) => {
-		if (key.upArrow) {
+		if (key.upArrow || input === 'k') {
 			handleUpArrow();
-		} else if (key.downArrow) {
+		} else if (key.downArrow || input === 'j') {
 			handleDownArrow();
 		} else if (key.leftArrow) {
 			handleHorizontalArrow('left');
@@ -172,7 +172,7 @@ const DeleteConfirmation: React.FC<DeleteConfirmationProps> = ({
 
 			<Box marginTop={1}>
 				<Text dimColor>
-					Use ↑↓ to navigate options, Space/Enter to select,{' '}
+					Use ↑↓ or j/k to navigate options, Space/Enter to select,{' '}
 					{shortcutManager.getShortcutDisplay('cancel')} to cancel
 				</Text>
 			</Box>

--- a/src/components/DeleteWorktree.tsx
+++ b/src/components/DeleteWorktree.tsx
@@ -41,9 +41,9 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 			return;
 		}
 
-		if (key.upArrow) {
+		if (key.upArrow || input === 'k') {
 			setFocusedIndex(prev => Math.max(0, prev - 1));
-		} else if (key.downArrow) {
+		} else if (key.downArrow || input === 'j') {
 			setFocusedIndex(prev => Math.min(worktrees.length - 1, prev + 1));
 		} else if (input === ' ') {
 			// Toggle selection
@@ -164,7 +164,7 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 
 			<Box marginTop={1} flexDirection="column">
 				<Text dimColor>
-					Controls: ↑↓ Navigate, Space Select, Enter Confirm,{' '}
+					Controls: ↑↓ or j/k Navigate, Space Select, Enter Confirm,{' '}
 					{shortcutManager.getShortcutDisplay('cancel')} Cancel
 				</Text>
 				{selectedIndices.size > 0 && (


### PR DESCRIPTION
This PR introduces the vim-like shortcut which allows you to move up and down using j/k.
This feature is partially implemented before this PR in views where the selector is implemented using [ink-select-input](https://github.com/vadimdemedes/ink-select-input). There are some views where a custom selector is used for advanced features (e.g. delete worktree view) where these shortcuts are not available, which lead to confusion.