### PR TITLE
Fix: Prevent branch deletion prompt after failed merge/rebase

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -25,7 +25,6 @@ type View =
 	| 'delete-worktree'
 	| 'deleting-worktree'
 	| 'merge-worktree'
-	| 'merging-worktree'
 	| 'configuration'
 	| 'preset-selector';
 
@@ -263,46 +262,6 @@ const App: React.FC<AppProps> = ({devcontainerConfig}) => {
 		handleReturnToMenu();
 	};
 
-	const handleMergeWorktree = async (
-		sourceBranch: string,
-		targetBranch: string,
-		deleteAfterMerge: boolean,
-		useRebase: boolean,
-	) => {
-		setView('merging-worktree');
-		setError(null);
-
-		// Perform the merge
-		const mergeResult = worktreeService.mergeWorktree(
-			sourceBranch,
-			targetBranch,
-			useRebase,
-		);
-
-		if (mergeResult.success) {
-			// If user wants to delete the merged branch
-			if (deleteAfterMerge) {
-				const deleteResult =
-					worktreeService.deleteWorktreeByBranch(sourceBranch);
-				if (!deleteResult.success) {
-					setError(deleteResult.error || 'Failed to delete merged worktree');
-					setView('merge-worktree');
-					return;
-				}
-			}
-			// Success - return to menu
-			handleReturnToMenu();
-		} else {
-			// Show error
-			setError(mergeResult.error || 'Failed to merge branches');
-			setView('merge-worktree');
-		}
-	};
-
-	const handleCancelMergeWorktree = () => {
-		handleReturnToMenu();
-	};
-
 	if (view === 'menu') {
 		return (
 			<Menu
@@ -391,17 +350,9 @@ const App: React.FC<AppProps> = ({devcontainerConfig}) => {
 					</Box>
 				)}
 				<MergeWorktree
-					onComplete={handleMergeWorktree}
-					onCancel={handleCancelMergeWorktree}
+					onComplete={handleReturnToMenu}
+					onCancel={handleReturnToMenu}
 				/>
-			</Box>
-		);
-	}
-
-	if (view === 'merging-worktree') {
-		return (
-			<Box flexDirection="column">
-				<Text color="green">Merging worktrees...</Text>
 			</Box>
 		);
 	}


### PR DESCRIPTION
## Summary
- Fixed issue where users were prompted to delete source branch even after failed merge/rebase operations
- Refactored MergeWorktree component to handle all UI states internally
- Added proper error handling and conditional flow for delete confirmation

## Problem
The app was asking users to delete the source branch regardless of whether the merge/rebase operation succeeded or failed. This could lead to accidental data loss if users deleted branches that weren't successfully merged.

## Solution
Refactored the `MergeWorktree` component to be self-contained:
- Added merge execution logic directly in the component
- Added error handling that shows error message and returns to menu on failure
- Delete confirmation now only appears after successful merge operation
- Simplified the component interface to just `onComplete` and `onCancel` callbacks

## Changes
- Modified `src/components/MergeWorktree.tsx` to handle all merge flow states
- Updated `src/components/App.tsx` to use simplified MergeWorktree interface
- Removed unnecessary state management and handlers from App component

## Test plan
- [ ] Start ccmanager and create a test worktree
- [ ] Attempt to merge two branches that will succeed
- [ ] Verify delete confirmation appears after successful merge
- [ ] Attempt to merge branches that will fail (e.g., with conflicts)
- [ ] Verify error message appears and no delete confirmation is shown
- [ ] Test both merge and rebase operations

🤖 Generated with [Claude Code](https://claude.ai/code)