### PR TITLE
fix: disable auto-wrap on xterm-headless to prevent false busy detection

### DIFF
--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -293,12 +293,18 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	}
 
 	private createTerminal(): pkg.Terminal {
-		return new Terminal({
+		const terminal = new Terminal({
 			cols: process.stdout.columns || 80,
 			rows: process.stdout.rows || 24,
 			allowProposedApi: true,
 			logLevel: 'off',
 		});
+		// Disable auto-wrap to match the real terminal setting (Session.tsx sends
+		// \x1b[?7l to stdout).  Without this, long lines wrap in xterm-headless but
+		// are clipped on the real terminal, causing Ink's cursor-up re-render to
+		// leave ghost content (old spinners, "esc to interrupt", etc.) in the buffer.
+		terminal.write('\x1b[?7l');
+		return terminal;
 	}
 
 	private async createSessionInternal(


### PR DESCRIPTION
## Summary
- `Session.tsx` disables auto-wrap (`\x1b[?7l`) on the real terminal, but the xterm-headless virtual terminal kept the default (auto-wrap enabled)
- This caused long lines to wrap differently in xterm-headless vs the real terminal, so when Ink re-renders with cursor-up, old content (spinners, "esc to interrupt", etc.) was never overwritten in the virtual buffer
- The state detector then read this ghost content and falsely detected "busy" from leftover spinner patterns
- Fix: write `\x1b[?7l` to the xterm-headless terminal at creation time to match the real terminal's behavior

## Test plan
- [x] lint: pass
- [x] typecheck: pass
- [x] tests: all pass (1 pre-existing failure unrelated to this change)
- [ ] Manual verification: open a session, let Claude finish a task, confirm state correctly shows idle (no false busy detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)