### PR TITLE
fix: always detect idle when search prompt is displayed

### DIFF
--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -346,6 +346,39 @@ describe('ClaudeStateDetector', () => {
 			// Assert - Should detect waiting_input from viewport
 			expect(state).toBe('waiting_input');
 		});
+
+		it('should detect idle when "⌕ Search…" is present', () => {
+			// Arrange - Search prompt should always be idle
+			terminal = createMockTerminal(['⌕ Search…', 'Some content']);
+
+			// Act
+			const state = detector.detectState(terminal, 'busy');
+
+			// Assert
+			expect(state).toBe('idle');
+		});
+
+		it('should detect idle when "⌕ Search…" is present even with "esc to cancel"', () => {
+			// Arrange
+			terminal = createMockTerminal(['⌕ Search…', 'esc to cancel']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert - Should be idle because search prompt takes precedence
+			expect(state).toBe('idle');
+		});
+
+		it('should detect idle when "⌕ Search…" is present even with "esc to interrupt"', () => {
+			// Arrange
+			terminal = createMockTerminal(['⌕ Search…', 'Press esc to interrupt']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert - Should be idle because search prompt takes precedence
+			expect(state).toBe('idle');
+		});
 	});
 
 	describe('detectBackgroundTask', () => {

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -11,6 +11,11 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			return currentState;
 		}
 
+		// Check for search prompt (⌕ Search…) - always idle
+		if (content.includes('⌕ Search…')) {
+			return 'idle';
+		}
+
 		// Check for "Do you want" or "Would you like" pattern with options
 		// Handles both simple ("Do you want...\nYes") and complex (numbered options) formats
 		if (


### PR DESCRIPTION
## Summary
- Add condition to return `idle` state when "⌕ Search…" is present in terminal content
- This ensures the search/resume session screen is properly handled regardless of other state indicators

## Test plan
- [x] Added 3 new test cases for search prompt scenarios
- [x] All 1133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)