### PR TITLE
fix: detect busy state for web search with ctrl+c interrupt

### DIFF
--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -40,6 +40,20 @@ describe('ClaudeStateDetector', () => {
 			expect(state).toBe('busy');
 		});
 
+		it('should detect busy when "ctrl+c to interrupt" is present (web search)', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Googling. (ctrl+c to interrupt',
+				'Searching for relevant information...',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
 		it('should detect idle when no specific patterns are found', () => {
 			// Arrange
 			terminal = createMockTerminal([

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -25,7 +25,10 @@ export class ClaudeStateDetector extends BaseStateDetector {
 		}
 
 		// Check for busy state
-		if (lowerContent.includes('esc to interrupt')) {
+		if (
+			lowerContent.includes('esc to interrupt') ||
+			lowerContent.includes('ctrl+c to interrupt')
+		) {
 			return 'busy';
 		}
 


### PR DESCRIPTION
## TL;DR
Adds `ctrl+c to interrupt` pattern detection to recognize busy state during web searches.

## Problem
When Claude Code performs web searches, it displays `Googling. (ctrl+c to interrupt` - this wasn't detected as a busy state.

<img width="1156" height="735" alt="Screenshot 2026-01-11 at 9 32 43 AM" src="https://github.com/user-attachments/assets/26b514d8-0fee-443d-b98a-53fe49303270" />


## Solution
Extended `ClaudeStateDetector.detectState()` to also match `ctrl+c to interrupt` alongside the existing `esc to interrupt` pattern.

## Changes
- `src/services/stateDetector/claude.ts` - Added `ctrl+c to interrupt` condition
- `src/services/stateDetector/claude.test.ts` - Added test case for web search scenario

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)