### PR TITLE
feat: add {project} placeholder for worktree directory patterns

### DIFF
--- a/docs/worktree-auto-directory.md
+++ b/docs/worktree-auto-directory.md
@@ -38,6 +38,7 @@ Edit `~/.config/ccmanager/config.json`:
 
 The pattern supports the following placeholders:
 - `{branch}` or `{branch-name}`: Replaced with the sanitized branch name
+- `{project}`: Replaced with the Git repository name (main working directory basename)
 
 ## Branch Name Sanitization
 
@@ -62,13 +63,15 @@ Branch names are automatically sanitized for filesystem compatibility:
 
 ## Pattern Examples
 
-| Pattern | Branch Name | Generated Directory |
-|---------|-------------|-------------------|
-| `../{branch}` | `feature/login` | `../feature-login` |
-| `.git/tasks/{branch}` | `fix/bug-123` | `.git/tasks/fix-bug-123` |
-| `worktrees/{branch}` | `hotfix/v1.2.3` | `worktrees/hotfix-v1.2.3` |
-| `~/work/{branch}` | `feature/new-ui` | `~/work/feature-new-ui` |
-| `../{branch}-wt` | `develop` | `../develop-wt` |
+| Pattern                     | Branch Name      | Generated Directory         |
+| --------------------------- | ---------------- | --------------------------- |
+| `../{branch}`               | `feature/login`  | `../feature-login`          |
+| `.git/tasks/{branch}`       | `fix/bug-123`    | `.git/tasks/fix-bug-123`    |
+| `worktrees/{branch}`        | `hotfix/v1.2.3`  | `worktrees/hotfix-v1.2.3`   |
+| `~/work/{branch}`           | `feature/new-ui` | `~/work/feature-new-ui`     |
+| `../{branch}-wt`            | `develop`        | `../develop-wt`             |
+| `../{project}-{branch}`     | `feature/auth`   | `../myproject-feature-auth` |
+| `~/work/{project}/{branch}` | `fix/typo`       | `~/work/myproject/fix-typo` |
 
 ## User Experience
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -407,6 +407,7 @@ const App: React.FC<AppProps> = ({devcontainerConfig, multiProject}) => {
 					</Box>
 				)}
 				<NewWorktree
+					projectPath={selectedProject?.path || process.cwd()}
 					onComplete={handleCreateWorktree}
 					onCancel={handleCancelNewWorktree}
 				/>

--- a/src/components/ConfigureWorktree.tsx
+++ b/src/components/ConfigureWorktree.tsx
@@ -4,6 +4,7 @@ import SelectInput from 'ink-select-input';
 import TextInputWrapper from './TextInputWrapper.js';
 import {configurationManager} from '../services/configurationManager.js';
 import {shortcutManager} from '../services/shortcutManager.js';
+import {generateWorktreeDirectory} from '../utils/worktreeUtils.js';
 
 interface ConfigureWorktreeProps {
 	onComplete: () => void;
@@ -29,6 +30,10 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 	);
 	const [editMode, setEditMode] = useState<EditMode>('menu');
 	const [tempPattern, setTempPattern] = useState(pattern);
+
+	// Example values for preview
+	const exampleProjectPath = '/home/user/src/myproject';
+	const exampleBranchName = 'feature/my-feature';
 
 	useInput((input, key) => {
 		if (
@@ -111,7 +116,8 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 
 				<Box marginBottom={1}>
 					<Text dimColor>
-						Available placeholders: {'{branch}'} - full branch name
+						Available placeholders: {'{branch}'} - full branch name,{' '}
+						{'{project}'} - repository name
 					</Text>
 				</Box>
 
@@ -147,8 +153,14 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 			{autoDirectory && (
 				<Box marginBottom={1}>
 					<Text>
-						Example: branch &quot;feature/my-feature&quot; → directory &quot;
-						{pattern.replace('{branch}', 'feature-my-feature')}&quot;
+						Example: project &quot;{exampleProjectPath}&quot;, branch &quot;
+						{exampleBranchName}&quot; → directory &quot;
+						{generateWorktreeDirectory(
+							exampleProjectPath,
+							exampleBranchName,
+							pattern,
+						)}
+						&quot;
 					</Text>
 				</Box>
 			)}

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -9,6 +9,7 @@ import {WorktreeService} from '../services/worktreeService.js';
 import {useSearchMode} from '../hooks/useSearchMode.js';
 
 interface NewWorktreeProps {
+	projectPath?: string;
 	onComplete: (
 		path: string,
 		branch: string,
@@ -31,7 +32,11 @@ interface BranchItem {
 	value: string;
 }
 
-const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
+const NewWorktree: React.FC<NewWorktreeProps> = ({
+	projectPath,
+	onComplete,
+	onCancel,
+}) => {
 	const worktreeConfig = configurationManager.getWorktreeConfig();
 	const isAutoDirectory = worktreeConfig.autoDirectory;
 	const limit = 10;
@@ -126,6 +131,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 		if (isAutoDirectory) {
 			// Generate path from branch name
 			const autoPath = generateWorktreeDirectory(
+				projectPath || process.cwd(),
 				branch,
 				worktreeConfig.autoDirectoryPattern,
 			);
@@ -138,9 +144,18 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({onComplete, onCancel}) => {
 	// Calculate generated path for preview (memoized to avoid expensive recalculations)
 	const generatedPath = useMemo(() => {
 		return isAutoDirectory && branch
-			? generateWorktreeDirectory(branch, worktreeConfig.autoDirectoryPattern)
+			? generateWorktreeDirectory(
+					projectPath || process.cwd(),
+					branch,
+					worktreeConfig.autoDirectoryPattern,
+				)
 			: '';
-	}, [isAutoDirectory, branch, worktreeConfig.autoDirectoryPattern]);
+	}, [
+		isAutoDirectory,
+		branch,
+		worktreeConfig.autoDirectoryPattern,
+		projectPath,
+	]);
 
 	return (
 		<Box flexDirection="column">

--- a/src/utils/hookExecutor.test.ts
+++ b/src/utils/hookExecutor.test.ts
@@ -4,7 +4,7 @@ import {
 	executeWorktreePostCreationHook,
 	executeStatusHook,
 } from './hookExecutor.js';
-import {mkdtemp, rm, readFile} from 'fs/promises';
+import {mkdtemp, rm, readFile, realpath} from 'fs/promises';
 import {tmpdir} from 'os';
 import {join} from 'path';
 import type {SessionState, Session} from '../types/index.js';
@@ -175,7 +175,9 @@ describe('hookExecutor Integration Tests', () => {
 				const output = await readFile(outputFile, 'utf-8');
 
 				// Assert - should be executed in tmpDir
-				expect(output.trim()).toBe(tmpDir);
+				const expectedPath = await realpath(tmpDir);
+				const actualPath = await realpath(output.trim());
+				expect(actualPath).toBe(expectedPath);
 			} finally {
 				// Cleanup
 				await rm(tmpDir, {recursive: true});
@@ -231,7 +233,11 @@ describe('hookExecutor Integration Tests', () => {
 				const output = await readFile(outputFile, 'utf-8');
 
 				// Assert - should be executed in worktree path, not git root
-				expect(output.trim()).toBe(tmpDir);
+				const expectedPath = await realpath(tmpDir);
+				const actualPath = await realpath(output.trim());
+				expect(actualPath).toBe(expectedPath);
+
+				// Also verify it's not the git root path
 				expect(output.trim()).not.toBe(gitRoot);
 			} finally {
 				// Cleanup


### PR DESCRIPTION
- Support {project} placeholder in generateWorktreeDirectory()
- Add getGitRepositoryName() to extract Git repository name from the project path, tracing back the main .git directory when run in a worktree
- Update the ConfigureWorktree component to use the real logic