### PR TITLE
fix: detect running agents as busy instead of idle

### DIFF
--- a/src/services/stateDetector.ts
+++ b/src/services/stateDetector.ts
@@ -83,8 +83,14 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			return 'waiting_input';
 		}
 
-		// Check for busy state
+		// Check for busy state - standard processing indicator
 		if (lowerContent.includes('esc to interrupt')) {
+			return 'busy';
+		}
+
+		// Check for running agents/subprocesses (Task tool, Explore, Plan, etc.)
+		// These show "ctrl+b to run in background" while actively running
+		if (lowerContent.includes('ctrl+b to run in background')) {
 			return 'busy';
 		}
 


### PR DESCRIPTION
## Summary
- **ClaudeStateDetector**: Add detection for running agents/subprocesses (Task, Explore, Plan, etc.) by recognizing "ctrl+b to run in background" as a busy state indicator
- Previously, running agents were incorrectly detected as `idle` because they display "ctrl+b to run in background" instead of "esc to interrupt"

## Test plan
- [x] All existing tests pass (998 tests)
- [x] New tests added for Explore agent detection
- [x] New tests added for Task agent detection
- [x] Case insensitivity test added
- [x] Priority test verifies waiting_input takes precedence over agent busy state

🤖 Generated with [Claude Code](https://claude.com/claude-code)