### PR TITLE
fix: detect background tasks shown as "N local agents"

### DIFF
--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -491,6 +491,61 @@ describe('ClaudeStateDetector', () => {
 			expect(count).toBe(1);
 		});
 
+		it('should return count 3 when "3 local agents" is in status bar', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Some output',
+				'More output',
+				'bypass permissions on - 3 local agents',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(3);
+		});
+
+		it('should return count 1 when "1 local agent" is in status bar', () => {
+			// Arrange
+			terminal = createMockTerminal(['Some output', '1 local agent']);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(1);
+		});
+
+		it('should detect local agent count case-insensitively', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Output line 1',
+				'Output line 2',
+				'2 LOCAL AGENTS running',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(2);
+		});
+
+		it('should prioritize explicit count from "N local agents" over "(running)"', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Some output',
+				'3 local agents | task1 (running)',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(3);
+		});
+
 		it('should prioritize count from "N background task" over "(running)"', () => {
 			// Arrange - both patterns present, count should be from explicit pattern
 			terminal = createMockTerminal([

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -41,7 +41,9 @@ export class ClaudeStateDetector extends BaseStateDetector {
 		const content = lines.join('\n').toLowerCase();
 
 		// Check for "N background task(s)" pattern first (content already lowercased)
-		const countMatch = content.match(/(\d+)\s+background\s+task/);
+		const countMatch = content.match(
+			/(\d+)\s+(?:background\s+task|local\s+agent)/,
+		);
 		if (countMatch?.[1]) {
 			return parseInt(countMatch[1], 10);
 		}


### PR DESCRIPTION
## Summary
- Claude Code now shows background tasks as "N local agents" instead of "N background tasks" in the status bar
- Updated regex in `ClaudeStateDetector.detectBackgroundTask` to match both old and new formats
- Added 4 new tests covering the "local agents" pattern

<img width="921" height="667" alt="Screenshot 2026-01-29 at 5 13 23 PM" src="https://github.com/user-attachments/assets/0953c7fc-000e-472e-9957-0d0b46ef8191" />


## Test plan
- [x] All 35 stateDetector tests pass (`bun run test`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)