### PR TITLE
feat: auto-adjust menu item limit based on terminal height

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {Box, Text, useInput} from 'ink';
+import {Box, Text, useInput, useStdout} from 'ink';
 import SelectInput from 'ink-select-input';
 import {Effect} from 'effect';
 import {Worktree, Session, GitProject} from '../types/index.js';
@@ -95,16 +95,39 @@ const Menu: React.FC<MenuProps> = ({
 	const [sessions, setSessions] = useState<Session[]>([]);
 	const [items, setItems] = useState<MenuItem[]>([]);
 	const [recentProjects, setRecentProjects] = useState<RecentProject[]>([]);
-	const limit = 10;
+	const {stdout} = useStdout();
+	const fixedRows = 6;
+	const [terminalRows, setTerminalRows] = useState(stdout.rows);
 
-	// Get worktree configuration for sorting
-	const worktreeConfig = configReader.getWorktreeConfig();
+	// Update terminal rows on resize
+	useEffect(() => {
+		const handleResize = () => {
+			setTerminalRows(stdout.rows);
+		};
+
+		stdout.on('resize', handleResize);
+
+		return () => {
+			stdout.off('resize', handleResize);
+		};
+	}, [stdout]);
 
 	// Use the search mode hook
 	const {isSearchMode, searchQuery, selectedIndex, setSearchQuery} =
 		useSearchMode(items.length, {
 			isDisabled: !!error || !!loadError,
 		});
+
+	const limit = Math.max(
+		5,
+		terminalRows -
+			fixedRows -
+			(isSearchMode ? 1 : 0) -
+			(error || loadError ? 3 : 0),
+	);
+
+	// Get worktree configuration for sorting
+	const worktreeConfig = configReader.getWorktreeConfig();
 
 	useEffect(() => {
 		let cancelled = false;


### PR DESCRIPTION
## Summary
- Automatically calculate the optimal number of menu items to display without scrolling based on terminal height
- Dynamically adjust the limit when terminal is resized
- Account for fixed UI elements (header, footer, search bar, error displays)

## Changes
- Added `useStdout` hook to access terminal dimensions
- Added resize event listener to update terminal height dynamically  
- Calculate menu item limit dynamically with minimum 5 items
- Fixed elements accounted for: 6 rows (header/footer), 1 row (search mode), 3 rows (error display)

## Testing
- Build, lint, and typecheck all pass
- Manual testing with various terminal sizes