### PR TITLE
feat: add search and dynamic scroll to DeleteWorktree, extract shared utilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.11.2",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.11.2",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.11.2",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.11.2",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.11.2",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.11.3",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.11.3",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.11.3",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.11.3",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.11.3",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.11.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jxcvDWfSaN/JUDZSp1pLcuVVatKF3T0ywCGSZBdjQAnQbAM6nAsYUGKrFzrsHl2tGwd7DiqLvx7JKoV3LRzlzg=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.11.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-x6tl0Hh8EE48jcnqpK5TA+AFT46u7JFCYcV29711bfhFlwOQNlB/nKh5MV+Z4GlK+wV4pxWoBVnJspvZK+33Sg=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.11.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-e4HlqX4VGwNyLBPUmgA9DIdjkH20K6Helm8MAS07LMoSlvKRYZdbrB89YTC4ImJorEOXcJ4CvImCV+kWna+bBA=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.11.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-miiFf1Upb+jPrelHKdpOWZQ7hAyy/uFVpSWsP+rZXDvDK0aK604hGWt2C3o8XXmynm2zZ1oVKNZeJpfwxXu9dQ=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-fs3f1bq432i/nBHdEP6JWdSRy8+HlrYhh6yDM0pGDIMLDxL8vmVnZCAmltWzTsqcG8wJ8BIwiYFDrYO0GWUStw=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.11.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-J09JvHSAYDYpfdOFyznDKaQMaGKltBVX+AzO1tCjIQu9/yeSI56CsfXx0qv5IDkVMHHf2EZlAqABKqf4jcQRQA=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UOqhCHI3swucAZYojk/EvRsWSwiLRuGcuXnxmekWcB0UXrOdbO7bupyozxYtyaRfiEiieA/1pGzBIWLvMh0V9A=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.11.3", "", { "os": "linux", "cpu": "x64" }, "sha512-8PSU4fCoE6JhTw3LrG5b/QLAF2lV7O0H2SY3gM5b1+00xxPx1PD1AY6WhQqJRbs0hnmgO4pSFEeECm/8RJking=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-43Y2WHiwQu59vKn7QnorW8MGWfhtoghbssjdlvPu6XtYq1TVB3yfZjC5pYr9ec1wbIwzLO+zZhqzXMJwfefv5g=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.11.3", "", { "os": "win32", "cpu": "x64" }, "sha512-ImTzxP0IY8TTYBdzn43XOUOY+rei0cXXa0q4Uq0if/cTnWfZDUNHGiUq0+zp3B6JCsOJfij/OqIfrwNI0QfGsw=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, useMemo} from 'react';
-import {Box, Text, useInput, useStdout} from 'ink';
+import {Box, Text, useInput} from 'ink';
 import {Effect} from 'effect';
 import SelectInput from 'ink-select-input';
 import stripAnsi from 'strip-ansi';
@@ -21,6 +21,7 @@ import {
 	getStatusDisplay,
 } from '../constants/statusIcons.js';
 import {useSearchMode} from '../hooks/useSearchMode.js';
+import {useDynamicLimit} from '../hooks/useDynamicLimit.js';
 import {useGitStatus} from '../hooks/useGitStatus.js';
 import {
 	type WorktreeItem,
@@ -34,7 +35,7 @@ import {
 	formatGitAheadBehind,
 	formatParentBranch,
 } from '../utils/gitStatus.js';
-import TextInputWrapper from './TextInputWrapper.js';
+import SearchableList from './SearchableList.js';
 
 const MAX_BRANCH_NAME_LENGTH = 70;
 
@@ -162,9 +163,6 @@ const Dashboard: React.FC<DashboardProps> = ({
 	);
 	const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
 
-	const {stdout} = useStdout();
-	const fixedRows = 6;
-
 	const displayError = error || loadError;
 
 	const {isSearchMode, searchQuery, selectedIndex, setSearchQuery} =
@@ -173,10 +171,10 @@ const Dashboard: React.FC<DashboardProps> = ({
 			skipInTest: false,
 		});
 
-	const limit = Math.max(
-		5,
-		stdout.rows - fixedRows - (isSearchMode ? 1 : 0) - (displayError ? 3 : 0),
-	);
+	const limit = useDynamicLimit({
+		isSearchMode,
+		hasError: !!displayError,
+	});
 
 	// Git status polling for session worktrees
 	const enrichedWorktrees = useGitStatus(
@@ -635,18 +633,6 @@ const Dashboard: React.FC<DashboardProps> = ({
 				</Text>
 			</Box>
 
-			{isSearchMode && (
-				<Box marginBottom={1}>
-					<Text>Search: </Text>
-					<TextInputWrapper
-						value={searchQuery}
-						onChange={setSearchQuery}
-						focus={true}
-						placeholder="Type to filter..."
-					/>
-				</Box>
-			)}
-
 			{loading ? (
 				<Box>
 					<Text color="yellow">Discovering projects...</Text>
@@ -655,30 +641,25 @@ const Dashboard: React.FC<DashboardProps> = ({
 				<Box>
 					<Text color="yellow">No git repositories found in {projectsDir}</Text>
 				</Box>
-			) : isSearchMode && items.length === 0 ? (
-				<Box>
-					<Text color="yellow">No matches found</Text>
-				</Box>
-			) : isSearchMode ? (
-				<Box flexDirection="column">
-					{items.slice(0, limit).map((item, index) => (
-						<Text
-							key={item.value}
-							color={index === selectedIndex ? 'green' : undefined}
-						>
-							{index === selectedIndex ? '❯ ' : '  '}
-							{item.label}
-						</Text>
-					))}
-				</Box>
 			) : (
-				<SelectInput
+				<SearchableList
+					isSearchMode={isSearchMode}
+					searchQuery={searchQuery}
+					onSearchQueryChange={setSearchQuery}
+					selectedIndex={selectedIndex}
 					items={items}
-					onSelect={item => handleSelect(item as DashboardItem)}
-					isFocused={!displayError}
 					limit={limit}
-					initialIndex={selectedIndex}
-				/>
+					placeholder="Type to filter..."
+					noMatchMessage="No matches found"
+				>
+					<SelectInput
+						items={items}
+						onSelect={item => handleSelect(item as DashboardItem)}
+						isFocused={!displayError}
+						limit={limit}
+						initialIndex={selectedIndex}
+					/>
+				</SearchableList>
 			)}
 
 			{displayError && (

--- a/src/components/DeleteWorktree.tsx
+++ b/src/components/DeleteWorktree.tsx
@@ -7,6 +7,10 @@ import {Worktree} from '../types/index.js';
 import {WorktreeService} from '../services/worktreeService.js';
 import DeleteConfirmation from './DeleteConfirmation.js';
 import {shortcutManager} from '../services/shortcutManager.js';
+import {useSearchMode} from '../hooks/useSearchMode.js';
+import {useDynamicLimit} from '../hooks/useDynamicLimit.js';
+import {filterWorktreesByQuery} from '../utils/filterByQuery.js';
+import SearchableList from './SearchableList.js';
 
 interface DeleteWorktreeProps {
 	projectPath?: string;
@@ -27,6 +31,21 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 	const [focusedIndex, setFocusedIndex] = useState(0);
 	const [error, setError] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
+
+	const [menuItems, setMenuItems] = useState<{label: string; value: string}[]>(
+		[],
+	);
+
+	// Use the search mode hook
+	const {isSearchMode, searchQuery, selectedIndex, setSearchQuery} =
+		useSearchMode(menuItems.length, {
+			isDisabled: confirmMode,
+		});
+
+	const limit = useDynamicLimit({
+		isSearchMode,
+		hasError: !!error,
+	});
 
 	useEffect(() => {
 		let cancelled = false;
@@ -71,17 +90,24 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 		};
 	}, [projectPath]);
 
-	// Create menu items from worktrees
-	const menuItems = worktrees.map((worktree, index) => {
-		const branchName = worktree.branch
-			? worktree.branch.replace('refs/heads/', '')
-			: 'detached';
-		const isSelected = selectedIndices.has(index);
-		return {
-			label: `${isSelected ? '[✓]' : '[ ]'} ${branchName} (${worktree.path})`,
-			value: index.toString(),
-		};
-	});
+	// Build menu items from worktrees, filtering by search query
+	useEffect(() => {
+		const filteredWorktrees = filterWorktreesByQuery(worktrees, searchQuery);
+
+		const items = filteredWorktrees.map(worktree => {
+			const originalIndex = worktrees.indexOf(worktree);
+			const branchName = worktree.branch
+				? worktree.branch.replace('refs/heads/', '')
+				: 'detached';
+			const isSelected = selectedIndices.has(originalIndex);
+			return {
+				label: `${isSelected ? '[✓]' : '[ ]'} ${branchName} (${worktree.path})`,
+				value: originalIndex.toString(),
+			};
+		});
+
+		setMenuItems(items);
+	}, [worktrees, searchQuery, selectedIndices]);
 
 	const handleSelect = (item: {value: string}) => {
 		// Don't toggle on Enter - this will be used to confirm
@@ -93,6 +119,11 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 	useInput((input, key) => {
 		if (confirmMode) {
 			// Confirmation component handles input
+			return;
+		}
+
+		// Don't process other keys if in search mode (handled by useSearchMode)
+		if (isSearchMode) {
 			return;
 		}
 
@@ -184,38 +215,49 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 				</Text>
 			</Box>
 
-			<SelectInput
+			<SearchableList
+				isSearchMode={isSearchMode}
+				searchQuery={searchQuery}
+				onSearchQueryChange={setSearchQuery}
+				selectedIndex={selectedIndex}
 				items={menuItems}
-				onSelect={handleSelect}
-				onHighlight={(item: {value: string}) => {
-					const index = parseInt(item.value, 10);
-					setFocusedIndex(index);
-				}}
-				limit={10}
-				indicatorComponent={({isSelected}) => (
-					<Text color={isSelected ? 'green' : undefined}>
-						{isSelected ? '>' : ' '}
-					</Text>
-				)}
-				itemComponent={({isSelected, label}) => {
-					// Check if this item is actually selected (checkbox checked)
-					const hasCheckmark = label.includes('[✓]');
-					return (
-						<Text
-							color={isSelected ? 'green' : undefined}
-							inverse={isSelected}
-							dimColor={!isSelected && !hasCheckmark}
-						>
-							{label}
+				limit={limit}
+				placeholder="Type to filter worktrees..."
+				noMatchMessage="No worktrees match your search"
+			>
+				<SelectInput
+					items={menuItems}
+					onSelect={handleSelect}
+					onHighlight={(item: {value: string}) => {
+						const index = parseInt(item.value, 10);
+						setFocusedIndex(index);
+					}}
+					limit={limit}
+					indicatorComponent={({isSelected}) => (
+						<Text color={isSelected ? 'green' : undefined}>
+							{isSelected ? '>' : ' '}
 						</Text>
-					);
-				}}
-			/>
+					)}
+					itemComponent={({isSelected, label}) => {
+						const hasCheckmark = label.includes('[✓]');
+						return (
+							<Text
+								color={isSelected ? 'green' : undefined}
+								inverse={isSelected}
+								dimColor={!isSelected && !hasCheckmark}
+							>
+								{label}
+							</Text>
+						);
+					}}
+				/>
+			</SearchableList>
 
 			<Box marginTop={1} flexDirection="column">
 				<Text dimColor>
-					Controls: ↑↓/j/k Navigate, Space Select, Enter Confirm,{' '}
-					{shortcutManager.getShortcutDisplay('cancel')} Cancel
+					{isSearchMode
+						? 'Search Mode: Type to filter, Enter to exit search, ESC to exit search'
+						: `Controls: ↑↓/j/k Navigate, Space Select, Enter Confirm, /-Search, ${shortcutManager.getShortcutDisplay('cancel')} Cancel`}
 				</Text>
 				{selectedIndices.size > 0 && (
 					<Text color="yellow">

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {Box, Text, useInput, useStdout} from 'ink';
+import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 import {Effect} from 'effect';
 import {Worktree, Session, GitProject} from '../types/index.js';
@@ -19,8 +19,10 @@ import {
 } from '../utils/worktreeUtils.js';
 import {projectManager} from '../services/projectManager.js';
 import {RecentProject} from '../types/index.js';
-import TextInputWrapper from './TextInputWrapper.js';
 import {useSearchMode} from '../hooks/useSearchMode.js';
+import {useDynamicLimit} from '../hooks/useDynamicLimit.js';
+import {filterWorktreesByQuery} from '../utils/filterByQuery.js';
+import SearchableList from './SearchableList.js';
 import {globalSessionOrchestrator} from '../services/globalSessionOrchestrator.js';
 import {configReader} from '../services/config/configReader.js';
 
@@ -101,8 +103,6 @@ const Menu: React.FC<MenuProps> = ({
 		string | null
 	>(null);
 	const [autoApprovalToggleCounter, setAutoApprovalToggleCounter] = useState(0);
-	const {stdout} = useStdout();
-	const fixedRows = 6;
 
 	// Use the search mode hook
 	const {isSearchMode, searchQuery, selectedIndex, setSearchQuery} =
@@ -110,13 +110,10 @@ const Menu: React.FC<MenuProps> = ({
 			isDisabled: !!error || !!loadError,
 		});
 
-	const limit = Math.max(
-		5,
-		stdout.rows -
-			fixedRows -
-			(isSearchMode ? 1 : 0) -
-			(error || loadError ? 3 : 0),
-	);
+	const limit = useDynamicLimit({
+		isSearchMode,
+		hasError: !!(error || loadError),
+	});
 
 	// Get worktree configuration for sorting
 	const worktreeConfig = configReader.getWorktreeConfig();
@@ -217,16 +214,14 @@ const Menu: React.FC<MenuProps> = ({
 		const columnPositions = calculateColumnPositions(items);
 
 		// Filter worktrees based on search query
-		const filteredItems = searchQuery
-			? items.filter(item => {
-					const branchName = item.worktree.branch || '';
-					const searchLower = searchQuery.toLowerCase();
-					return (
-						branchName.toLowerCase().includes(searchLower) ||
-						item.worktree.path.toLowerCase().includes(searchLower)
-					);
-				})
-			: items;
+		const filteredWorktrees = filterWorktreesByQuery(
+			items.map(item => item.worktree),
+			searchQuery,
+		);
+		const filteredWorktreeSet = new Set(filteredWorktrees);
+		const filteredItems = items.filter(item =>
+			filteredWorktreeSet.has(item.worktree),
+		);
 
 		// Build menu items with proper alignment
 		const menuItems: MenuItem[] = filteredItems.map(
@@ -640,36 +635,16 @@ const Menu: React.FC<MenuProps> = ({
 				</Text>
 			</Box>
 
-			{isSearchMode && (
-				<Box marginBottom={1}>
-					<Text>Search: </Text>
-					<TextInputWrapper
-						value={searchQuery}
-						onChange={setSearchQuery}
-						focus={true}
-						placeholder="Type to filter worktrees..."
-					/>
-				</Box>
-			)}
-
-			{isSearchMode && items.length === 0 ? (
-				<Box>
-					<Text color="yellow">No worktrees match your search</Text>
-				</Box>
-			) : isSearchMode ? (
-				// In search mode, show the items as a list without SelectInput
-				<Box flexDirection="column">
-					{items.slice(0, limit).map((item, index) => (
-						<Text
-							key={item.value}
-							color={index === selectedIndex ? 'green' : undefined}
-						>
-							{index === selectedIndex ? '❯ ' : '  '}
-							{item.label}
-						</Text>
-					))}
-				</Box>
-			) : (
+			<SearchableList
+				isSearchMode={isSearchMode}
+				searchQuery={searchQuery}
+				onSearchQueryChange={setSearchQuery}
+				selectedIndex={selectedIndex}
+				items={items}
+				limit={limit}
+				placeholder="Type to filter worktrees..."
+				noMatchMessage="No worktrees match your search"
+			>
 				<SelectInput
 					items={items}
 					onSelect={item => handleSelect(item as MenuItem)}
@@ -688,7 +663,7 @@ const Menu: React.FC<MenuProps> = ({
 					initialIndex={selectedIndex}
 					limit={limit}
 				/>
-			)}
+			</SearchableList>
 
 			{(error || loadError) && (
 				<Box marginTop={1} paddingX={1} borderStyle="round" borderColor="red">

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -7,6 +7,7 @@ import {configReader} from '../services/config/configReader.js';
 import {generateWorktreeDirectory} from '../utils/worktreeUtils.js';
 import {WorktreeService} from '../services/worktreeService.js';
 import {useSearchMode} from '../hooks/useSearchMode.js';
+import SearchableList from './SearchableList.js';
 import {Effect} from 'effect';
 import type {AppError} from '../types/errors.js';
 import {
@@ -433,34 +434,16 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 					<Box marginBottom={1}>
 						<Text>Select base branch for the worktree:</Text>
 					</Box>
-					{isSearchMode && (
-						<Box marginBottom={1}>
-							<Text>Search: </Text>
-							<TextInputWrapper
-								value={searchQuery}
-								onChange={setSearchQuery}
-								focus={true}
-								placeholder="Type to filter branches..."
-							/>
-						</Box>
-					)}
-					{isSearchMode && branchItems.length === 0 ? (
-						<Box>
-							<Text color="yellow">No branches match your search</Text>
-						</Box>
-					) : isSearchMode ? (
-						<Box flexDirection="column">
-							{branchItems.slice(0, limit).map((item, index) => (
-								<Text
-									key={item.value}
-									color={index === selectedIndex ? 'green' : undefined}
-								>
-									{index === selectedIndex ? '❯ ' : '  '}
-									{item.label}
-								</Text>
-							))}
-						</Box>
-					) : (
+					<SearchableList
+						isSearchMode={isSearchMode}
+						searchQuery={searchQuery}
+						onSearchQueryChange={setSearchQuery}
+						selectedIndex={selectedIndex}
+						items={branchItems}
+						limit={limit}
+						placeholder="Type to filter branches..."
+						noMatchMessage="No branches match your search"
+					>
 						<SelectInput
 							items={branchItems}
 							onSelect={handleBaseBranchSelect}
@@ -468,7 +451,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 							limit={limit}
 							isFocused={!isSearchMode}
 						/>
-					)}
+					</SearchableList>
 					{!isSearchMode && (
 						<Box marginTop={1}>
 							<Text dimColor>Press / to search</Text>

--- a/src/components/SearchableList.tsx
+++ b/src/components/SearchableList.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {Box, Text} from 'ink';
+import TextInputWrapper from './TextInputWrapper.js';
+
+interface ListItem {
+	label: string;
+	value: string;
+}
+
+interface SearchableListProps {
+	isSearchMode: boolean;
+	searchQuery: string;
+	onSearchQueryChange: (query: string) => void;
+	selectedIndex: number;
+	items: ListItem[];
+	limit: number;
+	placeholder?: string;
+	noMatchMessage?: string;
+	children: React.ReactNode;
+}
+
+/**
+ * Shared search mode UI: search input, filtered result list, and no-match message.
+ * Wraps a SelectInput (passed as children) which is shown when not in search mode.
+ */
+const SearchableList: React.FC<SearchableListProps> = ({
+	isSearchMode,
+	searchQuery,
+	onSearchQueryChange,
+	selectedIndex,
+	items,
+	limit,
+	placeholder = 'Type to filter...',
+	noMatchMessage = 'No matches found',
+	children,
+}) => {
+	if (!isSearchMode) {
+		return <>{children}</>;
+	}
+
+	return (
+		<>
+			<Box marginBottom={1}>
+				<Text>Search: </Text>
+				<TextInputWrapper
+					value={searchQuery}
+					onChange={onSearchQueryChange}
+					focus={true}
+					placeholder={placeholder}
+				/>
+			</Box>
+
+			{items.length === 0 ? (
+				<Box>
+					<Text color="yellow">{noMatchMessage}</Text>
+				</Box>
+			) : (
+				<Box flexDirection="column">
+					{items.slice(0, limit).map((item, index) => (
+						<Text
+							key={item.value}
+							color={index === selectedIndex ? 'green' : undefined}
+						>
+							{index === selectedIndex ? '❯ ' : '  '}
+							{item.label}
+						</Text>
+					))}
+				</Box>
+			)}
+		</>
+	);
+};
+
+export default SearchableList;

--- a/src/hooks/useDynamicLimit.ts
+++ b/src/hooks/useDynamicLimit.ts
@@ -1,0 +1,19 @@
+import {useStdout} from 'ink';
+
+interface UseDynamicLimitOptions {
+	fixedRows?: number;
+	isSearchMode?: boolean;
+	hasError?: boolean;
+}
+
+/**
+ * Calculate the maximum number of list items to display based on terminal height.
+ */
+export function useDynamicLimit(options: UseDynamicLimitOptions = {}): number {
+	const {fixedRows = 6, isSearchMode = false, hasError = false} = options;
+	const {stdout} = useStdout();
+	return Math.max(
+		5,
+		stdout.rows - fixedRows - (isSearchMode ? 1 : 0) - (hasError ? 3 : 0),
+	);
+}

--- a/src/utils/filterByQuery.ts
+++ b/src/utils/filterByQuery.ts
@@ -1,0 +1,19 @@
+import {Worktree} from '../types/index.js';
+
+/**
+ * Filter worktrees by matching search query against branch name and path.
+ */
+export function filterWorktreesByQuery(
+	worktrees: Worktree[],
+	query: string,
+): Worktree[] {
+	if (!query) return worktrees;
+	const searchLower = query.toLowerCase();
+	return worktrees.filter(worktree => {
+		const branchName = worktree.branch || '';
+		return (
+			branchName.toLowerCase().includes(searchLower) ||
+			worktree.path.toLowerCase().includes(searchLower)
+		);
+	});
+}


### PR DESCRIPTION
## Summary
- Add slash (`/`) search and dynamic terminal-height-based scrolling to `DeleteWorktree`, matching `Menu`'s behavior
- Extract shared search/scroll patterns into reusable abstractions used across 4 components:
  - `SearchableList` component — search input + filtered list + no-match message
  - `useDynamicLimit` hook — terminal-height-based item limit calculation
  - `filterWorktreesByQuery` utility — worktree branch/path filtering

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (110 files, 1352 tests)
- [ ] Manual: open DeleteWorktree, press `/` to search, verify filtering by branch/path
- [ ] Manual: resize terminal, verify item count adjusts dynamically
- [ ] Manual: verify Menu, Dashboard, NewWorktree still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)