### PR TITLE
feat: always clear output history on screen clear

### DIFF
--- a/src/components/ConfigureOther.tsx
+++ b/src/components/ConfigureOther.tsx
@@ -34,10 +34,6 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 	const [customCommandDraft, setCustomCommandDraft] = useState(customCommand);
 	const [timeout, setTimeout] = useState(autoApprovalConfig.timeout ?? 30);
 	const [timeoutDraft, setTimeoutDraft] = useState(timeout);
-	const [clearHistoryOnClear, setClearHistoryOnClear] = useState(
-		autoApprovalConfig.clearHistoryOnClear ?? false,
-	);
-
 	// Show if inheriting from global (for project scope)
 	const isInheriting =
 		scope === 'project' && !configEditor.hasProjectOverride('autoApproval');
@@ -72,10 +68,6 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 			value: 'timeout',
 		},
 		{
-			label: `Clear History on Screen Clear: ${clearHistoryOnClear ? '✅ Enabled' : '❌ Disabled'}`,
-			value: 'toggleClearHistory',
-		},
-		{
 			label: '💾 Save Changes',
 			value: 'save',
 		},
@@ -98,15 +90,11 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 				setTimeoutDraft(timeout);
 				setView('timeout');
 				break;
-			case 'toggleClearHistory':
-				setClearHistoryOnClear(!clearHistoryOnClear);
-				break;
 			case 'save':
 				configEditor.setAutoApprovalConfig({
 					enabled: autoApprovalEnabled,
 					customCommand: customCommand.trim() || undefined,
 					timeout,
-					clearHistoryOnClear,
 				});
 				onComplete();
 				break;
@@ -178,16 +166,6 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 			</Box>
 
 			<CustomCommandSummary command={customCommand} />
-
-			{clearHistoryOnClear && (
-				<Box marginBottom={1}>
-					<Text dimColor>
-						Clear History: When enabled, session output history is cleared when
-						a screen clear escape sequence is detected (e.g., /clear command).
-						This prevents excessive scrolling during session restoration.
-					</Text>
-				</Box>
-			)}
 
 			<SelectInput items={menuItems} onSelect={handleSelect} isFocused />
 

--- a/src/services/config/configReader.ts
+++ b/src/services/config/configReader.ts
@@ -127,11 +127,6 @@ export class ConfigReader implements IConfigReader {
 		return this.getAutoApprovalConfig().enabled;
 	}
 
-	// Check if clear history on clear is enabled
-	isClearHistoryOnClearEnabled(): boolean {
-		return this.getAutoApprovalConfig().clearHistoryOnClear ?? false;
-	}
-
 	// Command Preset methods - delegate to global config for modifications
 	getDefaultPreset(): CommandPreset {
 		const presets = this.getCommandPresets();

--- a/src/services/config/globalConfigManager.ts
+++ b/src/services/config/globalConfigManager.ts
@@ -104,7 +104,6 @@ class GlobalConfigManager implements IConfigEditor {
 			this.config.autoApproval = {
 				enabled: false,
 				timeout: 30,
-				clearHistoryOnClear: false,
 			};
 		} else {
 			if (
@@ -122,14 +121,6 @@ class GlobalConfigManager implements IConfigEditor {
 				)
 			) {
 				this.config.autoApproval.timeout = 30;
-			}
-			if (
-				!Object.prototype.hasOwnProperty.call(
-					this.config.autoApproval,
-					'clearHistoryOnClear',
-				)
-			) {
-				this.config.autoApproval.clearHistoryOnClear = false;
 			}
 		}
 

--- a/src/services/sessionManager.statePersistence.test.ts
+++ b/src/services/sessionManager.statePersistence.test.ts
@@ -48,7 +48,6 @@ vi.mock('./config/configReader.js', () => ({
 		getWorktreeLastOpened: vi.fn(() => ({})),
 		isAutoApprovalEnabled: vi.fn(() => false),
 		setAutoApprovalEnabled: vi.fn(),
-		isClearHistoryOnClearEnabled: vi.fn(() => false),
 	},
 }));
 

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -34,7 +34,6 @@ vi.mock('./config/configReader.js', () => ({
 		getWorktreeLastOpened: vi.fn(() => ({})),
 		isAutoApprovalEnabled: vi.fn(() => false),
 		setAutoApprovalEnabled: vi.fn(),
-		isClearHistoryOnClearEnabled: vi.fn(() => false),
 	},
 }));
 
@@ -1194,16 +1193,13 @@ describe('SessionManager', () => {
 	});
 
 	describe('clearHistoryOnClear', () => {
-		it('should clear output history when screen clear escape sequence is detected and setting is enabled', async () => {
+		it('should clear output history when screen clear escape sequence is detected', async () => {
 			// Setup
 			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
 				id: '1',
 				name: 'Main',
 				command: 'claude',
 			});
-			vi.mocked(configReader.isClearHistoryOnClearEnabled).mockReturnValue(
-				true,
-			);
 			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
 
 			// Create session
@@ -1226,47 +1222,13 @@ describe('SessionManager', () => {
 			expect(session.outputHistory[0]?.toString()).toBe('\x1B[2J');
 		});
 
-		it('should not clear output history when screen clear escape sequence is detected but setting is disabled', async () => {
+		it('should not clear output history for normal data', async () => {
 			// Setup
 			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
 				id: '1',
 				name: 'Main',
 				command: 'claude',
 			});
-			vi.mocked(configReader.isClearHistoryOnClearEnabled).mockReturnValue(
-				false,
-			);
-			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
-
-			// Create session
-			const session = await Effect.runPromise(
-				sessionManager.createSessionWithPresetEffect('/test/worktree'),
-			);
-
-			// Simulate some data output
-			mockPty.emit('data', 'Hello World');
-			mockPty.emit('data', 'More data');
-
-			// Verify output history has data
-			expect(session.outputHistory.length).toBe(2);
-
-			// Simulate screen clear escape sequence
-			mockPty.emit('data', '\x1B[2J');
-
-			// Verify output history was NOT cleared
-			expect(session.outputHistory.length).toBe(3);
-		});
-
-		it('should not clear output history for normal data when setting is enabled', async () => {
-			// Setup
-			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
-				id: '1',
-				name: 'Main',
-				command: 'claude',
-			});
-			vi.mocked(configReader.isClearHistoryOnClearEnabled).mockReturnValue(
-				true,
-			);
 			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
 
 			// Create session
@@ -1290,9 +1252,6 @@ describe('SessionManager', () => {
 				name: 'Main',
 				command: 'claude',
 			});
-			vi.mocked(configReader.isClearHistoryOnClearEnabled).mockReturnValue(
-				true,
-			);
 			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
 
 			// Create session

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -426,12 +426,9 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			session.terminal.write(data);
 
 			// Check for screen clear escape sequence (e.g., from /clear command)
-			// When enabled and detected, clear the output history to prevent replaying old content on restore
+			// When detected, clear the output history to prevent replaying old content on restore
 			// This helps avoid excessive scrolling when restoring sessions with large output history
-			if (
-				configReader.isClearHistoryOnClearEnabled() &&
-				data.includes('\x1B[2J')
-			) {
+			if (data.includes('\x1B[2J')) {
 				session.outputHistory = [];
 			}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,7 +154,6 @@ export interface ConfigurationData {
 		enabled: boolean; // Whether auto-approval is enabled
 		customCommand?: string; // Custom verification command; must output JSON matching AutoApprovalResponse
 		timeout?: number; // Timeout in seconds for auto-approval verification (default: 30)
-		clearHistoryOnClear?: boolean; // Clear output history when screen clear escape sequence is detected
 	};
 }
 
@@ -165,7 +164,6 @@ export interface AutoApprovalConfig {
 	enabled: boolean;
 	customCommand?: string;
 	timeout?: number;
-	clearHistoryOnClear?: boolean; // Clear output history when screen clear escape sequence is detected
 }
 
 export interface ProjectConfigurationData {


### PR DESCRIPTION
## Summary
- Remove the experimental `clearHistoryOnClear` config toggle and make screen clear history cleanup always active
- Remove the UI toggle from ConfigureOther settings
- Remove the `clearHistoryOnClear` field from types, config reader, and global config manager

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1397 passed)
- [ ] Verify that `/clear` in a session clears output history (no excessive scrolling on session restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)