### PR TITLE
fix: extend search prompt detection range to 200 lines

### DIFF
--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -3,17 +3,19 @@ import {BaseStateDetector} from './base.js';
 
 export class ClaudeStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, currentState: SessionState): SessionState {
-		const content = this.getTerminalContent(terminal);
+		// Check for search prompt (⌕ Search…) within 200 lines - always idle
+		const extendedContent = this.getTerminalContent(terminal, 200);
+		if (extendedContent.includes('⌕ Search…')) {
+			return 'idle';
+		}
+
+		// Existing logic with 30 lines
+		const content = this.getTerminalContent(terminal, 30);
 		const lowerContent = content.toLowerCase();
 
 		// Check for ctrl+r toggle prompt - maintain current state
 		if (lowerContent.includes('ctrl+r to toggle')) {
 			return currentState;
-		}
-
-		// Check for search prompt (⌕ Search…) - always idle
-		if (content.includes('⌕ Search…')) {
-			return 'idle';
 		}
 
 		// Check for "Do you want" or "Would you like" pattern with options

--- a/src/services/stateDetector/cline.ts
+++ b/src/services/stateDetector/cline.ts
@@ -4,7 +4,7 @@ import {BaseStateDetector} from './base.js';
 // https://github.com/cline/cline/blob/580db36476b6b52def03c8aeda325aae1c817cde/cli/pkg/cli/task/input_handler.go
 export class ClineStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
-		const content = this.getTerminalContent(terminal);
+		const content = this.getTerminalContent(terminal, 30);
 		const lowerContent = content.toLowerCase();
 
 		// Check for waiting prompts with tool permission - Priority 1

--- a/src/services/stateDetector/codex.ts
+++ b/src/services/stateDetector/codex.ts
@@ -3,7 +3,7 @@ import {BaseStateDetector} from './base.js';
 
 export class CodexStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
-		const content = this.getTerminalContent(terminal);
+		const content = this.getTerminalContent(terminal, 30);
 		const lowerContent = content.toLowerCase();
 
 		// Check for confirmation prompt patterns - highest priority

--- a/src/services/stateDetector/cursor.ts
+++ b/src/services/stateDetector/cursor.ts
@@ -3,7 +3,7 @@ import {BaseStateDetector} from './base.js';
 
 export class CursorStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
-		const content = this.getTerminalContent(terminal);
+		const content = this.getTerminalContent(terminal, 30);
 		const lowerContent = content.toLowerCase();
 
 		// Check for waiting prompts - Priority 1

--- a/src/services/stateDetector/gemini.ts
+++ b/src/services/stateDetector/gemini.ts
@@ -4,7 +4,7 @@ import {BaseStateDetector} from './base.js';
 // https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
 export class GeminiStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
-		const content = this.getTerminalContent(terminal);
+		const content = this.getTerminalContent(terminal, 30);
 		const lowerContent = content.toLowerCase();
 
 		// Check for explicit user confirmation message - highest priority

--- a/src/services/stateDetector/github-copilot.ts
+++ b/src/services/stateDetector/github-copilot.ts
@@ -3,7 +3,7 @@ import {BaseStateDetector} from './base.js';
 
 export class GitHubCopilotStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
-		const content = this.getTerminalContent(terminal);
+		const content = this.getTerminalContent(terminal, 30);
 		const lowerContent = content.toLowerCase();
 
 		// Check for confirmation prompt pattern - highest priority

--- a/src/services/stateDetector/opencode.ts
+++ b/src/services/stateDetector/opencode.ts
@@ -3,7 +3,7 @@ import {BaseStateDetector} from './base.js';
 
 export class OpenCodeStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
-		const content = this.getTerminalContent(terminal);
+		const content = this.getTerminalContent(terminal, 30);
 
 		// Check for waiting input state - permission required prompt
 		// The triangle symbol (△) indicates permission is required


### PR DESCRIPTION
## Summary
- Increases search prompt (⌕ Search…) detection range from 30 to 200 lines in ClaudeStateDetector
- Keeps other state detection at 30 lines for performance
- Explicitly specifies line count in all state detectors for clarity

## Background
When the Claude Code search UI displays many results, the search prompt can appear far from the bottom of the terminal, causing the state detector to miss it and incorrectly report the session as busy instead of idle.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)