### PR TITLE
feat: add option to copy .claude directory when creating worktree

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -179,7 +179,7 @@ const App: React.FC = () => {
 		path: string,
 		branch: string,
 		baseBranch: string,
-		copySettings: boolean,
+		copyClaudeDirectory: boolean,
 	) => {
 		setView('creating-worktree');
 		setError(null);
@@ -189,7 +189,7 @@ const App: React.FC = () => {
 			path,
 			branch,
 			baseBranch,
-			copySettings,
+			copyClaudeDirectory,
 		);
 
 		if (result.success) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -179,12 +179,18 @@ const App: React.FC = () => {
 		path: string,
 		branch: string,
 		baseBranch: string,
+		copySettings: boolean,
 	) => {
 		setView('creating-worktree');
 		setError(null);
 
 		// Create the worktree
-		const result = worktreeService.createWorktree(path, branch, baseBranch);
+		const result = worktreeService.createWorktree(
+			path,
+			branch,
+			baseBranch,
+			copySettings,
+		);
 
 		if (result.success) {
 			// Success - return to menu

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -12,7 +12,7 @@ interface NewWorktreeProps {
 		path: string,
 		branch: string,
 		baseBranch: string,
-		copySettings: boolean,
+		copyClaudeDirectory: boolean,
 	) => void;
 	onCancel: () => void;
 }
@@ -79,9 +79,9 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 	const handleBaseBranchSelect = (item: {label: string; value: string}) => {
 		setBaseBranch(item.value);
 
-		// Check if settings file exists in the base branch
+		// Check if .claude directory exists in the base branch
 		const service = new WorktreeService();
-		if (service.hasSettingsFileInBranch(item.value)) {
+		if (service.hasClaudeDirectoryInBranch(item.value)) {
 			setStep('copy-settings');
 		} else {
 			// Skip copy-settings step and complete with copySettings = false
@@ -203,14 +203,17 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 				<Box flexDirection="column">
 					<Box marginBottom={1}>
 						<Text>
-							Copy .claude/settings.local.json from base branch (
+							Copy .claude directory from base branch (
 							<Text color="cyan">{baseBranch}</Text>)?
 						</Text>
 					</Box>
 					<SelectInput
 						items={[
-							{label: 'Yes - Copy settings from base branch', value: true},
-							{label: 'No - Start with fresh settings', value: false},
+							{
+								label: 'Yes - Copy .claude directory from base branch',
+								value: true,
+							},
+							{label: 'No - Start without .claude directory', value: false},
 						]}
 						onSelect={handleCopySettingsSelect}
 						initialIndex={0}

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -78,7 +78,23 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 
 	const handleBaseBranchSelect = (item: {label: string; value: string}) => {
 		setBaseBranch(item.value);
-		setStep('copy-settings');
+
+		// Check if settings file exists in the base branch
+		const service = new WorktreeService();
+		if (service.hasSettingsFileInBranch(item.value)) {
+			setStep('copy-settings');
+		} else {
+			// Skip copy-settings step and complete with copySettings = false
+			if (isAutoDirectory) {
+				const autoPath = generateWorktreeDirectory(
+					branch,
+					worktreeConfig.autoDirectoryPattern,
+				);
+				onComplete(autoPath, branch, item.value, false);
+			} else {
+				onComplete(path, branch, item.value, false);
+			}
+		}
 	};
 
 	const handleCopySettingsSelect = (item: {label: string; value: boolean}) => {

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -403,6 +403,46 @@ export class WorktreeService {
 		}
 	}
 
+	hasSettingsFileInBranch(branchName: string): boolean {
+		const settingsFileName = 'settings.local.json';
+		const claudeDir = '.claude';
+
+		// Find the worktree directory for the branch
+		const worktrees = this.getWorktrees();
+		let targetWorktree = worktrees.find(
+			wt => wt.branch && wt.branch.replace('refs/heads/', '') === branchName,
+		);
+
+		// If branch worktree not found, try the default branch
+		if (!targetWorktree) {
+			const defaultBranch = this.getDefaultBranch();
+			if (branchName === defaultBranch) {
+				targetWorktree = worktrees.find(
+					wt =>
+						wt.branch && wt.branch.replace('refs/heads/', '') === defaultBranch,
+				);
+			}
+		}
+
+		// If still not found and it's the default branch, try the main worktree
+		if (!targetWorktree && branchName === this.getDefaultBranch()) {
+			targetWorktree = worktrees.find(wt => wt.isMainWorktree);
+		}
+
+		if (!targetWorktree) {
+			return false;
+		}
+
+		// Check if settings file exists in the worktree
+		const settingsPath = path.join(
+			targetWorktree.path,
+			claudeDir,
+			settingsFileName,
+		);
+
+		return existsSync(settingsPath);
+	}
+
 	private copySettingsFromBaseBranch(
 		worktreePath: string,
 		baseBranch: string,


### PR DESCRIPTION
## Summary

This PR adds a new feature to optionally copy the `.claude` directory from the base branch when creating a new worktree. The feature intelligently shows the copy option only when the `.claude` directory exists in the base branch, helping users maintain consistent Claude Code configurations across related worktrees.

## Description

### Claude Directory Copy Feature

When creating a new worktree, users can now choose to copy the entire `.claude` directory from the base branch to the new worktree. This ensures all Claude Code configurations, including `settings.local.json` and any other files, are preserved across worktrees.

**Key behaviors:**
- The copy option is only shown if the `.claude` directory exists in the base branch
- Recursively copies all files and subdirectories within `.claude`
- Falls back to default branch worktree if base branch worktree not found
- Falls back to main worktree if default branch worktree not found
- Creates the target `.claude` directory automatically if needed

### UI Flow Enhancement

Added a conditional step in the worktree creation process:
1. Path selection (if not using auto-directory mode)
2. Branch name input
3. Base branch selection
4. **NEW: Copy .claude directory prompt** (only shown if `.claude` directory exists in base branch)

The copy prompt presents two options:
- "Yes - Copy .claude directory from base branch"
- "No - Start without .claude directory"

If the `.claude` directory doesn't exist in the base branch, this step is automatically skipped.

### Implementation Details

**New methods added:**
- `WorktreeService.hasClaudeDirectoryInBranch(branchName: string): boolean` - Checks if `.claude` directory exists in a branch's worktree
- `WorktreeService.copyClaudeDirectoryFromBaseBranch(worktreePath: string, baseBranch: string): void` - Recursively copies the entire `.claude` directory
- `WorktreeService.copyDirectoryRecursive(source: string, target: string): void` - Helper method for recursive directory copying

**Modified components:**
- `NewWorktree.tsx`: Added conditional copy step and checks for directory existence
- `App.tsx`: Updated to handle the new `copyClaudeDirectory` parameter
- `worktreeService.ts`: Added directory checking and recursive copying functionality

**Error handling:**
- Directory copy failures are logged but don't block worktree creation
- Missing directories are handled gracefully with appropriate fallbacks
- File system operations include proper error boundaries

### Benefits

1. **Configuration Consistency**: Developers can maintain consistent Claude Code settings across feature branches
2. **Team Collaboration**: Shared configurations can be easily propagated to new worktrees
3. **Flexibility**: Users can choose whether to inherit configurations or start fresh
4. **Smart UX**: The option only appears when relevant, reducing unnecessary prompts
EOF < /dev/null