### PR TITLE
fix: strip libvterm terminal auto-responses from PTY output

### DIFF
--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -3,6 +3,7 @@ import {useStdout} from 'ink';
 import {Session as ISession} from '../types/index.js';
 import {SessionManager} from '../services/sessionManager.js';
 import {shortcutManager} from '../services/shortcutManager.js';
+import {stripBunTerminalAutoResponses} from '../utils/stripBunTerminalAutoResponses.js';
 
 interface SessionProps {
 	session: ISession;
@@ -57,11 +58,13 @@ const Session: React.FC<SessionProps> = ({
 		const sanitizeReplayBuffer = (input: string): string => {
 			// Remove terminal mode toggles emitted by Codex so replay doesn't re-enable them
 			// on our own TTY when restoring the session view.
-			return stripOscColorSequences(input)
-				.replace(/\x1B\[>4;?\d*m/g, '') // modifyOtherKeys set/reset
-				.replace(/\x1B\[>[0-9;]*u/g, '') // kitty keyboard protocol enables
-				.replace(/\x1B\[\?1004[hl]/g, '') // focus tracking
-				.replace(/\x1B\[\?2004[hl]/g, ''); // bracketed paste
+			return stripBunTerminalAutoResponses(
+				stripOscColorSequences(input)
+					.replace(/\x1B\[>4;?\d*m/g, '') // modifyOtherKeys set/reset
+					.replace(/\x1B\[>[0-9;]*u/g, '') // kitty keyboard protocol enables
+					.replace(/\x1B\[\?1004[hl]/g, '') // focus tracking
+					.replace(/\x1B\[\?2004[hl]/g, ''), // bracketed paste
+			);
 		};
 
 		// Reset modes immediately on entry in case a previous session left them on

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -31,6 +31,7 @@ import {
 import {getTerminalScreenContent} from '../utils/screenCapture.js';
 import {injectTeammateMode} from '../utils/commandArgs.js';
 import {preparePresetLaunch} from '../utils/presetPrompt.js';
+import {createBunTerminalOutputSanitizer} from '../utils/stripBunTerminalAutoResponses.js';
 const {Terminal} = pkg;
 const execAsync = promisify(exec);
 const TERMINAL_CONTENT_MAX_LINES = 300;
@@ -414,10 +415,14 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	}
 
 	private setupDataHandler(session: Session): void {
+		const sanitizer = createBunTerminalOutputSanitizer();
+
 		// This handler always runs for all data
 		session.process.onData((data: string) => {
+			const cleaned = sanitizer.push(data);
+
 			// Write data to virtual terminal
-			session.terminal.write(data);
+			session.terminal.write(cleaned);
 
 			// Check for screen clear escape sequence (e.g., from /clear command)
 			// When detected, clear the output history to prevent replaying old content on restore
@@ -426,8 +431,14 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				session.outputHistory = [];
 			}
 
+			session.lastActivity = new Date();
+
+			if (cleaned.length === 0) {
+				return;
+			}
+
 			// Store in output history as Buffer
-			const buffer = Buffer.from(data, 'utf8');
+			const buffer = Buffer.from(cleaned, 'utf8');
 			session.outputHistory.push(buffer);
 
 			// Limit memory usage - keep max 10MB of output history
@@ -443,11 +454,9 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				}
 			}
 
-			session.lastActivity = new Date();
-
 			// Only emit data events when session is active
 			if (session.isActive) {
-				this.emit('sessionData', session, data);
+				this.emit('sessionData', session, cleaned);
 			}
 		});
 	}

--- a/src/utils/stripBunTerminalAutoResponses.test.ts
+++ b/src/utils/stripBunTerminalAutoResponses.test.ts
@@ -1,0 +1,49 @@
+import {describe, it, expect} from 'vitest';
+import {
+	stripBunTerminalAutoResponses,
+	createBunTerminalOutputSanitizer,
+} from './stripBunTerminalAutoResponses.js';
+
+describe('stripBunTerminalAutoResponses', () => {
+	it('removes libvterm DCS identify and Primary DA response', () => {
+		const raw = 'prompt\x1bP>|libvterm(0.3)\x1b\\\x1b[?1;2ctail';
+		expect(stripBunTerminalAutoResponses(raw)).toBe('prompttail');
+	});
+
+	it('removes Secondary DA-style response', () => {
+		const raw = 'x\x1b[>65;320;1c\n';
+		expect(stripBunTerminalAutoResponses(raw)).toBe('x\n');
+	});
+
+	it('preserves normal SGR and cursor sequences', () => {
+		const raw = '\x1b[31mred\x1b[0m\x1b[2J';
+		expect(stripBunTerminalAutoResponses(raw)).toBe(raw);
+	});
+
+	it('handles BEL-terminated DCS', () => {
+		const raw = 'a\x1bP>|libvterm(0.3)\x07b';
+		expect(stripBunTerminalAutoResponses(raw)).toBe('ab');
+	});
+});
+
+describe('createBunTerminalOutputSanitizer', () => {
+	it('strips auto-responses split across chunks', () => {
+		const s = createBunTerminalOutputSanitizer();
+		expect(s.push('pre\x1bP>|lib')).toBe('pre');
+		expect(s.push('vterm(0.3)\x1b\\\x1b[?1;2c')).toBe('');
+		expect(s.push('ok')).toBe('ok');
+	});
+
+	it('holds trailing ESC until continuation arrives', () => {
+		const s = createBunTerminalOutputSanitizer();
+		expect(s.push('ok\x1b')).toBe('ok');
+		expect(s.push('[?1;2c')).toBe('');
+		expect(s.push('.')).toBe('.');
+	});
+
+	it('flush emits carry after strip', () => {
+		const s = createBunTerminalOutputSanitizer();
+		expect(s.push('z\x1b')).toBe('z');
+		expect(s.flush()).toBe('\x1b');
+	});
+});

--- a/src/utils/stripBunTerminalAutoResponses.ts
+++ b/src/utils/stripBunTerminalAutoResponses.ts
@@ -1,0 +1,69 @@
+/**
+ * Strip terminal auto-responses that Bun's libvterm-backed `Bun.Terminal` can
+ * incorrectly merge into the PTY master read stream. Those bytes are meant for
+ * the child process (injected as input), not for the host that forwards output.
+ *
+ * @see https://bun.com/reference/bun/Terminal — no options to disable this behavior.
+ */
+
+/** xterm-style DCS terminal version / identify, terminated with ST or BEL */
+const DCS_VERSION_OR_IDENT = /\x1bP>\|[^\x07\x1b]*(?:\x1b\\|\x07)/g;
+
+/** Primary DA-style responses (CSI ? ... c) */
+const PRIMARY_DA_RESPONSE = /\x1b\[\?[0-9;]*c/g;
+
+/** Secondary DA-style responses (CSI > ... c) */
+const SECONDARY_DA_RESPONSE = /\x1b\[>[0-9;]*c/g;
+
+export function stripBunTerminalAutoResponses(input: string): string {
+	return input
+		.replace(DCS_VERSION_OR_IDENT, '')
+		.replace(PRIMARY_DA_RESPONSE, '')
+		.replace(SECONDARY_DA_RESPONSE, '');
+}
+
+/**
+ * Peel trailing bytes that might be an incomplete escape when chunks split
+ * across PTY reads. Everything before the peel is stripped and returned;
+ * the suffix is held until the next `push`.
+ */
+function peelIncompleteSuffix(s: string): {work: string; carry: string} {
+	if (s.length === 0) {
+		return {work: '', carry: ''};
+	}
+	if (s.endsWith('\x1b')) {
+		return {work: s.slice(0, -1), carry: '\x1b'};
+	}
+	const lastP = s.lastIndexOf('\x1bP');
+	if (lastP !== -1) {
+		const tail = s.slice(lastP);
+		if (!/\x1b\\|\x07/.test(tail)) {
+			return {work: s.slice(0, lastP), carry: tail};
+		}
+	}
+	const csiMatch = s.match(/\x1b\[(?:\?|>)[0-9;]*$/);
+	if (csiMatch && csiMatch.index !== undefined) {
+		return {work: s.slice(0, csiMatch.index), carry: csiMatch[0]};
+	}
+	return {work: s, carry: ''};
+}
+
+export function createBunTerminalOutputSanitizer(): {
+	push: (chunk: string) => string;
+	flush: () => string;
+} {
+	let carry = '';
+	return {
+		push(chunk: string): string {
+			const combined = carry + chunk;
+			const {work, carry: next} = peelIncompleteSuffix(combined);
+			carry = next;
+			return stripBunTerminalAutoResponses(work);
+		},
+		flush(): string {
+			const out = stripBunTerminalAutoResponses(carry);
+			carry = '';
+			return out;
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- Filter Bun/libvterm **DCS** (`ESC P >|…`) and **DA** reply sequences (`CSI ?…c`, `CSI >…c`) out of PTY `onData` before writing to xterm-headless, `outputHistory`, and live `sessionData`.
- Add `createBunTerminalOutputSanitizer()` so sequences split across read chunks are still removed.
- Run the same strip pass when replaying session history in `Session` (defense in depth).

## Context
`Bun.Terminal` has no API to disable this; replies meant for the child were appearing as literal garbage on the host TTY when opening a Claude Code session from the menu.

## Verification
- `npm run lint` / `npm run typecheck` pass.
- `npx vitest run src/services/sessionManager.test.ts src/utils/stripBunTerminalAutoResponses.test.ts` passes.
- Full `npm run test` still reports unrelated failures (`LoadingSpinner`, `terminalCapabilities` under current env / duplicate `dist` test runs).


Made with [Cursor](https://cursor.com)