### PR TITLE
fix: add rerender to stabilize flaky test in CI

### DIFF
--- a/src/components/Menu.recent-projects.test.tsx
+++ b/src/components/Menu.recent-projects.test.tsx
@@ -164,7 +164,19 @@ describe('Menu - Recent Projects', () => {
 		});
 		vi.spyOn(SessionManager, 'formatSessionCounts').mockReturnValue('');
 
-		const {lastFrame} = render(
+		const {lastFrame, rerender} = render(
+			<Menu
+				sessionManager={mockSessionManager}
+				worktreeService={mockWorktreeService}
+				onSelectWorktree={vi.fn()}
+				onSelectRecentProject={vi.fn()}
+				multiProject={true}
+				version="test"
+			/>,
+		);
+
+		// Force a rerender to ensure all effects have run
+		rerender(
 			<Menu
 				sessionManager={mockSessionManager}
 				worktreeService={mockWorktreeService}


### PR DESCRIPTION
## Summary
- Fixed flaky test `should show recent projects in multi-project mode` that was failing intermittently in CI
- Added `rerender` call to ensure React state updates complete before assertions
- Matches the pattern used in other stable tests in the same file

## Test plan
- [x] All tests pass locally (1096 passed, 18 skipped)
- [x] Lint and typecheck pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)