### PR TITLE
feat: add number keys 1-9 for quick preset selection

### DIFF
--- a/src/components/PresetSelector.test.tsx
+++ b/src/components/PresetSelector.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import {render} from 'ink-testing-library';
+import {vi, describe, it, expect, beforeEach, afterEach} from 'vitest';
+import type {Key} from 'ink';
+
+// Hoist mocks to avoid top-level variable access in vi.mock factories
+const {capturedHandlers} = vi.hoisted(() => {
+	const capturedHandlers: {
+		inputHandler: ((input: string, key: Key) => void) | null;
+	} = {
+		inputHandler: null,
+	};
+	return {capturedHandlers};
+});
+
+// Mock ink to avoid stdin issues and capture useInput callbacks
+vi.mock('ink', async () => {
+	const actual = await vi.importActual<typeof import('ink')>('ink');
+	return {
+		...actual,
+		useInput: vi.fn((handler: (input: string, key: Key) => void) => {
+			capturedHandlers.inputHandler = handler;
+		}),
+	};
+});
+
+// Mock SelectInput
+vi.mock('ink-select-input', async () => {
+	const React = await vi.importActual<typeof import('react')>('react');
+	const {Text, Box} = await vi.importActual<typeof import('ink')>('ink');
+
+	return {
+		default: ({
+			items,
+			onSelect: _onSelect,
+			initialIndex = 0,
+		}: {
+			items: Array<{label: string; value: string}>;
+			onSelect: (item: {label: string; value: string}) => void;
+			initialIndex?: number;
+		}) => {
+			return React.createElement(
+				Box,
+				{flexDirection: 'column'},
+				items.map((item, index) =>
+					React.createElement(
+						Text,
+						{key: index},
+						`${index === initialIndex ? '❯ ' : '  '}${item.label}`,
+					),
+				),
+			);
+		},
+	};
+});
+
+// Mock configReader
+vi.mock('../services/config/configReader.js', () => ({
+	configReader: {
+		getCommandPresets: vi.fn().mockReturnValue({
+			presets: [
+				{id: 'preset-1', name: 'Claude', command: 'claude'},
+				{id: 'preset-2', name: 'Gemini', command: 'gemini'},
+				{id: 'preset-3', name: 'Cursor', command: 'cursor'},
+			],
+			defaultPresetId: 'preset-1',
+			selectPresetOnStart: true,
+		}),
+	},
+}));
+
+import PresetSelector from './PresetSelector.js';
+
+const makeKey = (overrides: Partial<Key> = {}): Key => ({
+	upArrow: false,
+	downArrow: false,
+	leftArrow: false,
+	rightArrow: false,
+	pageDown: false,
+	pageUp: false,
+	home: false,
+	end: false,
+	return: false,
+	escape: false,
+	ctrl: false,
+	shift: false,
+	tab: false,
+	backspace: false,
+	delete: false,
+	meta: false,
+	...overrides,
+});
+
+describe('PresetSelector component', () => {
+	let onSelect: ReturnType<typeof vi.fn<(presetId: string) => void>>;
+	let onCancel: ReturnType<typeof vi.fn<() => void>>;
+
+	beforeEach(() => {
+		onSelect = vi.fn<(presetId: string) => void>();
+		onCancel = vi.fn<() => void>();
+		capturedHandlers.inputHandler = null;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders preset list with number prefixes and default label', () => {
+		const {lastFrame} = render(
+			<PresetSelector onSelect={onSelect} onCancel={onCancel} />,
+		);
+		const output = lastFrame();
+		expect(output).toContain('[1]');
+		expect(output).toContain('[2]');
+		expect(output).toContain('[3]');
+		expect(output).toContain('(default)');
+		expect(output).toContain('← Cancel');
+	});
+
+	it('pressing 1 calls onSelect with first preset id immediately', () => {
+		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
+		expect(capturedHandlers.inputHandler).not.toBeNull();
+		capturedHandlers.inputHandler!('1', makeKey());
+		expect(onSelect).toHaveBeenCalledWith('preset-1');
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+
+	it('pressing 2 calls onSelect with second preset id immediately', () => {
+		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
+		capturedHandlers.inputHandler!('2', makeKey());
+		expect(onSelect).toHaveBeenCalledWith('preset-2');
+	});
+
+	it('pressing 3 calls onSelect with third preset id immediately', () => {
+		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
+		capturedHandlers.inputHandler!('3', makeKey());
+		expect(onSelect).toHaveBeenCalledWith('preset-3');
+	});
+
+	it('pressing a number beyond preset count does nothing', () => {
+		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
+		capturedHandlers.inputHandler!('9', makeKey());
+		expect(onSelect).not.toHaveBeenCalled();
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+
+	it('pressing ESC calls onCancel', () => {
+		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
+		capturedHandlers.inputHandler!('', makeKey({escape: true}));
+		expect(onCancel).toHaveBeenCalled();
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it('displays title and subtitle', () => {
+		const {lastFrame} = render(
+			<PresetSelector onSelect={onSelect} onCancel={onCancel} />,
+		);
+		const output = lastFrame();
+		expect(output).toContain('Select Command Preset');
+		expect(output).toContain('Choose a preset to start the session with');
+	});
+});

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -16,11 +16,12 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
 	const [presets] = useState(presetsConfig.presets);
 	const defaultPresetId = presetsConfig.defaultPresetId;
 
-	const selectItems = presets.map(preset => {
+	const selectItems = presets.map((preset, index) => {
 		const isDefault = preset.id === defaultPresetId;
 		const args = preset.args?.join(' ') || '';
 		const fallback = preset.fallbackArgs?.join(' ') || '';
-		let label = preset.name;
+		const numberPrefix = index < 9 ? `[${index + 1}] ` : '';
+		let label = numberPrefix + preset.name;
 		if (isDefault) label += ' (default)';
 		label += `\n    Command: ${preset.command}`;
 		if (args) label += `\n    Args: ${args}`;
@@ -50,6 +51,16 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
 	useInput((input, key) => {
 		if (key.escape) {
 			onCancel();
+			return;
+		}
+
+		// Number keys 1-9: immediate launch
+		if (/^[1-9]$/.test(input)) {
+			const idx = parseInt(input) - 1;
+			if (idx < presets.length && presets[idx]) {
+				onSelect(presets[idx]!.id);
+			}
+			return;
 		}
 	});
 
@@ -73,7 +84,7 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
 
 			<Box marginTop={1}>
 				<Text dimColor>
-					Press ↑↓ to navigate, Enter to select, ESC to cancel
+					↑↓ Navigate 1-9 Quick Select Enter Select ESC Cancel
 				</Text>
 			</Box>
 		</Box>


### PR DESCRIPTION
## Summary

- Add `[1]`–`[9]` number prefixes to preset labels in PresetSelector
- Press a number key to immediately launch with that preset (no Enter needed)
- Numbers beyond the preset count are safely ignored
- Updated help text to show the new shortcut

## Test plan

- [x] Open PresetSelector with `selectPresetOnStart=true`
- [x] Verify presets show `[1] Claude`, `[2] Gemini`, etc.
- [x] Press `2` → session launches immediately with second preset
- [x] Press `9` with only 3 presets → nothing happens
- [x] ESC still cancels, Enter still selects highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)