### PR TITLE
chore: add @kodaikabasawa scope to platform package names

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ccmanager-darwin-arm64",
+	"name": "@kodaikabasawa/ccmanager-darwin-arm64",
 	"version": "3.1.5",
 	"description": "ccmanager binary for macOS ARM64 (Apple Silicon)",
 	"license": "MIT",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ccmanager-darwin-x64",
+	"name": "@kodaikabasawa/ccmanager-darwin-x64",
 	"version": "3.1.5",
 	"description": "ccmanager binary for macOS x64 (Intel)",
 	"license": "MIT",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ccmanager-linux-arm64",
+	"name": "@kodaikabasawa/ccmanager-linux-arm64",
 	"version": "3.1.5",
 	"description": "ccmanager binary for Linux ARM64",
 	"license": "MIT",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ccmanager-linux-x64",
+	"name": "@kodaikabasawa/ccmanager-linux-x64",
 	"version": "3.1.5",
 	"description": "ccmanager binary for Linux x64",
 	"license": "MIT",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ccmanager-win32-x64",
+	"name": "@kodaikabasawa/ccmanager-win32-x64",
 	"version": "3.1.5",
 	"description": "ccmanager binary for Windows x64",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
 		"bin"
 	],
 	"optionalDependencies": {
-		"ccmanager-darwin-arm64": "3.1.5",
-		"ccmanager-darwin-x64": "3.1.5",
-		"ccmanager-linux-arm64": "3.1.5",
-		"ccmanager-linux-x64": "3.1.5",
-		"ccmanager-win32-x64": "3.1.5"
+		"@kodaikabasawa/ccmanager-darwin-arm64": "3.1.5",
+		"@kodaikabasawa/ccmanager-darwin-x64": "3.1.5",
+		"@kodaikabasawa/ccmanager-linux-arm64": "3.1.5",
+		"@kodaikabasawa/ccmanager-linux-x64": "3.1.5",
+		"@kodaikabasawa/ccmanager-win32-x64": "3.1.5"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.28.0",

--- a/scripts/publish-packages.ts
+++ b/scripts/publish-packages.ts
@@ -38,7 +38,7 @@ async function publishPlatformPackage(platform: string, dryRun: boolean) {
 		return false;
 	}
 
-	console.log(`Publishing ccmanager-${platform}...`);
+	console.log(`Publishing @kodaikabasawa/ccmanager-${platform}...`);
 
 	try {
 		if (dryRun) {


### PR DESCRIPTION
## Summary
- Add `@kodaikabasawa` npm scope prefix to all platform-specific binary packages
- Update `optionalDependencies` in main `package.json` to reference scoped packages
- Update publish script console output to reflect new package names

## Test plan
- [ ] Verify `npm publish --dry-run` works for platform packages
- [ ] Verify `npm install` resolves scoped optional dependencies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)