### PR TITLE
feat: add Codex state detection strategy

### DIFF
--- a/src/components/ConfigureCommand.tsx
+++ b/src/components/ConfigureCommand.tsx
@@ -20,7 +20,14 @@ type EditField =
 
 const formatDetectionStrategy = (strategy: string | undefined): string => {
 	const value = strategy || 'claude';
-	return value === 'gemini' ? 'Gemini' : 'Claude';
+	switch (value) {
+		case 'gemini':
+			return 'Gemini';
+		case 'codex':
+			return 'Codex';
+		default:
+			return 'Claude';
+	}
 };
 
 const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
@@ -306,6 +313,7 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 		const strategyItems = [
 			{label: 'Claude', value: 'claude'},
 			{label: 'Gemini', value: 'gemini'},
+			{label: 'Codex', value: 'codex'},
 		];
 
 		const currentStrategy = preset.detectionStrategy || 'claude';
@@ -397,6 +405,7 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 			const strategyItems = [
 				{label: 'Claude', value: 'claude'},
 				{label: 'Gemini', value: 'gemini'},
+				{label: 'Codex', value: 'codex'},
 			];
 
 			return (

--- a/src/services/stateDetector.test.ts
+++ b/src/services/stateDetector.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, beforeEach} from 'vitest';
-import {ClaudeStateDetector, GeminiStateDetector} from './stateDetector.js';
+import {ClaudeStateDetector, GeminiStateDetector, CodexStateDetector} from './stateDetector.js';
 import type {Terminal} from '../types/index.js';
 
 describe('ClaudeStateDetector', () => {
@@ -297,5 +297,136 @@ describe('GeminiStateDetector', () => {
 			// Assert
 			expect(state).toBe('waiting_input'); // waiting_input should take precedence
 		});
+	});
+});
+
+describe('CodexStateDetector', () => {
+	let detector: CodexStateDetector;
+	let terminal: Terminal;
+
+	const createMockTerminal = (lines: string[]): Terminal => {
+		const buffer = {
+			length: lines.length,
+			active: {
+				length: lines.length,
+				getLine: (index: number) => {
+					if (index >= 0 && index < lines.length) {
+						return {
+							translateToString: () => lines[index],
+						};
+					}
+					return null;
+				},
+			},
+		};
+
+		return {buffer} as unknown as Terminal;
+	};
+
+	beforeEach(() => {
+		detector = new CodexStateDetector();
+	});
+
+	it('should detect waiting_input state for │Allow pattern', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Some output',
+			'│Allow execution?',
+			'│ > ',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal);
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
+
+	it('should detect waiting_input state for [y/N] pattern', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Some output',
+			'Continue? [y/N]',
+			'> ',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal);
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
+
+	it('should detect waiting_input state for Press any key pattern', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Some output',
+			'Press any key to continue...',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal);
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
+
+	it('should detect busy state for press esc pattern', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Processing...',
+			'press esc to cancel',
+			'Working...',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal);
+
+		// Assert
+		expect(state).toBe('busy');
+	});
+
+	it('should detect busy state for PRESS ESC (uppercase)', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Processing...',
+			'PRESS ESC to stop',
+			'Working...',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal);
+
+		// Assert
+		expect(state).toBe('busy');
+	});
+
+	it('should detect idle state when no patterns match', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Normal output',
+			'Some message',
+			'Ready',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal);
+
+		// Assert
+		expect(state).toBe('idle');
+	});
+
+	it('should prioritize waiting_input over busy', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'press esc to cancel',
+			'[y/N]',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal);
+
+		// Assert
+		expect(state).toBe('waiting_input');
 	});
 });

--- a/src/services/stateDetector.ts
+++ b/src/services/stateDetector.ts
@@ -16,6 +16,8 @@ export function createStateDetector(
 			return new ClaudeStateDetector();
 		case 'gemini':
 			return new GeminiStateDetector();
+		case 'codex':
+			return new CodexStateDetector();
 		default:
 			return new ClaudeStateDetector();
 	}
@@ -94,6 +96,30 @@ export class GeminiStateDetector extends BaseStateDetector {
 
 		// Check for busy state
 		if (lowerContent.includes('esc to cancel')) {
+			return 'busy';
+		}
+
+		// Otherwise idle
+		return 'idle';
+	}
+}
+
+export class CodexStateDetector extends BaseStateDetector {
+	detectState(terminal: Terminal): SessionState {
+		const content = this.getTerminalContent(terminal);
+		const lowerContent = content.toLowerCase();
+
+		// Check for waiting prompts
+		if (
+			content.includes('│Allow') ||
+			content.includes('[y/N]') ||
+			content.includes('Press any key')
+		) {
+			return 'waiting_input';
+		}
+
+		// Check for busy state
+		if (lowerContent.includes('press esc')) {
 			return 'busy';
 		}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export type Terminal = InstanceType<typeof pkg.Terminal>;
 
 export type SessionState = 'idle' | 'busy' | 'waiting_input';
 
-export type StateDetectionStrategy = 'claude' | 'gemini';
+export type StateDetectionStrategy = 'claude' | 'gemini' | 'codex';
 
 export interface Worktree {
 	path: string;


### PR DESCRIPTION
## Summary

This PR adds support for detecting the state of Codex CLI sessions in CCManager, enabling proper state tracking for users who work with the Codex tool alongside Claude Code and Gemini CLI.

## Description

### State Detection Strategy

Added a new `CodexStateDetector` class that implements state detection patterns specific to the Codex CLI tool:

- **Waiting for input states**: Detects when Codex is waiting for user confirmation or input
  - `│Allow` - When Codex asks for permission
  - `[y/N]` - Yes/No prompts
  - `Press any key` - Generic key press prompts

- **Busy state**: Detects when Codex is processing
  - `press esc` (case-insensitive) - Indicates an interruptible operation is in progress

- **Idle state**: Default state when no specific patterns are detected

### Implementation Details

1. **Type System Updates**: Extended the `StateDetectionStrategy` type to include `'codex'` as a valid option
2. **Factory Pattern Integration**: Added CodexStateDetector to the state detector factory function
3. **UI Integration**: Updated the command configuration UI to include "Codex" as a selectable detection strategy option
4. **Test Coverage**: Added comprehensive unit tests (7 test cases) covering all detection scenarios

### Testing

All existing tests continue to pass, and the new CodexStateDetector tests verify:
- Correct detection of all waiting input patterns
- Case-insensitive busy state detection
- Proper idle state fallback
- Priority handling when multiple patterns are present

This change maintains backward compatibility while extending CCManager's capabilities to support another popular CLI tool.
EOF < /dev/null