### PR TITLE
docs: rename Auto Verification to Auto Approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ https://github.com/user-attachments/assets/15914a88-e288-4ac9-94d5-8127f2e19dbf
 - Configurable state detection strategies for different CLI tools
 - Status change hooks for automation and notifications
 - Devcontainer integration
+- **Auto Approval (experimental)**: Automatically approve safe prompts using AI verification
 
 ## Why CCManager over Claude Squad?
 
@@ -248,6 +249,25 @@ CCManager can automatically generate worktree directory paths based on branch na
 - **Smart sanitization**: Branch names are automatically made filesystem-safe
 
 For detailed configuration and examples, see [docs/worktree-auto-directory.md](docs/worktree-auto-directory.md).
+
+## Auto Approval (Experimental)
+
+CCManager can automatically approve Claude Code prompts that don't require user permission, reducing manual intervention while maintaining safety for sensitive operations.
+
+### Features
+
+- **Automatic decision**: Uses Claude (Haiku) to analyze prompts and determine if they need manual approval
+- **Custom commands**: Replace the default verifier with your own script or different AI model
+- **Safe fallback**: Always defaults to manual approval on errors or timeouts
+- **Interruptible**: Press any key to cancel auto-approval and review manually
+
+### Quick Start
+
+1. Navigate to **Configuration** → **Other & Experimental**
+2. Enable **Auto Approval (experimental)**
+3. (Optional) Configure a custom command for verification
+
+For detailed configuration and usage, see [docs/auto-approval.md](docs/auto-approval.md).
 
 ## Devcontainer Integration
 

--- a/docs/auto-approval.md
+++ b/docs/auto-approval.md
@@ -1,7 +1,7 @@
-# Auto Verification (Experimental)
+# Auto Approval (Experimental)
 
 ## Overview
-- Auto verification lets CCManager decide whether a paused Claude Code session can continue without you typing Enter.
+- Auto approval lets CCManager decide whether a paused Claude Code session can continue without you typing Enter.
 - When enabled, CCManager checks a waiting prompt and either auto-approves it or leaves it for your manual review.
 - The feature is experimental—expect occasional false positives/negatives and keep an eye on prompts that matter.
 - Default expectation: CCManager assumes the `claude` CLI is already installed and on your PATH; it is **not** bundled. If you don’t have `claude`, either install it or set a custom command.
@@ -10,7 +10,7 @@
 1. Run `ccmanager`.
 2. Open **Configuration** → **Other & Experimental**.
 3. Choose **Auto Approval (experimental)** to toggle it to ✅ Enabled.
-4. (Optional) Pick **Edit Custom Command** to supply your own verifier command (see “Custom Command” below).
+4. (Optional) Pick **Edit Custom Command** to supply your own approver command (see "Custom Command" below).
 5. Select **Save Changes**.
 
 ## Enabling It (config file)
@@ -41,7 +41,7 @@ Leave `"enabled": false` to turn it off. You can also add `"customCommand": "my-
   - Keep it lightweight; long-running analysis will delay your prompt.
   - You can wrap other models/tools as long as you emit the JSON schema above.
   - Log to stderr if you need debugging—stderr is ignored except for debug logging.
-- Example (Codex): combine the source-tree schema [`auto-approval.schema.json`](./auto-approval.schema.json) with Codex to perform the verification instead of Claude. The schema ships in the repo but is **not bundled** into installed binaries—use your local copy or download it first:
+- Example (Codex): combine the source-tree schema [`auto-approval.schema.json`](./auto-approval.schema.json) with Codex to perform the approval check instead of Claude. The schema ships in the repo but is **not bundled** into installed binaries—use your local copy or download it first:
   ```bash
   codex exec --json "$DEFAULT_PROMPT" \
     --output-schema <path to json>/auto-approval.schema.json \
@@ -52,8 +52,8 @@ Leave `"enabled": false` to turn it off. You can also add `"customCommand": "my-
 
 ## How It Works
 - **When it runs:** If a session enters a prompt state that normally waits for your input, CCManager marks it as “Auto-approval pending…” and grabs the most recent terminal output (up to 300 lines).
-- **Verification step:** By default CCManager runs `claude --model haiku -p --output-format json --json-schema …`, passing the captured terminal output into the prompt so Claude can judge whether the action needs your permission.
-- **Decision:** If Claude replies that permission is not needed and the session is still waiting, CCManager sends a carriage return (`\r`) to the session—equivalent to pressing Enter for you. If Claude says permission is needed, the check times out (60s), errors, or you press any key while it’s pending, auto verification stops and the session stays in manual approval with a short reason displayed.
+- **Approval step:** By default CCManager runs `claude --model haiku -p --output-format json --json-schema …`, passing the captured terminal output into the prompt so Claude can judge whether the action needs your permission.
+- **Decision:** If Claude replies that permission is not needed and the session is still waiting, CCManager sends a carriage return (`\r`) to the session—equivalent to pressing Enter for you. If Claude says permission is needed, the check times out (60s), errors, or you press any key while it’s pending, auto approval stops and the session stays in manual approval with a short reason displayed.
 - **Safety:** When the helper fails for any reason, CCManager defaults to requiring your approval instead of proceeding automatically.
 
 ## Things to Keep in Mind


### PR DESCRIPTION
## Summary

- Rename `docs/auto-verification.md` to `docs/auto-approval.md` for consistent feature naming
- Update all references from "verification" to "approval" terminology in the documentation
- Add Auto Approval section to README.md with features overview and quick start guide

## Test plan

- [ ] Verify documentation links work correctly
- [ ] Review README section for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)