### PR TITLE
feat: add uncommitted changes warning for worktree deletion

### DIFF
--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -2,6 +2,27 @@ import path from 'path';
 import {execSync} from 'child_process';
 
 /**
+ * Check if a worktree or repository has uncommitted changes.
+ * This includes unstaged changes, staged changes, and untracked files.
+ *
+ * @param worktreePath - The path to the worktree or repository
+ * @returns true if there are uncommitted changes, false if clean
+ */
+export function hasUncommittedChanges(worktreePath: string): boolean {
+	try {
+		const output = execSync('git status --porcelain', {
+			cwd: worktreePath,
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		}).trim();
+		return output.length > 0;
+	} catch {
+		// Conservative default on error - treat as having changes
+		return true;
+	}
+}
+
+/**
  * Get the git repository root path from a given directory.
  * For worktrees, this returns the main repository root (parent of .git).
  * For submodules, this returns the submodule's working directory.

--- a/src/utils/gitUtils.uncommitted.test.ts
+++ b/src/utils/gitUtils.uncommitted.test.ts
@@ -1,0 +1,114 @@
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {execSync} from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import {hasUncommittedChanges} from './gitUtils.js';
+
+describe('hasUncommittedChanges', () => {
+	// Use os.tmpdir() and unique suffix to avoid conflicts with parallel tests
+	// Use realpathSync to resolve symlinks (e.g., /var -> /private/var on macOS)
+	const testDir = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'ccmanager-uncommitted-test-')),
+	);
+	const mainRepoDir = path.join(testDir, 'main-repo');
+	const worktreeDir = path.join(testDir, 'worktree-1');
+
+	beforeAll(() => {
+		// Clean up if exists
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+
+		// Create test directory structure
+		fs.mkdirSync(testDir, {recursive: true});
+
+		// Create main repository
+		fs.mkdirSync(mainRepoDir, {recursive: true});
+		execSync('git init', {cwd: mainRepoDir});
+		// Set git user for CI environment
+		execSync('git config user.email "test@test.com"', {cwd: mainRepoDir});
+		execSync('git config user.name "Test User"', {cwd: mainRepoDir});
+		fs.writeFileSync(path.join(mainRepoDir, 'README.md'), '# Main Repo');
+		execSync('git add README.md', {cwd: mainRepoDir});
+		execSync('git commit -m "Initial commit"', {cwd: mainRepoDir});
+
+		// Create a branch and worktree
+		execSync('git branch feature-branch', {cwd: mainRepoDir});
+		execSync(`git worktree add ${worktreeDir} feature-branch`, {
+			cwd: mainRepoDir,
+		});
+	});
+
+	afterAll(() => {
+		// Clean up worktree first
+		try {
+			execSync(`git worktree remove ${worktreeDir} --force`, {
+				cwd: mainRepoDir,
+			});
+		} catch {
+			// Ignore errors
+		}
+
+		// Clean up
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, {recursive: true, force: true});
+		}
+	});
+
+	it('should return false for a clean worktree', () => {
+		const result = hasUncommittedChanges(worktreeDir);
+		expect(result).toBe(false);
+	});
+
+	it('should return true for a worktree with unstaged changes', () => {
+		// Create an unstaged change
+		fs.writeFileSync(path.join(worktreeDir, 'README.md'), '# Modified');
+
+		const result = hasUncommittedChanges(worktreeDir);
+		expect(result).toBe(true);
+
+		// Restore the file
+		execSync('git checkout README.md', {cwd: worktreeDir});
+	});
+
+	it('should return true for a worktree with staged but uncommitted changes', () => {
+		// Create a staged change
+		fs.writeFileSync(path.join(worktreeDir, 'new-file.txt'), 'new content');
+		execSync('git add new-file.txt', {cwd: worktreeDir});
+
+		const result = hasUncommittedChanges(worktreeDir);
+		expect(result).toBe(true);
+
+		// Reset the change
+		execSync('git reset HEAD new-file.txt', {cwd: worktreeDir});
+		fs.unlinkSync(path.join(worktreeDir, 'new-file.txt'));
+	});
+
+	it('should return true for a worktree with untracked files', () => {
+		// Create an untracked file
+		fs.writeFileSync(path.join(worktreeDir, 'untracked.txt'), 'untracked');
+
+		const result = hasUncommittedChanges(worktreeDir);
+		expect(result).toBe(true);
+
+		// Clean up
+		fs.unlinkSync(path.join(worktreeDir, 'untracked.txt'));
+	});
+
+	it('should return false for a clean main repository', () => {
+		const result = hasUncommittedChanges(mainRepoDir);
+		expect(result).toBe(false);
+	});
+
+	it('should return true for a main repository with uncommitted changes', () => {
+		// Create an unstaged change
+		fs.writeFileSync(path.join(mainRepoDir, 'README.md'), '# Modified Main');
+
+		const result = hasUncommittedChanges(mainRepoDir);
+		expect(result).toBe(true);
+
+		// Restore the file
+		execSync('git checkout README.md', {cwd: mainRepoDir});
+	});
+});


### PR DESCRIPTION
## Summary

- Add warning dialog when deleting worktrees that have uncommitted changes
- Warning shows Yes/No options with No as default for safety
- Applies to both Delete Worktree menu and Merge Worktree flow

## Test plan

- [x] Create a worktree with uncommitted changes
- [x] Try to delete it via Delete Worktree menu → warning appears with No as default
- [x] Try to delete it via Merge Worktree flow → warning appears with No as default
- [x] All tests pass
- [x] Linter and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)