### PR TITLE
feat: add pre-creation worktree hook

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,7 @@ export interface WorktreeHook {
 }
 
 export interface WorktreeHookConfig {
+	pre_creation?: WorktreeHook;
 	post_creation?: WorktreeHook;
 }
 
@@ -305,7 +306,8 @@ export interface IWorktreeService {
 	): import('effect').Effect.Effect<
 		Worktree,
 		| import('../types/errors.js').GitError
-		| import('../types/errors.js').FileSystemError,
+		| import('../types/errors.js').FileSystemError
+		| import('../types/errors.js').ProcessError,
 		never
 	>;
 	deleteWorktreeEffect(


### PR DESCRIPTION
## Summary

- Add `pre_creation` hook to `worktreeHooks` that executes **before** `git worktree add`
- Failures in pre-creation hook **abort** worktree creation (unlike post-creation which continues)
- Hook runs in git root directory since worktree doesn't exist yet
- Add UI support in Configuration → Worktree Hooks → Pre Creation
- Add comprehensive tests and documentation

## Key Differences from Post-Creation Hook

| Aspect | Post-Creation | Pre-Creation |
|--------|---------------|--------------|
| Timing | After `git worktree add` | Before `git worktree add` |
| Working dir | New worktree path | Git root |
| Error handling | Log and continue | Fail and abort |

Closes #151

## Test plan

- [x] `npm run typecheck` - no errors
- [x] `npm run lint` - no errors
- [x] `npm run test` - all tests pass (1108 passed)
- [ ] Manual test: Configure pre-creation hook via UI
- [ ] Manual test: Create worktree with passing hook - succeeds
- [ ] Manual test: Create worktree with failing hook (exit 1) - creation aborted

🤖 Generated with [Claude Code](https://claude.com/claude-code)