### PR TITLE
feat: fallback to date-random branch name when claude -p fails

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,7 +15,11 @@ import type {NewWorktreeRequest} from './NewWorktree.js';
 import {SessionManager} from '../services/sessionManager.js';
 import {globalSessionOrchestrator} from '../services/globalSessionOrchestrator.js';
 import {WorktreeService} from '../services/worktreeService.js';
-import {worktreeNameGenerator} from '../services/worktreeNameGenerator.js';
+import {
+	worktreeNameGenerator,
+	generateFallbackBranchName,
+} from '../services/worktreeNameGenerator.js';
+import {logger} from '../utils/logger.js';
 import {
 	Worktree,
 	Session as ISession,
@@ -508,12 +512,13 @@ const App: React.FC<AppProps> = ({
 			);
 
 			if (generatedBranch._tag === 'Left') {
-				setError(formatErrorMessage(generatedBranch.left));
-				setView('new-worktree');
-				return;
+				logger.warn(
+					`Branch name generation failed, using fallback: ${formatErrorMessage(generatedBranch.left)}`,
+				);
+				branch = generateFallbackBranchName(existingBranches);
+			} else {
+				branch = generatedBranch.right;
 			}
-
-			branch = generatedBranch.right;
 			if (request.autoDirectoryPattern) {
 				targetPath = generateWorktreeDirectory(
 					request.projectPath,

--- a/src/services/worktreeNameGenerator.test.ts
+++ b/src/services/worktreeNameGenerator.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest';
 import {
 	deduplicateBranchName,
 	extractBranchNameFromOutput,
+	generateFallbackBranchName,
 	worktreeNameGenerator as generator,
 } from './worktreeNameGenerator.js';
 
@@ -63,5 +64,19 @@ describe('deduplicateBranchName', () => {
 		expect(deduplicateBranchName('Feature/New', ['feature/new'])).toBe(
 			'Feature/New-2',
 		);
+	});
+});
+
+describe('generateFallbackBranchName', () => {
+	it('returns a name matching YYYYMMDD-hex pattern', () => {
+		const name = generateFallbackBranchName();
+		expect(name).toMatch(/^\d{8}-[0-9a-f]{6}$/);
+	});
+
+	it('deduplicates against existing branches', () => {
+		const first = generateFallbackBranchName();
+		const name = generateFallbackBranchName([first]);
+		// Either it's different (random collision unlikely) or it has a -2 suffix
+		expect(name).not.toBe(first);
 	});
 });

--- a/src/services/worktreeNameGenerator.ts
+++ b/src/services/worktreeNameGenerator.ts
@@ -1,3 +1,4 @@
+import {randomBytes} from 'crypto';
 import {Effect} from 'effect';
 import {execFile, type ChildProcess} from 'child_process';
 import {ProcessError} from '../types/errors.js';
@@ -144,6 +145,18 @@ export const deduplicateBranchName = (
 			return candidate;
 		}
 	}
+};
+
+export const generateFallbackBranchName = (
+	existingBranches?: string[],
+): string => {
+	const date = new Date();
+	const dateStr = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}`;
+	const randomSuffix = randomBytes(3).toString('hex');
+	const name = `${dateStr}-${randomSuffix}`;
+	return existingBranches
+		? deduplicateBranchName(name, existingBranches)
+		: name;
 };
 
 export class WorktreeNameGenerator {


### PR DESCRIPTION
## Summary
- When automatic branch naming via `claude -p` fails (command not found, timeout, etc.), fall back to a `YYYYMMDD-<hex>` branch name instead of showing an error and returning to the form
- Adds `generateFallbackBranchName()` utility with deduplication support
- Adds tests for the fallback name generation

## Test plan
- [ ] Verify prompt-first worktree creation works normally when `claude` is available
- [ ] Verify fallback branch naming works when `claude` is not in PATH
- [ ] Verify fallback branch naming works when `claude -p` times out
- [ ] Run `bun run test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)