### PR TITLE
feat: detect approval prompts as waiting_input in Cursor state detector

### DIFF
--- a/src/services/stateDetector/cursor.test.ts
+++ b/src/services/stateDetector/cursor.test.ts
@@ -101,6 +101,50 @@ describe('CursorStateDetector', () => {
 		expect(state).toBe('waiting_input');
 	});
 
+	it('should detect waiting_input state for Allow ... (y) pattern', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Allow this web search?',
+			' → Allow search (y)',
+			'   Run Everything (shift+tab)',
+			'   Skip (esc or n)',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal, 'idle');
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
+
+	it('should detect waiting_input state for Run ... (y) pattern', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Run this command?',
+			'Not in allowlist: cd /some/path, npm run test',
+			' → Run (once) (y)',
+			'   Run Everything (shift+tab)',
+			'   Skip (esc or n)',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal, 'idle');
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
+
+	it('should detect waiting_input state for Skip (esc or n) pattern', () => {
+		// Arrange
+		terminal = createMockTerminal(['Some prompt', '   Skip (esc or n)']);
+
+		// Act
+		const state = detector.detectState(terminal, 'idle');
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
+
 	it('should detect busy state for ctrl+c to stop pattern', () => {
 		// Arrange
 		terminal = createMockTerminal([

--- a/src/services/stateDetector/cursor.ts
+++ b/src/services/stateDetector/cursor.ts
@@ -10,7 +10,10 @@ export class CursorStateDetector extends BaseStateDetector {
 		if (
 			lowerContent.includes('(y) (enter)') ||
 			lowerContent.includes('keep (n)') ||
-			/auto .* \(shift\+tab\)/.test(lowerContent)
+			/auto .* \(shift\+tab\)/.test(lowerContent) ||
+			/allow .+ \(y\)/.test(lowerContent) ||
+			/run .+ \(y\)/.test(lowerContent) ||
+			lowerContent.includes('skip (esc or n)')
 		) {
 			return 'waiting_input';
 		}


### PR DESCRIPTION
## Summary
- Add detection for Claude Code approval prompts (`Allow ... (y)`, `Run ... (y)`, `Skip (esc or n)`) as `waiting_input` state in `CursorStateDetector`
- Add 3 new test cases covering each pattern

## Test plan
- [x] All existing tests pass (1631 passed)
- [x] Lint and typecheck pass
- [x] New tests verify Allow, Run, and Skip prompt patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)