### PR TITLE
fix: trim newlines from remote branch names

### DIFF
--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -236,6 +236,29 @@ origin/feature/test
 			expect(result).toEqual(['main', 'feature/test', 'feature/remote']);
 		});
 
+		it('should trim newlines from remote branch names', async () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd.includes('branch -a')) {
+						return `main\norigin/main\norigin/feature/remote-only\n`;
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			const effect = service.getAllBranchesEffect();
+			const result = await Effect.runPromise(effect);
+
+			// Ensure no branch name has trailing whitespace/newlines
+			for (const branch of result) {
+				expect(branch).toBe(branch.trim());
+			}
+			expect(result).toEqual(['main', 'feature/remote-only']);
+		});
+
 		it('should return empty array on error', async () => {
 			mockedExecSync.mockImplementation((cmd, _options) => {
 				if (

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -604,7 +604,7 @@ export class WorktreeService {
 						.trim()
 						.split('\n')
 						.filter(branch => branch.startsWith('origin/'))
-						.map(branch => branch.replace('origin/', ''));
+						.map(branch => branch.replace('origin/', '').trim());
 
 					// Merge and deduplicate
 					const allBranches = [...new Set([...branches, ...remoteBranches])];


### PR DESCRIPTION
## Summary
- Remote branch names in `getAllBranchesEffect` were not trimmed after removing the `origin/` prefix, potentially leaving trailing whitespace/newlines
- Added `.trim()` to the remote branch name mapping in `worktreeService.ts`
- Added test to verify branch names are properly trimmed

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1353 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)