### PR TITLE
fix: pass projectPath to WorktreeService in multi-project mode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -631,6 +631,7 @@ const App: React.FC<AppProps> = ({devcontainerConfig, multiProject}) => {
 					</Box>
 				)}
 				<DeleteWorktree
+					projectPath={selectedProject?.path}
 					onComplete={handleDeleteWorktrees}
 					onCancel={handleCancelDeleteWorktree}
 				/>

--- a/src/components/DeleteWorktree.test.tsx
+++ b/src/components/DeleteWorktree.test.tsx
@@ -53,6 +53,75 @@ describe('DeleteWorktree - Effect Integration', () => {
 		vi.clearAllMocks();
 	});
 
+	it('should pass projectPath to WorktreeService when provided', async () => {
+		// GIVEN: projectPath is provided
+		const projectPath = '/test/project';
+		const mockWorktrees: Worktree[] = [
+			{
+				path: '/test/project/wt1',
+				branch: 'feature-1',
+				isMainWorktree: false,
+				hasSession: false,
+			},
+		];
+
+		const mockEffect = Effect.succeed(mockWorktrees);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: vi.fn(() => mockEffect),
+			} as Partial<WorktreeService> as WorktreeService;
+		});
+
+		const onComplete = vi.fn();
+		const onCancel = vi.fn();
+
+		// WHEN: Component renders with projectPath
+		render(
+			<DeleteWorktree
+				projectPath={projectPath}
+				onComplete={onComplete}
+				onCancel={onCancel}
+			/>,
+		);
+
+		// Wait for Effect to execute
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		// THEN: WorktreeService was called with projectPath
+		expect(WorktreeService).toHaveBeenCalledWith(projectPath);
+	});
+
+	it('should use undefined when projectPath not provided', async () => {
+		// GIVEN: No projectPath
+		const mockWorktrees: Worktree[] = [
+			{
+				path: '/test/wt1',
+				branch: 'feature-1',
+				isMainWorktree: false,
+				hasSession: false,
+			},
+		];
+
+		const mockEffect = Effect.succeed(mockWorktrees);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: vi.fn(() => mockEffect),
+			} as Partial<WorktreeService> as WorktreeService;
+		});
+
+		const onComplete = vi.fn();
+		const onCancel = vi.fn();
+
+		// WHEN: Component renders without projectPath
+		render(<DeleteWorktree onComplete={onComplete} onCancel={onCancel} />);
+
+		// Wait for Effect to execute
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		// THEN: WorktreeService was called with undefined (defaults to cwd)
+		expect(WorktreeService).toHaveBeenCalledWith(undefined);
+	});
+
 	it('should load worktrees using Effect-based method', async () => {
 		// GIVEN: Mock worktrees returned by Effect
 		const mockWorktrees: Worktree[] = [

--- a/src/components/DeleteWorktree.tsx
+++ b/src/components/DeleteWorktree.tsx
@@ -8,11 +8,13 @@ import DeleteConfirmation from './DeleteConfirmation.js';
 import {shortcutManager} from '../services/shortcutManager.js';
 
 interface DeleteWorktreeProps {
+	projectPath?: string;
 	onComplete: (worktreePaths: string[], deleteBranch: boolean) => void;
 	onCancel: () => void;
 }
 
 const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
+	projectPath,
 	onComplete,
 	onCancel,
 }) => {
@@ -29,7 +31,7 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 		let cancelled = false;
 
 		const loadWorktrees = async () => {
-			const worktreeService = new WorktreeService();
+			const worktreeService = new WorktreeService(projectPath);
 
 			try {
 				const allWorktrees = await Effect.runPromise(
@@ -57,7 +59,7 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 		return () => {
 			cancelled = true;
 		};
-	}, []);
+	}, [projectPath]);
 
 	// Create menu items from worktrees
 	const menuItems = worktrees.map((worktree, index) => {

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -65,7 +65,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	// Initialize worktree service and load branches using Effect
 	useEffect(() => {
 		let cancelled = false;
-		const service = new WorktreeService();
+		const service = new WorktreeService(projectPath);
 
 		const loadBranches = async () => {
 			// Use Effect.all to load branches and defaultBranch in parallel
@@ -110,7 +110,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 		return () => {
 			cancelled = true;
 		};
-	}, []);
+	}, [projectPath]);
 
 	// Create branch items with default branch first (memoized)
 	const allBranchItems: BranchItem[] = useMemo(


### PR DESCRIPTION
## Problem

In multi-project mode, `DeleteWorktree` and `NewWorktree` components created `WorktreeService()` without passing the selected project's path. This caused git commands to run in `process.cwd()` instead of the selected project directory.

**Symptom:** "fatal: not a git repository" errors when trying to delete worktrees or create new worktrees in multi-project mode.

## Solution

Pass `projectPath` to `WorktreeService` constructor in both components, following the existing pattern used elsewhere in the codebase.

## Changes

| File | Change |
|------|--------|
| `DeleteWorktree.tsx` | Add `projectPath` prop, pass to `WorktreeService` |
| `NewWorktree.tsx` | Use existing `projectPath` prop for branch loading |
| `App.tsx` | Pass `selectedProject?.path` to `DeleteWorktree` |
| `DeleteWorktree.test.tsx` | Add 2 tests for `projectPath` handling |

## Review Guide

1. **DeleteWorktree.tsx:11** - Added `projectPath?: string` to props interface
2. **DeleteWorktree.tsx:34** - Pass `projectPath` to `new WorktreeService(projectPath)`
3. **NewWorktree.tsx:68** - Same fix for branch loading
4. **App.tsx:634** - Parent passes `selectedProject?.path`

## Testing

- All 998 tests pass
- Manually verified: delete and create worktrees work in multi-project mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)