### PR TITLE
fix: inject version at build time for compiled binary

### DIFF
--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -10,6 +10,10 @@ const ROOT_DIR = join(__dirname, "..");
 const NPM_DIR = join(ROOT_DIR, "npm");
 const ENTRY_POINT = join(ROOT_DIR, "src", "cli.tsx");
 
+// Read version from package.json
+const PACKAGE_JSON = JSON.parse(readFileSync(join(ROOT_DIR, "package.json"), "utf-8"));
+const VERSION = PACKAGE_JSON.version;
+
 // Map of npm platform names to Bun target names
 const TARGETS = [
 	{
@@ -48,7 +52,7 @@ async function buildBinary(target: (typeof TARGETS)[number]) {
 	mkdirSync(outputDir, { recursive: true });
 
 	try {
-		await $`bun build ${ENTRY_POINT} --compile --target=${target.bunTarget} --outfile=${outputPath}`;
+		await $`bun build ${ENTRY_POINT} --compile --target=${target.bunTarget} --outfile=${outputPath} --define CCMANAGER_VERSION='"${VERSION}"'`;
 		console.log(`  -> Created ${outputPath}`);
 		return true;
 	} catch (error) {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -6,6 +6,11 @@ import App from './components/App.js';
 import {worktreeConfigManager} from './services/worktreeConfigManager.js';
 import {globalSessionOrchestrator} from './services/globalSessionOrchestrator.js';
 
+// Version is injected at build time via --define flag
+declare const CCMANAGER_VERSION: string;
+const version =
+	typeof CCMANAGER_VERSION !== 'undefined' ? CCMANAGER_VERSION : 'dev';
+
 const cli = meow(
 	`
 	Usage
@@ -25,6 +30,7 @@ const cli = meow(
 `,
 	{
 		importMeta: import.meta,
+		version: version,
 		flags: {
 			multiProject: {
 				type: 'boolean',


### PR DESCRIPTION
## Summary
- Fix `ccmanager --version` outputting nothing after switching to cross-compiled binary distribution
- Inject `CCMANAGER_VERSION` constant at build time via `--define` flag in bun build
- Use injected version in meow CLI parser instead of relying on package.json lookup

## Test plan
- [x] Run `bun run build:binary`
- [x] Execute compiled binary with `--version` flag
- [x] Verify correct version `3.2.2` is output

🤖 Generated with [Claude Code](https://claude.com/claude-code)