### PR TITLE
fix: show deleting-worktree spinner during git delete

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -698,6 +698,12 @@ const App: React.FC<AppProps> = ({
 		setView('deleting-worktree');
 		setError(null);
 
+		// Yield to the event loop so Ink can paint `deleting-worktree` before git work runs.
+		// Otherwise the confirmation UI stays visible until deletion finishes (no spinner).
+		await new Promise<void>(resolve => {
+			setTimeout(resolve, 0);
+		});
+
 		// Delete the worktrees sequentially using Effect
 		let hasError = false;
 		for (const path of worktreePaths) {


### PR DESCRIPTION
## Summary
After confirming worktree deletion (including branch options), the UI stayed on the confirmation screen until `git` finished—no `LoadingSpinner` on the `deleting-worktree` view.

## Cause
`setView('deleting-worktree')` was followed immediately by delete work in the same flow, so Ink did not paint the loading view before the long-running operation.

## Change
In `handleDeleteWorktrees` (`App.tsx`), yield once with `setTimeout(0)` after setting the loading view so the event loop can render the spinner before deletion runs.

## Verification
- `npm run lint`
- `npx vitest run src/components/App.test.tsx -t "displays branch deletion message"`