### PR TITLE
feat: add mutex protection for session state keys

### DIFF
--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -22,10 +22,11 @@ const Session: React.FC<SessionProps> = ({
 	const deriveStatus = (
 		currentSession: ISession,
 	): {message: string | null; variant: StatusVariant} => {
+		const stateData = currentSession.stateMutex.getSnapshot();
 		// Always prioritize showing the manual approval notice when verification failed
-		if (currentSession.autoApprovalFailed) {
-			const reason = currentSession.autoApprovalReason
-				? ` Reason: ${currentSession.autoApprovalReason}.`
+		if (stateData.autoApprovalFailed) {
+			const reason = stateData.autoApprovalReason
+				? ` Reason: ${stateData.autoApprovalReason}.`
 				: '';
 			return {
 				message: `Auto-approval failed.${reason} Manual approval required—respond to the prompt.`,
@@ -33,7 +34,7 @@ const Session: React.FC<SessionProps> = ({
 			};
 		}
 
-		if (currentSession.state === 'pending_auto_approval') {
+		if (stateData.state === 'pending_auto_approval') {
 			return {
 				message:
 					'Auto-approval pending... verifying permissions (press any key to cancel)',
@@ -246,7 +247,7 @@ const Session: React.FC<SessionProps> = ({
 				return;
 			}
 
-			if (session.state === 'pending_auto_approval') {
+			if (session.stateMutex.getSnapshot().state === 'pending_auto_approval') {
 				sessionManager.cancelAutoApproval(
 					session.worktreePath,
 					'User input received during auto-approval',

--- a/src/services/sessionManager.effect.test.ts
+++ b/src/services/sessionManager.effect.test.ts
@@ -99,7 +99,7 @@ describe('SessionManager Effect-based Operations', () => {
 
 			expect(session).toBeDefined();
 			expect(session.worktreePath).toBe('/test/worktree');
-			expect(session.state).toBe('busy');
+			expect(session.stateMutex.getSnapshot().state).toBe('busy');
 		});
 
 		it('should return Effect that fails with ConfigError when preset not found', async () => {

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1034,13 +1034,24 @@ describe('SessionManager', () => {
 
 	describe('static methods', () => {
 		describe('getSessionCounts', () => {
+			// Helper to create mock session with stateMutex
+			const createMockSession = (
+				id: string,
+				state: 'idle' | 'busy' | 'waiting_input' | 'pending_auto_approval',
+			): Partial<Session> => ({
+				id,
+				stateMutex: {
+					getSnapshot: () => ({state}),
+				} as Session['stateMutex'],
+			});
+
 			it('should count sessions by state', () => {
-				const sessions: Partial<Session>[] = [
-					{id: '1', state: 'idle'},
-					{id: '2', state: 'busy'},
-					{id: '3', state: 'busy'},
-					{id: '4', state: 'waiting_input'},
-					{id: '5', state: 'idle'},
+				const sessions = [
+					createMockSession('1', 'idle'),
+					createMockSession('2', 'busy'),
+					createMockSession('3', 'busy'),
+					createMockSession('4', 'waiting_input'),
+					createMockSession('5', 'idle'),
 				];
 
 				const counts = SessionManager.getSessionCounts(sessions as Session[]);
@@ -1061,10 +1072,10 @@ describe('SessionManager', () => {
 			});
 
 			it('should handle sessions with single state', () => {
-				const sessions: Partial<Session>[] = [
-					{id: '1', state: 'busy'},
-					{id: '2', state: 'busy'},
-					{id: '3', state: 'busy'},
+				const sessions = [
+					createMockSession('1', 'busy'),
+					createMockSession('2', 'busy'),
+					createMockSession('3', 'busy'),
 				];
 
 				const counts = SessionManager.getSessionCounts(sessions as Session[]);

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -21,6 +21,7 @@ import {Effect} from 'effect';
 import {ProcessError, ConfigError} from '../types/errors.js';
 import {autoApprovalVerifier} from './autoApprovalVerifier.js';
 import {logger} from '../utils/logger.js';
+import {Mutex, createInitialSessionStateData} from '../utils/mutex.js';
 const {Terminal} = pkg;
 const execAsync = promisify(exec);
 const TERMINAL_CONTENT_MAX_LINES = 300;
@@ -58,13 +59,17 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		// Create a detector based on the session's detection strategy
 		const strategy = session.detectionStrategy || 'claude';
 		const detector = createStateDetector(strategy);
-		const detectedState = detector.detectState(session.terminal, session.state);
+		const stateData = session.stateMutex.getSnapshot();
+		const detectedState = detector.detectState(
+			session.terminal,
+			stateData.state,
+		);
 
 		// If auto-approval is enabled and state is waiting_input, convert to pending_auto_approval
 		if (
 			detectedState === 'waiting_input' &&
 			configurationManager.isAutoApprovalEnabled() &&
-			!session.autoApprovalFailed
+			!stateData.autoApprovalFailed
 		) {
 			return 'pending_auto_approval';
 		}
@@ -103,8 +108,11 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		);
 
 		const abortController = new AbortController();
-		session.autoApprovalAbortController = abortController;
-		session.autoApprovalReason = undefined;
+		void session.stateMutex.update(data => ({
+			...data,
+			autoApprovalAbortController: abortController,
+			autoApprovalReason: undefined,
+		}));
 
 		// Get terminal content for verification
 		const terminalContent = this.getTerminalContent(session);
@@ -115,7 +123,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				signal: abortController.signal,
 			}),
 		)
-			.then(autoApprovalResult => {
+			.then(async autoApprovalResult => {
 				if (abortController.signal.aborted) {
 					logger.debug(
 						`[${session.id}] Auto-approval verification aborted before completion`,
@@ -124,9 +132,10 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				}
 
 				// If state already moved away, skip handling
-				if (session.state !== 'pending_auto_approval') {
+				const currentState = session.stateMutex.getSnapshot().state;
+				if (currentState !== 'pending_auto_approval') {
 					logger.debug(
-						`[${session.id}] Skipping auto-approval handling; current state is ${session.state}`,
+						`[${session.id}] Skipping auto-approval handling; current state is ${currentState}`,
 					);
 					return;
 				}
@@ -136,28 +145,34 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					logger.info(
 						`[${session.id}] Auto-approval verification determined user permission needed`,
 					);
-					session.state = 'waiting_input';
-					session.autoApprovalFailed = true;
-					session.autoApprovalReason = autoApprovalResult.reason;
-					session.pendingState = undefined;
-					session.pendingStateStart = undefined;
+					await session.stateMutex.update(data => ({
+						...data,
+						state: 'waiting_input',
+						autoApprovalFailed: true,
+						autoApprovalReason: autoApprovalResult.reason,
+						pendingState: undefined,
+						pendingStateStart: undefined,
+					}));
 					this.emit('sessionStateChanged', session);
 				} else {
 					// Auto-approve by simulating Enter key press
 					logger.info(
 						`[${session.id}] Auto-approval granted, simulating user permission`,
 					);
-					session.autoApprovalReason = undefined;
 					session.process.write('\r');
 					// Force state to busy to prevent endless auto-approval
 					// when the state detection still sees pending_auto_approval
-					session.state = 'busy';
-					session.pendingState = undefined;
-					session.pendingStateStart = undefined;
+					await session.stateMutex.update(data => ({
+						...data,
+						state: 'busy',
+						autoApprovalReason: undefined,
+						pendingState: undefined,
+						pendingStateStart: undefined,
+					}));
 					this.emit('sessionStateChanged', session);
 				}
 			})
-			.catch((error: unknown) => {
+			.catch(async (error: unknown) => {
 				if (abortController.signal.aborted) {
 					logger.debug(
 						`[${session.id}] Auto-approval verification aborted (${(error as Error)?.message ?? 'aborted'})`,
@@ -171,20 +186,29 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					error,
 				);
 
-				if (session.state === 'pending_auto_approval') {
-					session.state = 'waiting_input';
-					session.autoApprovalFailed = true;
-					session.autoApprovalReason =
-						(error as Error | undefined)?.message ??
-						'Auto-approval verification failed';
-					session.pendingState = undefined;
-					session.pendingStateStart = undefined;
+				const currentState = session.stateMutex.getSnapshot().state;
+				if (currentState === 'pending_auto_approval') {
+					await session.stateMutex.update(data => ({
+						...data,
+						state: 'waiting_input',
+						autoApprovalFailed: true,
+						autoApprovalReason:
+							(error as Error | undefined)?.message ??
+							'Auto-approval verification failed',
+						pendingState: undefined,
+						pendingStateStart: undefined,
+					}));
 					this.emit('sessionStateChanged', session);
 				}
 			})
-			.finally(() => {
-				if (session.autoApprovalAbortController === abortController) {
-					session.autoApprovalAbortController = undefined;
+			.finally(async () => {
+				const currentController =
+					session.stateMutex.getSnapshot().autoApprovalAbortController;
+				if (currentController === abortController) {
+					await session.stateMutex.update(data => ({
+						...data,
+						autoApprovalAbortController: undefined,
+					}));
 				}
 			});
 	}
@@ -193,7 +217,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		session: Session,
 		reason: string,
 	): void {
-		const controller = session.autoApprovalAbortController;
+		const stateData = session.stateMutex.getSnapshot();
+		const controller = stateData.autoApprovalAbortController;
 		if (!controller) {
 			return;
 		}
@@ -202,7 +227,10 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			controller.abort();
 		}
 
-		session.autoApprovalAbortController = undefined;
+		void session.stateMutex.update(data => ({
+			...data,
+			autoApprovalAbortController: undefined,
+		}));
 		logger.info(
 			`[${session.id}] Cancelled auto-approval verification: ${reason}`,
 		);
@@ -247,7 +275,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			id,
 			worktreePath,
 			process: ptyProcess,
-			state: 'busy', // Session starts as busy when created
 			output: [],
 			outputHistory: [],
 			lastActivity: new Date(),
@@ -258,11 +285,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			commandConfig,
 			detectionStrategy: options.detectionStrategy ?? 'claude',
 			devcontainerConfig: options.devcontainerConfig ?? undefined,
-			pendingState: undefined,
-			pendingStateStart: undefined,
-			autoApprovalFailed: false,
-			autoApprovalReason: undefined,
-			autoApprovalAbortController: undefined,
+			stateMutex: new Mutex(createInitialSessionStateData()),
 		};
 
 		// Set up persistent background data handler for state detection
@@ -473,47 +496,58 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 
 		// Set up interval-based state detection with persistence
 		session.stateCheckInterval = setInterval(() => {
-			const oldState = session.state;
+			const stateData = session.stateMutex.getSnapshot();
+			const oldState = stateData.state;
 			const detectedState = this.detectTerminalState(session);
 			const now = Date.now();
 
 			// If detected state is different from current state
 			if (detectedState !== oldState) {
 				// If this is a new pending state or the pending state changed
-				if (session.pendingState !== detectedState) {
-					session.pendingState = detectedState;
-					session.pendingStateStart = now;
+				if (stateData.pendingState !== detectedState) {
+					void session.stateMutex.update(data => ({
+						...data,
+						pendingState: detectedState,
+						pendingStateStart: now,
+					}));
 				} else if (
-					session.pendingState !== undefined &&
-					session.pendingStateStart !== undefined
+					stateData.pendingState !== undefined &&
+					stateData.pendingStateStart !== undefined
 				) {
 					// Check if the pending state has persisted long enough
-					const duration = now - session.pendingStateStart;
+					const duration = now - stateData.pendingStateStart;
 					if (duration >= STATE_PERSISTENCE_DURATION_MS) {
 						// Confirm the state change
-						session.state = detectedState;
-						session.pendingState = undefined;
-						session.pendingStateStart = undefined;
+						void session.stateMutex.update(data => {
+							const newData = {
+								...data,
+								state: detectedState,
+								pendingState: undefined,
+								pendingStateStart: undefined,
+							};
+
+							// If we previously blocked auto-approval and have moved out of a user prompt,
+							// allow future auto-approval attempts.
+							if (
+								data.autoApprovalFailed &&
+								detectedState !== 'waiting_input' &&
+								detectedState !== 'pending_auto_approval'
+							) {
+								newData.autoApprovalFailed = false;
+								newData.autoApprovalReason = undefined;
+							}
+
+							return newData;
+						});
 
 						if (
-							session.autoApprovalAbortController &&
+							stateData.autoApprovalAbortController &&
 							detectedState !== 'pending_auto_approval'
 						) {
 							this.cancelAutoApprovalVerification(
 								session,
 								`state changed to ${detectedState}`,
 							);
-						}
-
-						// If we previously blocked auto-approval and have moved out of a user prompt,
-						// allow future auto-approval attempts.
-						if (
-							session.autoApprovalFailed &&
-							detectedState !== 'waiting_input' &&
-							detectedState !== 'pending_auto_approval'
-						) {
-							session.autoApprovalFailed = false;
-							session.autoApprovalReason = undefined;
 						}
 
 						// Execute status hook asynchronously (non-blocking) using Effect
@@ -525,16 +559,20 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				}
 			} else {
 				// Detected state matches current state, clear any pending state
-				session.pendingState = undefined;
-				session.pendingStateStart = undefined;
+				void session.stateMutex.update(data => ({
+					...data,
+					pendingState: undefined,
+					pendingStateStart: undefined,
+				}));
 			}
 
 			// Handle auto-approval if state is pending_auto_approval and no verification is in progress.
 			// This ensures auto-approval is retried when the state remains pending_auto_approval
 			// but the previous verification completed (success, failure, timeout, or abort).
+			const currentStateData = session.stateMutex.getSnapshot();
 			if (
-				session.state === 'pending_auto_approval' &&
-				!session.autoApprovalAbortController
+				currentStateData.state === 'pending_auto_approval' &&
+				!currentStateData.autoApprovalAbortController
 			) {
 				this.handleAutoApproval(session);
 			}
@@ -545,7 +583,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	}
 
 	private cleanupSession(session: Session): void {
-		if (session.autoApprovalAbortController) {
+		const stateData = session.stateMutex.getSnapshot();
+		if (stateData.autoApprovalAbortController) {
 			this.cancelAutoApprovalVerification(session, 'Session cleanup');
 		}
 
@@ -554,11 +593,13 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			clearInterval(session.stateCheckInterval);
 			session.stateCheckInterval = undefined;
 		}
-		// Clear any pending state
-		session.pendingState = undefined;
-		session.pendingStateStart = undefined;
-		// Update state to idle before destroying
-		session.state = 'idle';
+		// Clear any pending state and update state to idle before destroying
+		void session.stateMutex.update(data => ({
+			...data,
+			state: 'idle',
+			pendingState: undefined,
+			pendingStateStart: undefined,
+		}));
 		this.emit('sessionStateChanged', session);
 		this.destroySession(session.worktreePath);
 		this.emit('sessionExit', session);
@@ -594,21 +635,32 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			return;
 		}
 
+		const stateData = session.stateMutex.getSnapshot();
 		if (
-			session.state !== 'pending_auto_approval' &&
-			!session.autoApprovalAbortController
+			stateData.state !== 'pending_auto_approval' &&
+			!stateData.autoApprovalAbortController
 		) {
 			return;
 		}
 
 		this.cancelAutoApprovalVerification(session, reason);
-		session.autoApprovalFailed = true;
-		session.autoApprovalReason = reason;
-		session.pendingState = undefined;
-		session.pendingStateStart = undefined;
+		void session.stateMutex.update(data => {
+			const newData = {
+				...data,
+				autoApprovalFailed: true,
+				autoApprovalReason: reason,
+				pendingState: undefined,
+				pendingStateStart: undefined,
+			};
 
-		if (session.state === 'pending_auto_approval') {
-			session.state = 'waiting_input';
+			if (data.state === 'pending_auto_approval') {
+				newData.state = 'waiting_input';
+			}
+
+			return newData;
+		});
+
+		if (stateData.state === 'pending_auto_approval') {
 			this.emit('sessionStateChanged', session);
 		}
 	}
@@ -616,7 +668,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	destroySession(worktreePath: string): void {
 		const session = this.sessions.get(worktreePath);
 		if (session) {
-			if (session.autoApprovalAbortController) {
+			const stateData = session.stateMutex.getSnapshot();
+			if (stateData.autoApprovalAbortController) {
 				this.cancelAutoApprovalVerification(session, 'Session destroyed');
 			}
 
@@ -835,7 +888,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		};
 
 		sessions.forEach(session => {
-			switch (session.state) {
+			const stateData = session.stateMutex.getSnapshot();
+			switch (stateData.state) {
 				case 'idle':
 					counts.idle++;
 					break;

--- a/src/utils/hookExecutor.test.ts
+++ b/src/utils/hookExecutor.test.ts
@@ -8,10 +8,11 @@ import {
 import {mkdtemp, rm, readFile, realpath} from 'fs/promises';
 import {tmpdir} from 'os';
 import {join} from 'path';
-import type {SessionState, Session} from '../types/index.js';
+import type {Session} from '../types/index.js';
 import {configurationManager} from '../services/configurationManager.js';
 import {WorktreeService} from '../services/worktreeService.js';
 import {GitError} from '../types/errors.js';
+import {Mutex, createInitialSessionStateData} from './mutex.js';
 
 // Mock the configurationManager
 vi.mock('../services/configurationManager.js', () => ({
@@ -340,25 +341,22 @@ describe('hookExecutor Integration Tests', () => {
 			const tmpDir = await mkdtemp(join(tmpdir(), 'status-hook-test-'));
 			const outputFile = join(tmpDir, 'status-hook-output.txt');
 
-			const mockSession = {
+			const mockSession: Session = {
 				id: 'test-session-123',
 				worktreePath: tmpDir, // Use tmpDir as the worktree path
 				process: {} as unknown as Session['process'],
 				terminal: {} as unknown as Session['terminal'],
 				output: [],
 				outputHistory: [],
-				state: 'idle' as SessionState,
 				stateCheckInterval: undefined,
 				isPrimaryCommand: true,
 				commandConfig: undefined,
 				detectionStrategy: 'claude',
 				devcontainerConfig: undefined,
-				pendingState: undefined,
-				pendingStateStart: undefined,
 				lastActivity: new Date(),
 				isActive: true,
-				autoApprovalFailed: false,
-			} satisfies Session;
+				stateMutex: new Mutex(createInitialSessionStateData()),
+			};
 
 			// Mock WorktreeService to return a worktree with the tmpDir path
 			vi.mocked(WorktreeService).mockImplementation(
@@ -405,25 +403,22 @@ describe('hookExecutor Integration Tests', () => {
 			// Arrange
 			const tmpDir = await mkdtemp(join(tmpdir(), 'status-hook-test-'));
 
-			const mockSession = {
+			const mockSession: Session = {
 				id: 'test-session-456',
 				worktreePath: tmpDir, // Use tmpDir as the worktree path
 				process: {} as unknown as Session['process'],
 				terminal: {} as unknown as Session['terminal'],
 				output: [],
 				outputHistory: [],
-				state: 'idle' as SessionState,
 				stateCheckInterval: undefined,
 				isPrimaryCommand: true,
 				commandConfig: undefined,
 				detectionStrategy: 'claude',
 				devcontainerConfig: undefined,
-				pendingState: undefined,
-				pendingStateStart: undefined,
 				lastActivity: new Date(),
 				isActive: true,
-				autoApprovalFailed: false,
-			} satisfies Session;
+				stateMutex: new Mutex(createInitialSessionStateData()),
+			};
 
 			// Mock WorktreeService to return a worktree with the tmpDir path
 			vi.mocked(WorktreeService).mockImplementation(
@@ -469,25 +464,22 @@ describe('hookExecutor Integration Tests', () => {
 			const tmpDir = await mkdtemp(join(tmpdir(), 'status-hook-test-'));
 			const outputFile = join(tmpDir, 'should-not-exist.txt');
 
-			const mockSession = {
+			const mockSession: Session = {
 				id: 'test-session-789',
 				worktreePath: tmpDir, // Use tmpDir as the worktree path
 				process: {} as unknown as Session['process'],
 				terminal: {} as unknown as Session['terminal'],
 				output: [],
 				outputHistory: [],
-				state: 'idle' as SessionState,
 				stateCheckInterval: undefined,
 				isPrimaryCommand: true,
 				commandConfig: undefined,
 				detectionStrategy: 'claude',
 				devcontainerConfig: undefined,
-				pendingState: undefined,
-				pendingStateStart: undefined,
 				lastActivity: new Date(),
 				isActive: true,
-				autoApprovalFailed: false,
-			} satisfies Session;
+				stateMutex: new Mutex(createInitialSessionStateData()),
+			};
 
 			// Mock WorktreeService to return a worktree with the tmpDir path
 			vi.mocked(WorktreeService).mockImplementation(
@@ -534,25 +526,22 @@ describe('hookExecutor Integration Tests', () => {
 			const tmpDir = await mkdtemp(join(tmpdir(), 'status-hook-test-'));
 			const outputFile = join(tmpDir, 'hook-output.txt');
 
-			const mockSession = {
+			const mockSession: Session = {
 				id: 'test-session-failure',
 				worktreePath: tmpDir,
 				process: {} as unknown as Session['process'],
 				terminal: {} as unknown as Session['terminal'],
 				output: [],
 				outputHistory: [],
-				state: 'idle' as SessionState,
 				stateCheckInterval: undefined,
 				isPrimaryCommand: true,
 				commandConfig: undefined,
 				detectionStrategy: 'claude',
 				devcontainerConfig: undefined,
-				pendingState: undefined,
-				pendingStateStart: undefined,
 				lastActivity: new Date(),
 				isActive: true,
-				autoApprovalFailed: false,
-			} satisfies Session;
+				stateMutex: new Mutex(createInitialSessionStateData()),
+			};
 
 			// Mock WorktreeService to fail with GitError
 			vi.mocked(WorktreeService).mockImplementation(

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -1,0 +1,106 @@
+/**
+ * A simple mutex implementation for protecting shared state.
+ * Provides exclusive access to wrapped data through async locking.
+ */
+export class Mutex<T> {
+	private data: T;
+	private locked = false;
+	private waitQueue: Array<() => void> = [];
+
+	constructor(initialData: T) {
+		this.data = initialData;
+	}
+
+	/**
+	 * Acquire the lock. Returns a promise that resolves when the lock is acquired.
+	 */
+	private async acquire(): Promise<void> {
+		if (!this.locked) {
+			this.locked = true;
+			return;
+		}
+
+		return new Promise<void>(resolve => {
+			this.waitQueue.push(resolve);
+		});
+	}
+
+	/**
+	 * Release the lock, allowing the next waiter to proceed.
+	 */
+	private release(): void {
+		const next = this.waitQueue.shift();
+		if (next) {
+			next();
+		} else {
+			this.locked = false;
+		}
+	}
+
+	/**
+	 * Run a function with exclusive access to the protected data.
+	 * The lock is acquired before the function runs and released after it completes.
+	 *
+	 * @param fn - Function that receives the current data and returns updated data or a promise of updated data
+	 * @returns Promise that resolves with the function's return value
+	 */
+	async runExclusive<R>(fn: (data: T) => R | Promise<R>): Promise<R> {
+		await this.acquire();
+		try {
+			const result = await fn(this.data);
+			return result;
+		} finally {
+			this.release();
+		}
+	}
+
+	/**
+	 * Run a function with exclusive access and update the protected data.
+	 * The lock is acquired before the function runs and released after it completes.
+	 *
+	 * @param fn - Function that receives the current data and returns the updated data
+	 */
+	async update(fn: (data: T) => T | Promise<T>): Promise<void> {
+		await this.acquire();
+		try {
+			this.data = await fn(this.data);
+		} finally {
+			this.release();
+		}
+	}
+
+	/**
+	 * Get a snapshot of the current data without acquiring the lock.
+	 * Use with caution - this does not guarantee consistency.
+	 * Prefer runExclusive for reads that need to be consistent with writes.
+	 */
+	getSnapshot(): T {
+		return this.data;
+	}
+}
+
+/**
+ * Interface for the session state data protected by mutex.
+ */
+export interface SessionStateData {
+	state: import('../types/index.js').SessionState;
+	pendingState: import('../types/index.js').SessionState | undefined;
+	pendingStateStart: number | undefined;
+	autoApprovalFailed: boolean;
+	autoApprovalReason: string | undefined;
+	autoApprovalAbortController: AbortController | undefined;
+}
+
+/**
+ * Create initial session state data with default values.
+ */
+export function createInitialSessionStateData(): SessionStateData {
+	return {
+		state: 'busy',
+		pendingState: undefined,
+		pendingStateStart: undefined,
+		autoApprovalFailed: false,
+		autoApprovalReason: undefined,
+		autoApprovalAbortController: undefined,
+	};
+}

--- a/src/utils/worktreeUtils.test.ts
+++ b/src/utils/worktreeUtils.test.ts
@@ -9,6 +9,7 @@ import {
 } from './worktreeUtils.js';
 import {Worktree, Session} from '../types/index.js';
 import {execSync} from 'child_process';
+import {Mutex, createInitialSessionStateData} from './mutex.js';
 
 // Mock child_process module
 vi.mock('child_process');
@@ -232,7 +233,6 @@ describe('prepareWorktreeItems', () => {
 	const mockSession: Session = {
 		id: 'test-session',
 		worktreePath: '/path/to/worktree',
-		state: 'idle',
 		process: {} as Session['process'],
 		output: [],
 		outputHistory: [],
@@ -244,9 +244,10 @@ describe('prepareWorktreeItems', () => {
 		commandConfig: undefined,
 		detectionStrategy: 'claude',
 		devcontainerConfig: undefined,
-		pendingState: undefined,
-		pendingStateStart: undefined,
-		autoApprovalFailed: false,
+		stateMutex: new Mutex({
+			...createInitialSessionStateData(),
+			state: 'idle',
+		}),
 	};
 
 	it('should prepare basic worktree without git status', () => {

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -117,7 +117,9 @@ export function prepareWorktreeItems(
 ): WorktreeItem[] {
 	return worktrees.map(wt => {
 		const session = sessions.find(s => s.worktreePath === wt.path);
-		const status = session ? ` [${getStatusDisplay(session.state)}]` : '';
+		const status = session
+			? ` [${getStatusDisplay(session.stateMutex.getSnapshot().state)}]`
+			: '';
 		const fullBranchName = wt.branch
 			? wt.branch.replace('refs/heads/', '')
 			: 'detached';


### PR DESCRIPTION
Wrap session state-related keys (state, pendingState, pendingStateStart,
autoApprovalFailed, autoApprovalReason, autoApprovalAbortController) with
a Mutex to ensure thread-safe concurrent access.

- Create Mutex utility class with runExclusive, update, and getSnapshot methods
- Update Session interface to use stateMutex instead of individual state keys
- Update sessionManager.ts to use mutex for all state key operations
- Update UI components to use getSnapshot() for state reads
- Fix tests to use async timer methods for proper mutex update handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
