### PR TITLE
feat: clear output history on screen clear escape sequence

### DIFF
--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -395,6 +395,12 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			// Write data to virtual terminal
 			session.terminal.write(data);
 
+			// Check for screen clear escape sequence (e.g., from /clear command)
+			// When detected, clear the output history to prevent replaying old content on restore
+			if (data.includes('\x1B[2J')) {
+				session.outputHistory = [];
+			}
+
 			// Store in output history as Buffer
 			const buffer = Buffer.from(data, 'utf8');
 			session.outputHistory.push(buffer);


### PR DESCRIPTION
## Summary
- Clear session output history when a screen clear escape sequence (`\x1B[2J`) is detected
- Prevents replaying large amounts of old content during session restoration
- Eliminates excessive scrolling when returning to a session after `/clear` command

## Test plan
- [ ] Start a session with significant output
- [ ] Run `/clear` in the session
- [ ] Return to menu and re-enter the session
- [ ] Verify that only content after `/clear` is displayed (no excessive scrolling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)