### PR TITLE
fix: prevent deletion of worktree matching current working directory

### DIFF
--- a/src/components/DeleteWorktree.tsx
+++ b/src/components/DeleteWorktree.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useEffect} from 'react';
+import path from 'path';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 import {Effect} from 'effect';
@@ -39,10 +40,19 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 				);
 
 				if (!cancelled) {
-					// Filter out main worktree - we shouldn't delete it
-					const deletableWorktrees = allWorktrees.filter(
-						wt => !wt.isMainWorktree,
-					);
+					// Filter out main worktree and current working directory worktree
+					const resolvedCwd = path.resolve(process.cwd());
+					const deletableWorktrees = allWorktrees.filter(wt => {
+						if (wt.isMainWorktree) return false;
+						const resolvedPath = path.resolve(wt.path);
+						if (
+							resolvedCwd === resolvedPath ||
+							resolvedCwd.startsWith(resolvedPath + path.sep)
+						) {
+							return false;
+						}
+						return true;
+					});
 					setWorktrees(deletableWorktrees);
 					setIsLoading(false);
 				}

--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -943,6 +943,39 @@ branch refs/heads/main
 				expect.fail('Should have returned Left with GitError');
 			}
 		});
+		it('should return Effect that fails with GitError when trying to delete worktree matching cwd', async () => {
+			const cwdPath = process.cwd();
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd === 'git worktree list --porcelain') {
+						return `worktree /fake/path
+HEAD abcd1234
+branch refs/heads/main
+
+worktree ${cwdPath}
+HEAD efgh5678
+branch refs/heads/feature
+`;
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			const effect = service.deleteWorktreeEffect(cwdPath);
+			const result = await Effect.runPromise(Effect.either(effect));
+
+			if (result._tag === 'Left') {
+				expect(result.left).toBeInstanceOf(GitError);
+				expect(result.left.stderr).toContain(
+					'because it is the current working directory',
+				);
+			} else {
+				expect.fail('Should have returned Left with GitError');
+			}
+		});
 	});
 
 	describe('Effect-based mergeWorktree', () => {

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -1105,6 +1105,22 @@ export class WorktreeService {
 				);
 			}
 
+			// Prevent deleting the worktree that contains the current working directory
+			const resolvedWorktreePath = path.resolve(worktreePath);
+			const resolvedCwd = path.resolve(process.cwd());
+			if (
+				resolvedCwd === resolvedWorktreePath ||
+				resolvedCwd.startsWith(resolvedWorktreePath + path.sep)
+			) {
+				return yield* Effect.fail(
+					new GitError({
+						command: 'git worktree remove',
+						exitCode: 1,
+						stderr: `Cannot delete the worktree at "${worktreePath}" because it is the current working directory`,
+					}),
+				);
+			}
+
 			// Remove the worktree
 			yield* Effect.try({
 				try: () => {


### PR DESCRIPTION
## Summary
- Prevent deletion of a worktree when its path matches the current working directory (or a parent of it)
- Add a guard in `WorktreeService.deleteWorktreeEffect` that throws `GitError` if cwd is inside the target worktree
- Filter out the cwd worktree from the delete selection UI in `DeleteWorktree.tsx`
- Add unit test covering the cwd protection check

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new warnings)
- [x] `npm run test` passes (1353 tests, including new cwd protection test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)