### PR TITLE
Revert "chore(deps): bump react-devtools-core from 6.1.5 to 7.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"ink-text-input": "^6.0.0",
 		"meow": "^14.0.0",
 		"react": "^19.2.3",
-		"react-devtools-core": "^7.0.1",
+		"react-devtools-core": "^6.1.2",
 		"react-dom": "^19.2.3",
 		"strip-ansi": "^7.1.0"
 	}


### PR DESCRIPTION
Reverts kbwo/ccmanager#188

```
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: ink@6.6.0
npm warn Found: react-devtools-core@7.0.1
npm warn node_modules/ccmanager/node_modules/react-devtools-core
npm warn   react-devtools-core@"^7.0.1" from ccmanager@3.6.7
npm warn   node_modules/ccmanager
npm warn     ccmanager@"3.6.7" from the root project
npm warn
npm warn Could not resolve dependency:
npm warn peerOptional react-devtools-core@"^6.1.2" from ink@6.6.0
npm warn node_modules/ccmanager/node_modules/ink
npm warn   ink@"^6.6.0" from ccmanager@3.6.7
npm warn   node_modules/ccmanager
npm warn   2 more (ink-select-input, ink-text-input)
npm warn
npm warn Conflicting peer dependency: react-devtools-core@6.1.5
npm warn node_modules/react-devtools-core
npm warn   peerOptional react-devtools-core@"^6.1.2" from ink@6.6.0
npm warn   node_modules/ccmanager/node_modules/ink
npm warn     ink@"^6.6.0" from ccmanager@3.6.7
npm warn     node_modules/ccmanager
npm warn     2 more (ink-select-input, ink-text-input)
```
