### PR TITLE
fix: handle bracketed paste mode escape sequences in text inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
 				"ink-text-input": "^5.0.1",
 				"meow": "^11.0.0",
 				"node-pty": "^1.0.0",
-				"react": "^18.2.0"
+				"react": "^18.2.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"bin": {
 				"ccmanager": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"ink-text-input": "^5.0.1",
 		"meow": "^11.0.0",
 		"node-pty": "^1.0.0",
-		"react": "^18.2.0"
+		"react": "^18.2.0",
+		"strip-ansi": "^7.1.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/src/components/ConfigureCommand.tsx
+++ b/src/components/ConfigureCommand.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Box, Text, useInput} from 'ink';
-import TextInput from 'ink-text-input';
+import TextInputWrapper from './TextInputWrapper.js';
 import SelectInput from 'ink-select-input';
 import {configurationManager} from '../services/configurationManager.js';
 import {shortcutManager} from '../services/shortcutManager.js';
@@ -377,7 +377,7 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 				)}
 
 				<Box>
-					<TextInput
+					<TextInputWrapper
 						value={inputValue}
 						onChange={setInputValue}
 						onSubmit={handleFieldUpdate}
@@ -462,7 +462,7 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 				)}
 
 				<Box>
-					<TextInput
+					<TextInputWrapper
 						value={inputValue}
 						onChange={setInputValue}
 						onSubmit={handleAddPresetInput}

--- a/src/components/ConfigureHooks.tsx
+++ b/src/components/ConfigureHooks.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import {Box, Text, useInput} from 'ink';
-import TextInput from 'ink-text-input';
+import TextInputWrapper from './TextInputWrapper.js';
 import SelectInput from 'ink-select-input';
 import {configurationManager} from '../services/configurationManager.js';
 import {StatusHookConfig, SessionState} from '../types/index.js';
@@ -137,7 +137,7 @@ const ConfigureHooks: React.FC<ConfigureHooksProps> = ({onComplete}) => {
 				</Box>
 
 				<Box marginBottom={1}>
-					<TextInput
+					<TextInputWrapper
 						value={currentCommand}
 						onChange={setCurrentCommand}
 						onSubmit={handleCommandSubmit}

--- a/src/components/ConfigureWorktree.tsx
+++ b/src/components/ConfigureWorktree.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
-import TextInput from 'ink-text-input';
+import TextInputWrapper from './TextInputWrapper.js';
 import {configurationManager} from '../services/configurationManager.js';
 import {shortcutManager} from '../services/shortcutManager.js';
 
@@ -117,7 +117,7 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 
 				<Box>
 					<Text color="cyan">{'> '}</Text>
-					<TextInput
+					<TextInputWrapper
 						value={tempPattern}
 						onChange={setTempPattern}
 						onSubmit={handlePatternSubmit}

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useMemo} from 'react';
 import {Box, Text, useInput} from 'ink';
-import TextInput from 'ink-text-input';
+import TextInputWrapper from './TextInputWrapper.js';
 import SelectInput from 'ink-select-input';
 import {shortcutManager} from '../services/shortcutManager.js';
 import {configurationManager} from '../services/configurationManager.js';
@@ -134,7 +134,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 					</Box>
 					<Box>
 						<Text color="cyan">{'> '}</Text>
-						<TextInput
+						<TextInputWrapper
 							value={path}
 							onChange={setPath}
 							onSubmit={handlePathSubmit}
@@ -152,7 +152,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 					</Box>
 					<Box>
 						<Text color="cyan">{'> '}</Text>
-						<TextInput
+						<TextInputWrapper
 							value={branch}
 							onChange={setBranch}
 							onSubmit={handleBranchSubmit}
@@ -167,7 +167,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 					</Box>
 					<Box>
 						<Text color="cyan">{'> '}</Text>
-						<TextInput
+						<TextInputWrapper
 							value={branch}
 							onChange={setBranch}
 							onSubmit={handleBranchSubmit}

--- a/src/components/TextInputWrapper.tsx
+++ b/src/components/TextInputWrapper.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import TextInput from 'ink-text-input';
+import stripAnsi from 'strip-ansi';
+
+interface TextInputWrapperProps {
+	value: string;
+	onChange: (value: string) => void;
+	onSubmit?: (value: string) => void;
+	placeholder?: string;
+	focus?: boolean;
+	mask?: string;
+	showCursor?: boolean;
+	highlightPastedText?: boolean;
+}
+
+const TextInputWrapper: React.FC<TextInputWrapperProps> = ({
+	value,
+	onChange,
+	...props
+}) => {
+	const handleChange = (newValue: string) => {
+		// First strip all ANSI escape sequences
+		let cleanedValue = stripAnsi(newValue);
+
+		// Then specifically remove bracketed paste mode markers that might remain
+		// These sometimes appear as literal text after ANSI stripping
+		cleanedValue = cleanedValue.replace(/\[200~/g, '').replace(/\[201~/g, '');
+
+		onChange(cleanedValue);
+	};
+
+	return <TextInput value={value} onChange={handleChange} {...props} />;
+};
+
+export default TextInputWrapper;

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import stripAnsi from 'strip-ansi';
 import {Worktree, Session} from '../types/index.js';
 import {getStatusDisplay} from '../constants/statusIcons.js';
 import {
@@ -10,9 +11,6 @@ import {
 // Constants
 const MAX_BRANCH_NAME_LENGTH = 40; // Maximum characters for branch name display
 const MIN_COLUMN_PADDING = 2; // Minimum spaces between columns
-
-// Strip ANSI escape codes for length calculation
-const stripAnsi = (str: string): string => str.replace(/\x1b\[[0-9;]*m/g, '');
 
 /**
  * Worktree item with formatted content for display.


### PR DESCRIPTION
## Summary
- Fixed an issue where bracketed paste mode escape sequences ([200~ and [201~) were appearing in TextInput fields
- Created a TextInputWrapper component that filters out these sequences using the strip-ansi package
- Replaced all TextInput usages with the new wrapper component

## Problem
When pasting text into any TextInput field in ccmanager, the terminal's bracketed paste mode escape sequences were included in the input value. This caused unwanted characters like `[200~` at the start and `[201~` at the end of pasted text.

## Solution
1. Created a `TextInputWrapper` component that:
   - Uses the `strip-ansi` package to remove all ANSI escape sequences
   - Additionally filters out any remaining bracketed paste markers
   - Maintains the same API as the original TextInput component

2. Updated all components using TextInput:
   - `NewWorktree.tsx`
   - `ConfigureCommand.tsx`
   - `ConfigureHooks.tsx`
   - `ConfigureWorktree.tsx`

3. Replaced the custom `stripAnsi` function in `worktreeUtils.ts` with the `strip-ansi` package for consistency

## Testing
- Paste text containing bracketed paste sequences into any text input field
- Verify that only the actual text content appears without escape sequences
- Test with various paste scenarios including multiple pastes and ANSI colored text

🤖 Generated with [Claude Code](https://claude.ai/code)