### PR TITLE
fix: change cursor default command to 'agent'

### DIFF
--- a/src/components/ConfigureCommand.tsx
+++ b/src/components/ConfigureCommand.tsx
@@ -45,7 +45,7 @@ const DEFAULT_COMMANDS: Record<StateDetectionStrategy, string> = {
 	claude: 'claude',
 	gemini: 'gemini',
 	codex: 'codex',
-	cursor: 'cursor',
+	cursor: 'agent',
 	'github-copilot': 'copilot',
 	cline: 'cline',
 	opencode: 'opencode',


### PR DESCRIPTION
## Summary
- Change the default command for the `cursor` detection strategy from `cursor` to `agent`

## Test plan
- [ ] Verify adding a new preset with cursor strategy auto-fills `agent` as the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)