### PR TITLE
feat: add CCMANAGER_WORKTREE_DIR env var to status hooks

### DIFF
--- a/docs/status-hooks.md
+++ b/docs/status-hooks.md
@@ -50,5 +50,6 @@ tmux set -g status-right "Claude: $CCMANAGER_NEW_STATE" && noti -t "Claude Statu
 - `CCMANAGER_OLD_STATE`: Previous state (idle, busy, waiting_input)
 - `CCMANAGER_NEW_STATE`: New state (idle, busy, waiting_input)
 - `CCMANAGER_WORKTREE_PATH`: Path to the worktree where status changed
+- `CCMANAGER_WORKTREE_DIR`: Parent directory containing the worktree
 - `CCMANAGER_WORKTREE_BRANCH`: Git branch name of the worktree
 - `CCMANAGER_SESSION_ID`: Unique session identifier

--- a/src/components/ConfigureStatusHooks.tsx
+++ b/src/components/ConfigureStatusHooks.tsx
@@ -178,7 +178,7 @@ const ConfigureStatusHooks: React.FC<ConfigureStatusHooksProps> = ({
 				</Box>
 				<Box>
 					<Text dimColor>
-						{`CCMANAGER_WORKTREE_PATH, CCMANAGER_WORKTREE_BRANCH, CCMANAGER_SESSION_ID`}
+						{`CCMANAGER_WORKTREE_PATH, CCMANAGER_WORKTREE_DIR, CCMANAGER_WORKTREE_BRANCH, CCMANAGER_SESSION_ID`}
 					</Text>
 				</Box>
 

--- a/src/utils/hookExecutor.ts
+++ b/src/utils/hookExecutor.ts
@@ -1,4 +1,5 @@
 import {spawn} from 'child_process';
+import {dirname} from 'path';
 import {Effect} from 'effect';
 import {ProcessError} from '../types/errors.js';
 import {Worktree, Session, SessionState} from '../types/index.js';
@@ -210,6 +211,7 @@ export function executeStatusHook(
 		// Build environment for status hook
 		const environment: HookEnvironment = {
 			CCMANAGER_WORKTREE_PATH: session.worktreePath,
+			CCMANAGER_WORKTREE_DIR: dirname(session.worktreePath),
 			CCMANAGER_WORKTREE_BRANCH: branch,
 			CCMANAGER_GIT_ROOT: session.worktreePath, // For status hooks, we use worktree path as cwd
 			CCMANAGER_OLD_STATE: oldState,


### PR DESCRIPTION
## Summary
- Add `CCMANAGER_WORKTREE_DIR` environment variable to status hooks, providing the parent directory of the worktree path (`path.dirname(worktreePath)`)
- Update the UI hint in ConfigureStatusHooks to list the new variable
- Update status hooks documentation with the new variable

## Test plan
- [x] Typecheck passes
- [x] All 20 hookExecutor tests pass
- [ ] Manually configure a status hook using `$CCMANAGER_WORKTREE_DIR` and verify the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)