### PR TITLE
feat: add Kimi CLI support

### DIFF
--- a/src/components/ConfigureCommand.tsx
+++ b/src/components/ConfigureCommand.tsx
@@ -31,6 +31,7 @@ const createStrategyItems = (): {
 		},
 		cline: {label: 'Cline', value: 'cline'},
 		opencode: {label: 'OpenCode', value: 'opencode'},
+		kimi: {label: 'Kimi', value: 'kimi'},
 	};
 
 	return Object.values(strategies);
@@ -48,6 +49,7 @@ const DEFAULT_COMMANDS: Record<StateDetectionStrategy, string> = {
 	'github-copilot': 'copilot',
 	cline: 'cline',
 	opencode: 'opencode',
+	kimi: 'kimi',
 };
 
 interface ConfigureCommandProps {
@@ -77,6 +79,8 @@ const formatDetectionStrategy = (strategy: string | undefined): string => {
 			return 'Cline';
 		case 'opencode':
 			return 'OpenCode';
+		case 'kimi':
+			return 'Kimi';
 		default:
 			return 'Claude';
 	}

--- a/src/services/stateDetector/index.ts
+++ b/src/services/stateDetector/index.ts
@@ -7,6 +7,7 @@ import {CursorStateDetector} from './cursor.js';
 import {GitHubCopilotStateDetector} from './github-copilot.js';
 import {ClineStateDetector} from './cline.js';
 import {OpenCodeStateDetector} from './opencode.js';
+import {KimiStateDetector} from './kimi.js';
 
 export function createStateDetector(
 	strategy: StateDetectionStrategy = 'claude',
@@ -26,6 +27,8 @@ export function createStateDetector(
 			return new ClineStateDetector();
 		case 'opencode':
 			return new OpenCodeStateDetector();
+		case 'kimi':
+			return new KimiStateDetector();
 		default:
 			return new ClaudeStateDetector();
 	}

--- a/src/services/stateDetector/kimi.test.ts
+++ b/src/services/stateDetector/kimi.test.ts
@@ -1,0 +1,255 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {KimiStateDetector} from './kimi.js';
+import type {Terminal} from '../../types/index.js';
+import {createMockTerminal} from './testUtils.js';
+
+describe('KimiStateDetector', () => {
+	let detector: KimiStateDetector;
+	let terminal: Terminal;
+
+	beforeEach(() => {
+		detector = new KimiStateDetector();
+	});
+
+	describe('detectState', () => {
+		it('should detect idle when no specific patterns are found', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Command completed successfully',
+				'Ready for next command',
+				'> ',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('idle');
+		});
+
+		it('should handle empty terminal', () => {
+			// Arrange
+			terminal = createMockTerminal([]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('idle');
+		});
+
+		it('should detect waiting_input when "Allow?" prompt is present', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Kimi wants to execute a command',
+				'Allow?',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
+		it('should detect waiting_input when "Confirm?" prompt is present', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'About to make changes to file.ts',
+				'Confirm?',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
+		it('should detect waiting_input when "Approve?" prompt is present', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Requesting permission to modify config',
+				'Approve?',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
+		it('should detect waiting_input when "Proceed?" prompt is present', () => {
+			// Arrange
+			terminal = createMockTerminal(['Ready to execute action', 'Proceed?']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
+		it('should detect waiting_input when "[y/n]" pattern is present', () => {
+			// Arrange
+			terminal = createMockTerminal(['Do you want to continue? [y/n]', '> ']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
+		it('should detect waiting_input when "(y/n)" pattern is present', () => {
+			// Arrange
+			terminal = createMockTerminal(['Apply changes? (y/n)', '> ']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
+		it('should detect busy when "thinking" is present', () => {
+			// Arrange
+			terminal = createMockTerminal(['Processing your request...', 'thinking']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should detect busy when "processing" is present', () => {
+			// Arrange
+			terminal = createMockTerminal(['Analyzing code...', 'processing']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should detect busy when "generating" is present', () => {
+			// Arrange
+			terminal = createMockTerminal(['Working on solution...', 'generating']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should detect busy when "waiting for response" is present', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Request sent',
+				'waiting for response from API',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should detect busy when "ctrl+c to cancel" is present', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Running task...',
+				'Press ctrl+c to cancel',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should detect busy when "ctrl-c to cancel" is present', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Executing command...',
+				'ctrl-c to cancel',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should detect busy when "press ctrl+c" is present', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Working...',
+				'Press Ctrl+C to stop the operation',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should detect patterns case-insensitively', () => {
+			// Arrange
+			terminal = createMockTerminal(['THINKING about the problem...']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('busy');
+		});
+
+		it('should prioritize waiting_input over busy when both patterns present', () => {
+			// Arrange
+			terminal = createMockTerminal(['Processing...', 'thinking', 'Allow?']);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+	});
+
+	describe('detectBackgroundTask', () => {
+		it('should return 0 as Kimi CLI does not support background tasks', () => {
+			// Arrange
+			terminal = createMockTerminal([
+				'Some output',
+				'More output',
+				'Status bar',
+			]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(0);
+		});
+
+		it('should return 0 for empty terminal', () => {
+			// Arrange
+			terminal = createMockTerminal([]);
+
+			// Act
+			const count = detector.detectBackgroundTask(terminal);
+
+			// Assert
+			expect(count).toBe(0);
+		});
+	});
+});

--- a/src/services/stateDetector/kimi.ts
+++ b/src/services/stateDetector/kimi.ts
@@ -1,0 +1,58 @@
+import {SessionState, Terminal} from '../../types/index.js';
+import {BaseStateDetector} from './base.js';
+
+/**
+ * State detector for Kimi CLI (kimi-cli).
+ * Kimi CLI is an AI coding assistant by Moonshot AI.
+ * Command: kimi
+ * Installation: uv tool install --python 3.13 kimi-cli
+ */
+export class KimiStateDetector extends BaseStateDetector {
+	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
+		const content = this.getTerminalContent(terminal);
+		const lowerContent = content.toLowerCase();
+
+		// Check for permission/confirmation prompts - waiting_input state
+		// Kimi CLI uses prompts like "Allow?", "Confirm?", "Yes/No" patterns
+		if (
+			lowerContent.includes('allow?') ||
+			lowerContent.includes('confirm?') ||
+			lowerContent.includes('approve?') ||
+			lowerContent.includes('proceed?')
+		) {
+			return 'waiting_input';
+		}
+
+		// Check for Yes/No option patterns
+		if (/\[y\/n\]/.test(lowerContent) || /\(y\/n\)/.test(lowerContent)) {
+			return 'waiting_input';
+		}
+
+		// Check for busy state - processing indicators
+		if (
+			lowerContent.includes('thinking') ||
+			lowerContent.includes('processing') ||
+			lowerContent.includes('generating') ||
+			lowerContent.includes('waiting for response')
+		) {
+			return 'busy';
+		}
+
+		// Check for common interrupt patterns
+		if (
+			lowerContent.includes('ctrl+c to cancel') ||
+			lowerContent.includes('ctrl-c to cancel') ||
+			lowerContent.includes('press ctrl+c')
+		) {
+			return 'busy';
+		}
+
+		// Otherwise idle
+		return 'idle';
+	}
+
+	detectBackgroundTask(_terminal: Terminal): number {
+		// Kimi CLI does not currently support background tasks
+		return 0;
+	}
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,7 +19,8 @@ export type StateDetectionStrategy =
 	| 'cursor'
 	| 'github-copilot'
 	| 'cline'
-	| 'opencode';
+	| 'opencode'
+	| 'kimi';
 
 export interface Worktree {
 	path: string;


### PR DESCRIPTION
## Summary
- Add state detection support for Kimi CLI (kimi-cli), an AI coding assistant by Moonshot AI
- Kimi CLI command: `kimi` (installed via `uv tool install --python 3.13 kimi-cli`)

## Changes
| File | Action | Description |
|------|--------|-------------|
| `src/types/index.ts` | Modified | Add 'kimi' to StateDetectionStrategy type |
| `src/services/stateDetector/kimi.ts` | Created | KimiStateDetector implementation |
| `src/services/stateDetector/kimi.test.ts` | Created | Unit tests (19 test cases) |
| `src/services/stateDetector/index.ts` | Modified | Register KimiStateDetector in factory |
| `src/components/ConfigureCommand.tsx` | Modified | Add Kimi to UI strategy list |

## State Detection Patterns
- **waiting_input**: `Allow?`, `Confirm?`, `Approve?`, `Proceed?`, `[y/n]`, `(y/n)`
- **busy**: `thinking`, `processing`, `generating`, `waiting for response`, `ctrl+c to cancel`
- **background tasks**: Returns 0 (Kimi CLI does not currently support background tasks)

## Test Plan
- [x] `npm run typecheck` - passed
- [x] `npm run lint` - passed
- [x] `npm run test` - 19 new tests passed
- [x] `npm run build` - passed