### PR TITLE
docs: add Auto Directory tip to worktree path input

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "3.12.1",
-        "@kodaikabasawa/ccmanager-darwin-x64": "3.12.1",
-        "@kodaikabasawa/ccmanager-linux-arm64": "3.12.1",
-        "@kodaikabasawa/ccmanager-linux-x64": "3.12.1",
-        "@kodaikabasawa/ccmanager-win32-x64": "3.12.1",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "3.12.2",
+        "@kodaikabasawa/ccmanager-darwin-x64": "3.12.2",
+        "@kodaikabasawa/ccmanager-linux-arm64": "3.12.2",
+        "@kodaikabasawa/ccmanager-linux-x64": "3.12.2",
+        "@kodaikabasawa/ccmanager-win32-x64": "3.12.2",
       },
     },
   },
@@ -127,15 +127,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.12.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9V0seczKBFo7f+kfISJSBrEfZLc58o0ZGcNC/Pi9aTUyqNjojr3HXEbwoOLfFuh6k93JVG5SrjBjBGRTYzbg0A=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@3.12.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u4alJhr0Ta+39gL4nMmGAgQ4I7Dy+OASpqFj3ayOKzFD9hBfrad+SCAbOVBBO0neFapfTRDiXaWqPtYXlEvvkA=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.12.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-otlWiIxwzsQpXHDrTV2y06y8E71oytbWr0+2Eq0nJtpWEkPxeF6Fr557gCmbfJdNcfknKDYw3//NxdIzhJSVyA=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@3.12.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-vgqfLeJkjGxYyVse4HNUXPdW3rWr2vFOwBdSRaKvr93IgwMXknus41o9U3M2eEeHVA5ht6/y0jgN2OF4R0V20w=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.12.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-OXXiQR4h9FwPS3Etvno+YG8N0sPTjlCjUv+kmeMqlPR/RZPcu5j/vsfIsxKL5pJULJN5cv9iGQnsZu3uvegYqA=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@3.12.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-D5w352YMNq6dmhKGJUZZwYCOgNW0XjAkZmKEKgDR/t/wg1qs7pRKNzudyNg7e8hoCbIpPM21x0BcusF4QKOHXQ=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.12.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Rv2yvf1epxH4pY91QyMLKA75pA0P3nnAc3wmx8hdkvj+fsPTyjF5JCyAY4+wyGHvI3xSFBKavDJjIWy7b3abaQ=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@3.12.2", "", { "os": "linux", "cpu": "x64" }, "sha512-8mEDRTFhSjS72Svh6vSrBvS7WlCyUjrP3o/Xfej/TGxVKhIz/KCdg3ktjtJUtdsBesNrlMHdiTV6CtLAMtttQg=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.12.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BdkU+6gowWW5ZquT336A+cgpfRTay5+xuYhp6tUzngWAsxCa7m04FKhUJsKIwSiR+aAr+5gc8uo98aivBU1B2w=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@3.12.2", "", { "os": "win32", "cpu": "x64" }, "sha512-pU+YZzmjuhkqHRW1SvaVofmRD9MyloDYkCtCNyURvLefFrOj6aJjsic2jULfOOOWJkSXWENP+67p7h6gv6KyDg=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -428,8 +428,9 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 					</Box>
 					<Box marginTop={1}>
 						<Text dimColor>
-							Tip: Enable "Auto Directory" in settings to generate paths
-							automatically from branch names.
+							{
+								'Tip: Enable "Auto Directory" in settings to generate paths automatically from branch names.'
+							}
 						</Text>
 					</Box>
 				</Box>


### PR DESCRIPTION
## Summary
- Add a hint text on the worktree path input screen informing users they can enable "Auto Directory" in settings to auto-generate paths from branch names.

## Test plan
- [ ] Run `npm run dev` and navigate to the new worktree creation flow
- [ ] Verify the tip text appears below the path input when Auto Directory is disabled
- [ ] Verify the tip does not appear when Auto Directory is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)