### PR TITLE
feat: add defense-in-depth safety layer for auto-approval

### DIFF
--- a/src/services/autoApprovalVerifier.test.ts
+++ b/src/services/autoApprovalVerifier.test.ts
@@ -3,8 +3,11 @@ import {Effect} from 'effect';
 import {EventEmitter} from 'events';
 import type {ChildProcess} from 'child_process';
 import type {Writable} from 'node:stream';
+import {homedir} from 'os';
 import {
 	checkDangerousPatterns,
+	allAbsolutePathsUnderCwd,
+	resolveTildePath,
 	DANGEROUS_COMMAND_PATTERNS,
 } from './autoApprovalVerifier.js';
 
@@ -480,5 +483,140 @@ describe('checkDangerousPatterns', () => {
 		);
 		const uniquePatterns = new Set(patternStrings);
 		expect(uniquePatterns.size).toBe(patternStrings.length);
+	});
+
+	describe('cwd-aware: allows path-sensitive patterns when paths are under cwd', () => {
+		const cwd = '/home/user/project';
+
+		it.each([
+			['rm -rf /home/user/project/dist', 'rm -rf under cwd (absolute)'],
+			[
+				'rm -rf /home/user/project/node_modules',
+				'rm -rf node_modules (absolute)',
+			],
+			['rm -f /home/user/project/tmp/file.log', 'rm -f under cwd'],
+			['rm /home/user/project/old-file', 'rm under cwd (no flags)'],
+		])('allows: %s (%s)', input => {
+			const result = checkDangerousPatterns(input, cwd);
+			expect(result).toBeNull();
+		});
+
+		it.each([
+			['rm -rf /home/user/other-project/dist', 'rm -rf outside cwd'],
+			['rm -rf /tmp/something', 'rm -rf /tmp (not under cwd)'],
+			['rm -rf /home/user/project/../secrets', 'rm -rf traversal outside cwd'],
+			['rm -rf /', 'rm -rf / (root)'],
+		])('still blocks: %s (%s)', input => {
+			const result = checkDangerousPatterns(input, cwd);
+			expect(result).not.toBeNull();
+			expect(result?.needsPermission).toBe(true);
+		});
+
+		it('allows chmod -R on path under cwd', () => {
+			const result = checkDangerousPatterns(
+				'chmod -R 755 /home/user/project/dist',
+				cwd,
+			);
+			expect(result).toBeNull();
+		});
+
+		it('blocks chmod -R on path outside cwd', () => {
+			const result = checkDangerousPatterns(
+				'chmod -R 755 /home/other/stuff',
+				cwd,
+			);
+			expect(result).not.toBeNull();
+		});
+
+		it('allows chown -R on path under cwd', () => {
+			const result = checkDangerousPatterns(
+				'chown -R user:user /home/user/project/build',
+				cwd,
+			);
+			expect(result).toBeNull();
+		});
+
+		it('blocks chown -R on path outside cwd', () => {
+			const result = checkDangerousPatterns('chown -R user:user /var/log', cwd);
+			expect(result).not.toBeNull();
+		});
+
+		it('blocks when no cwd is provided even for project-like paths', () => {
+			const result = checkDangerousPatterns('rm -rf /home/user/project/dist');
+			expect(result).not.toBeNull();
+		});
+	});
+
+	describe('cwd-aware: tilde paths resolved against home directory', () => {
+		it('allows rm ~/project/dist when cwd matches expanded path', () => {
+			const home = homedir();
+			const cwd = `${home}/project`;
+			const result = checkDangerousPatterns('rm -rf ~/project/dist', cwd);
+			expect(result).toBeNull();
+		});
+
+		it('blocks rm ~/other when cwd is different', () => {
+			const home = homedir();
+			const cwd = `${home}/project`;
+			const result = checkDangerousPatterns('rm -rf ~/other/dist', cwd);
+			expect(result).not.toBeNull();
+		});
+	});
+});
+
+describe('allAbsolutePathsUnderCwd', () => {
+	const cwd = '/home/user/project';
+
+	it('returns true when all paths are under cwd', () => {
+		expect(
+			allAbsolutePathsUnderCwd('rm -rf /home/user/project/dist', cwd),
+		).toBe(true);
+	});
+
+	it('returns true for exact cwd path', () => {
+		expect(allAbsolutePathsUnderCwd('rm -rf /home/user/project', cwd)).toBe(
+			true,
+		);
+	});
+
+	it('returns false when any path is outside cwd', () => {
+		expect(
+			allAbsolutePathsUnderCwd('rm -rf /home/user/project/dist /tmp/bad', cwd),
+		).toBe(false);
+	});
+
+	it('returns false when no absolute paths found', () => {
+		expect(allAbsolutePathsUnderCwd('rm -rf node_modules', cwd)).toBe(false);
+	});
+
+	it('returns false for parent traversal', () => {
+		expect(
+			allAbsolutePathsUnderCwd('rm -rf /home/user/project/../secrets', cwd),
+		).toBe(false);
+	});
+
+	it('resolves tilde paths using home directory', () => {
+		const home = homedir();
+		const cwdWithHome = `${home}/myproject`;
+		expect(
+			allAbsolutePathsUnderCwd('rm -rf ~/myproject/dist', cwdWithHome),
+		).toBe(true);
+		expect(allAbsolutePathsUnderCwd('rm -rf ~/other', cwdWithHome)).toBe(false);
+	});
+});
+
+describe('resolveTildePath', () => {
+	it('expands ~ to home directory', () => {
+		const home = homedir();
+		expect(resolveTildePath('~')).toBe(home);
+	});
+
+	it('expands ~/path to home directory + path', () => {
+		const home = homedir();
+		expect(resolveTildePath('~/Documents')).toBe(`${home}/Documents`);
+	});
+
+	it('returns absolute paths unchanged', () => {
+		expect(resolveTildePath('/etc/passwd')).toBe('/etc/passwd');
 	});
 });

--- a/src/services/autoApprovalVerifier.ts
+++ b/src/services/autoApprovalVerifier.ts
@@ -10,6 +10,8 @@ import {
 	type ExecFileOptionsWithStringEncoding,
 	type SpawnOptions,
 } from 'child_process';
+import {homedir} from 'os';
+import path from 'path';
 
 const DEFAULT_TIMEOUT_SECONDS = 30;
 
@@ -62,17 +64,21 @@ Respond with ONLY valid JSON matching: {“needsPermission”: true|false, “re
 export const DANGEROUS_COMMAND_PATTERNS: ReadonlyArray<{
 	pattern: RegExp;
 	reason: string;
+	pathSensitive?: boolean;
 }> = [
 	// --- Destructive file operations targeting system / home paths ---
 	// NOTE: project-scoped rm (e.g. rm -rf node_modules, rm -f dist/) is intentionally
 	// NOT blocked here. Only rm targeting system-critical or home paths is blocked.
+	// pathSensitive: if the absolute path resolves to inside cwd, allow it.
 	{
 		pattern: /\brm\s+-[a-zA-Z]*\s+(['”]?\/|['”]?~)/,
 		reason: 'File deletion targeting root or home directory',
+		pathSensitive: true,
 	},
 	{
 		pattern: /\brm\s+(['”]?\/|['”]?~\/)/,
 		reason: 'File deletion targeting root or home directory',
+		pathSensitive: true,
 	},
 
 	// --- Disk / filesystem destruction ---
@@ -220,11 +226,13 @@ export const DANGEROUS_COMMAND_PATTERNS: ReadonlyArray<{
 		pattern:
 			/\bchmod\s+-[a-zA-Z]*R[a-zA-Z]*\s+\S+\s+(\/(?:\s|$)|~\/|\/etc(?:\s|\/|$)|\/var(?:\s|\/|$)|\/home(?:\s|\/|$))/,
 		reason: 'Recursive permission change on sensitive path',
+		pathSensitive: true,
 	},
 	{
 		pattern:
 			/\bchown\s+-[a-zA-Z]*R[a-zA-Z]*\s+\S+\s+(\/(?:\s|$)|~\/|\/etc(?:\s|\/|$)|\/var(?:\s|\/|$)|\/home(?:\s|\/|$))/,
 		reason: 'Recursive ownership change on sensitive path',
+		pathSensitive: true,
 	},
 
 	// --- Process mass-kill ---
@@ -294,14 +302,60 @@ export const DANGEROUS_COMMAND_PATTERNS: ReadonlyArray<{
 ];
 
 /**
+ * Regex to extract absolute/tilde paths from commands in terminal output.
+ * Matches paths starting with / or ~ that follow typical command arguments.
+ */
+const ABSOLUTE_PATH_RE = /['"]?([/~][^\s'"]*)/g;
+
+/**
+ * Resolve a path that may start with ~ to an absolute path.
+ */
+export const resolveTildePath = (p: string): string => {
+	if (p === '~') return homedir();
+	if (p.startsWith('~/')) return path.join(homedir(), p.slice(2));
+	return p;
+};
+
+/**
+ * Check whether every absolute/tilde path found in the terminal output
+ * is located within the given cwd. Returns true only if at least one path
+ * was found AND all of them are under cwd.
+ * Paths are resolved via path.resolve to normalize traversals like "..".
+ */
+export const allAbsolutePathsUnderCwd = (
+	terminalOutput: string,
+	cwd: string,
+): boolean => {
+	const resolvedCwd = path.resolve(cwd);
+	const normalizedCwd = resolvedCwd + '/';
+	const matches = [...terminalOutput.matchAll(ABSOLUTE_PATH_RE)];
+	const paths = matches.map(m => path.resolve(resolveTildePath(m[1]!)));
+	if (paths.length === 0) return false;
+	return paths.every(p => p === resolvedCwd || p.startsWith(normalizedCwd));
+};
+
+/**
  * Check terminal output against the hardcoded dangerous command blocklist.
  * Returns a matching result if a dangerous pattern is found, or null if safe.
+ *
+ * @param terminalOutput - Terminal output to analyze
+ * @param cwd - Optional working directory. If provided, path-sensitive patterns
+ *              will allow commands whose target paths are all within cwd.
  */
 export const checkDangerousPatterns = (
 	terminalOutput: string,
+	cwd?: string,
 ): AutoApprovalResponse | null => {
-	for (const {pattern, reason} of DANGEROUS_COMMAND_PATTERNS) {
+	for (const {pattern, reason, pathSensitive} of DANGEROUS_COMMAND_PATTERNS) {
 		if (pattern.test(terminalOutput)) {
+			// For path-sensitive patterns, skip if all absolute paths are under cwd
+			if (
+				pathSensitive &&
+				cwd &&
+				allAbsolutePathsUnderCwd(terminalOutput, cwd)
+			) {
+				continue;
+			}
 			return {needsPermission: true, reason};
 		}
 	}
@@ -537,10 +591,10 @@ export class AutoApprovalVerifier {
 	 */
 	verifyNeedsPermission(
 		terminalOutput: string,
-		options?: {signal?: AbortSignal},
+		options?: {signal?: AbortSignal; cwd?: string},
 	): Effect.Effect<AutoApprovalResponse, ProcessError, never> {
 		// Deterministic blocklist check BEFORE LLM — cannot be bypassed by prompt injection
-		const blockedResult = checkDangerousPatterns(terminalOutput);
+		const blockedResult = checkDangerousPatterns(terminalOutput, options?.cwd);
 		if (blockedResult) {
 			logger.info(
 				`Auto-approval blocked by dangerous pattern: ${blockedResult.reason}`,

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -151,6 +151,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		void Effect.runPromise(
 			autoApprovalVerifier.verifyNeedsPermission(terminalContent, {
 				signal: abortController.signal,
+				cwd: session.worktreePath,
 			}),
 		)
 			.then(async autoApprovalResult => {


### PR DESCRIPTION
## Summary
- Add a deterministic regex blocklist (`DANGEROUS_COMMAND_PATTERNS`) that checks terminal output **before** the LLM evaluation, preventing prompt injection from bypassing safety checks
- Wrap terminal output in `<terminal-output>` XML tags in the LLM prompt with explicit instructions to ignore directives inside the tags, mitigating prompt injection
- Project-scoped operations (`rm -rf node_modules`, `git push --force`, etc.) are intentionally **not** blocked by the regex layer — safety for these is delegated to the LLM

### Blocklist coverage
- System/home path destruction (`rm /`, `rm ~/`, `mkfs`, `dd`, `shred`, `wipefs`, `fdisk`, `parted`)
- Fork bombs
- Privilege escalation (`sudo rm/dd/mkfs/chmod/chown/sh/bash/su`)
- System shutdown/reboot/halt/poweroff
- Critical path overwrites (`/dev/`, `/etc/`, `/boot/`)
- Credential exfiltration (piping keys/secrets to `curl`/`wget`/`nc`)
- Dangerous eval/pipe patterns (`eval $(curl ...)`, `curl | bash`)
- Recursive permission/ownership changes on sensitive paths
- Process mass-kill (`killall`, `pkill -9`, `kill -9 -1`)
- Docker privileged/mass-removal
- Python/Node.js dangerous one-liners
- Firewall/crontab/systemd/launchctl manipulation

## Test plan
- [x] 81 test cases covering all blocklist categories, safe-output passthrough, project-scoped allowances, markup tag presence, and LLM bypass verification
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun vitest --run --dir src` — 775 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)