### PR TITLE
fix: resolve duplicate title issue in Menu component

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -32,7 +32,6 @@ const App: React.FC = () => {
 	const [worktreeService] = useState(() => new WorktreeService());
 	const [activeSession, setActiveSession] = useState<SessionType | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const [menuKey, setMenuKey] = useState(0); // Force menu refresh
 	const [selectedWorktree, setSelectedWorktree] = useState<Worktree | null>(
 		null,
 	); // Store selected worktree for preset selection
@@ -48,7 +47,6 @@ const App: React.FC = () => {
 						setActiveSession(null);
 						setError(null);
 						setView('menu');
-						setMenuKey(prev => prev + 1);
 						if (process.stdout.isTTY) {
 							process.stdout.write('\x1B[2J\x1B[H');
 						}
@@ -147,7 +145,6 @@ const App: React.FC = () => {
 	const handlePresetSelectorCancel = () => {
 		setSelectedWorktree(null);
 		setView('menu');
-		setMenuKey(prev => prev + 1);
 	};
 
 	const handleReturnToMenu = () => {
@@ -157,7 +154,6 @@ const App: React.FC = () => {
 		// Add a small delay to ensure Session cleanup completes
 		setTimeout(() => {
 			setView('menu');
-			setMenuKey(prev => prev + 1); // Force menu refresh
 
 			// Clear the screen when returning to menu
 			if (process.stdout.isTTY) {
@@ -280,7 +276,6 @@ const App: React.FC = () => {
 	if (view === 'menu') {
 		return (
 			<Menu
-				key={menuKey}
 				sessionManager={sessionManager}
 				onSelectWorktree={handleSelectWorktree}
 			/>


### PR DESCRIPTION
## Problem
The Menu component was displaying duplicate titles when navigating between different views and returning to the menu. This created a confusing user experience with multiple identical titles stacked on top of each other.

## Root Cause
The issue was caused by an unused menuKey state variable in the App component that was intended to force menu refreshes. The setMenuKey(prev => prev + 1) calls were triggering unnecessary re-renders that caused the Menu component to duplicate its title content.

## Solution
•  Removed the unused menuKey state variable and its setter from App.tsx
•  Eliminated all setMenuKey calls that were forcing menu refreshes
•  Simplified the state management flow without affecting functionality

## Testing
•  ✅ Menu titles now render correctly without duplication
•  ✅ Navigation between views works as expected
•  ✅ Returning to menu from sessions/presets shows single title
•  ✅ No regression in existing functionality

Before/After

https://github.com/user-attachments/assets/a3d746ec-562f-4491-bdba-1c9109c0aa6f


https://github.com/user-attachments/assets/42b61c2c-d578-4d1a-8703-849853ede4e1

