### PR TITLE
fix: disable automatic .env loading in Bun runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"build:binary:native": "bun run scripts/build-binaries.ts --target=native",
 		"build:binary:all": "bun run scripts/build-binaries.ts --target=all",
 		"dev": "bun run tsc --watch",
-		"start": "bun dist/cli.js",
+		"start": "bun --no-env-file dist/cli.js",
 		"test": "vitest --run",
 		"lint": "bun run eslint src",
 		"lint:fix": "bun run eslint src --fix",

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -52,7 +52,7 @@ async function buildBinary(target: (typeof TARGETS)[number]) {
 	mkdirSync(outputDir, { recursive: true });
 
 	try {
-		await $`bun build ${ENTRY_POINT} --compile --target=${target.bunTarget} --outfile=${outputPath} --define CCMANAGER_VERSION='"${VERSION}"'`;
+		await $`bun build ${ENTRY_POINT} --compile --target=${target.bunTarget} --outfile=${outputPath} --define CCMANAGER_VERSION='"${VERSION}"' --no-compile-autoload-dotenv --no-compile-autoload-bunfig`;
 		console.log(`  -> Created ${outputPath}`);
 		return true;
 	} catch (error) {


### PR DESCRIPTION
## Summary
- Add `--no-compile-autoload-dotenv` and `--no-compile-autoload-bunfig` flags to bun build command for compiled binaries
- Add `--no-env-file` flag to the `start` script for development mode
- Prevents unintended environment variables from being passed to child processes like Claude Code sessions

Fixes #177

## Test plan
- [x] All lint checks pass
- [x] All type checks pass
- [x] All 1066 tests pass (94 test files)
- [x] Binary build succeeds with the new flags
- [x] Manual verification: Create a `.env` file with test variables and confirm they are not loaded when running ccmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)