### PR TITLE
docs: fix environment variable name from `CCMANAGER_WORKTREE` to `CCMANAGER_WORKTREE_PATH`

### DIFF
--- a/docs/status-hooks.md
+++ b/docs/status-hooks.md
@@ -31,7 +31,7 @@ noti -t "Claude Code" -m "Claude is waiting for your input in $CCMANAGER_WORKTRE
 
 **Send to Slack (using webhook):**
 ```bash
-curl -X POST -H 'Content-type: application/json' --data '{"text":"Claude is now '"$CCMANAGER_NEW_STATE"' in '"$CCMANAGER_WORKTREE"'"}' YOUR_SLACK_WEBHOOK_URL
+curl -X POST -H 'Content-type: application/json' --data '{"text":"Claude is now '"$CCMANAGER_NEW_STATE"' in '"$CCMANAGER_WORKTREE_PATH"'"}' YOUR_SLACK_WEBHOOK_URL
 ```
 
 **Update tmux status:**
@@ -49,6 +49,6 @@ tmux set -g status-right "Claude: $CCMANAGER_NEW_STATE" && noti -t "Claude Statu
 
 - `CCMANAGER_OLD_STATE`: Previous state (idle, busy, waiting_input)
 - `CCMANAGER_NEW_STATE`: New state (idle, busy, waiting_input)
-- `CCMANAGER_WORKTREE`: Path to the worktree where status changed
+- `CCMANAGER_WORKTREE_PATH`: Path to the worktree where status changed
 - `CCMANAGER_WORKTREE_BRANCH`: Git branch name of the worktree
 - `CCMANAGER_SESSION_ID`: Unique session identifier

--- a/src/components/ConfigureStatusHooks.tsx
+++ b/src/components/ConfigureStatusHooks.tsx
@@ -170,7 +170,7 @@ const ConfigureStatusHooks: React.FC<ConfigureStatusHooksProps> = ({
 				</Box>
 				<Box>
 					<Text dimColor>
-						CCMANAGER_WORKTREE, CCMANAGER_WORKTREE_BRANCH, CCMANAGER_SESSION_ID
+						CCMANAGER_WORKTREE_PATH, CCMANAGER_WORKTREE_BRANCH, CCMANAGER_SESSION_ID
 					</Text>
 				</Box>
 

--- a/src/components/ConfigureWorktreeHooks.tsx
+++ b/src/components/ConfigureWorktreeHooks.tsx
@@ -142,7 +142,7 @@ const ConfigureWorktreeHooks: React.FC<ConfigureWorktreeHooksProps> = ({
 
 				<Box marginTop={1}>
 					<Text dimColor>
-						Environment variables available: CCMANAGER_WORKTREE,
+						Environment variables available: CCMANAGER_WORKTREE_PATH,
 						CCMANAGER_WORKTREE_BRANCH,
 					</Text>
 				</Box>


### PR DESCRIPTION
## Summary

Fix documentation and UI text to use the correct environment variable name `CCMANAGER_WORKTREE_PATH` instead of the incorrect `CCMANAGER_WORKTREE`.

## Problem

The documentation in `docs/status-hooks.md` and UI help text in hook configuration screens incorrectly referenced `CCMANAGER_WORKTREE` as an available environment variable. However, the actual implementation has always used `CCMANAGER_WORKTREE_PATH` since the feature was introduced.

This discrepancy caused confusion for users who tried to use `CCMANAGER_WORKTREE` in their hook commands, only to find it wasn't available.

## Root Cause

When the status hook feature was initially added (commit 2e0caf0, June 15, 2025), the commit message mentioned `CCMANAGER_WORKTREE`. However, when the worktree hook feature was added later (commit 644e57d, August 6, 2025), the `HookEnvironment` interface defined the variable as `CCMANAGER_WORKTREE_PATH`, which became the standard across all hook implementations.

The documentation was never updated to reflect the actual implementation.

## Changes

- **docs/status-hooks.md**: Updated environment variable name in Slack webhook example and Environment Variables Reference section
- **src/components/ConfigureStatusHooks.tsx**: Updated UI help text to show `CCMANAGER_WORKTREE_PATH`
- **src/components/ConfigureWorktreeHooks.tsx**: Updated UI help text to show `CCMANAGER_WORKTREE_PATH`

## Verification

- [x] Build passes (`npm run build`)
- [x] Linting passes (`npm run lint`)
- [x] All references to `CCMANAGER_WORKTREE` (without `_PATH` suffix) have been updated
- [x] Documentation now matches code implementation


