### PR TITLE
feat: detect Cursor spinner activity as busy state

### DIFF
--- a/src/services/stateDetector/cursor.test.ts
+++ b/src/services/stateDetector/cursor.test.ts
@@ -175,6 +175,24 @@ describe('CursorStateDetector', () => {
 		expect(state).toBe('busy');
 	});
 
+	it('should detect busy state for spinner activity (⬡ …ing..)', () => {
+		terminal = createMockTerminal(['  ⬡ Grepping..', 'Some footer']);
+
+		expect(detector.detectState(terminal, 'idle')).toBe('busy');
+	});
+
+	it('should detect busy state for spinner activity (⬢ …ing...)', () => {
+		terminal = createMockTerminal(['  ⬢ Reading...']);
+
+		expect(detector.detectState(terminal, 'idle')).toBe('busy');
+	});
+
+	it('should detect busy state for spinner activity with Unicode ellipsis', () => {
+		terminal = createMockTerminal(['⬡ Searching\u2026']);
+
+		expect(detector.detectState(terminal, 'idle')).toBe('busy');
+	});
+
 	it('should detect idle state when no patterns match', () => {
 		// Arrange
 		terminal = createMockTerminal(['Normal output', 'Some message', 'Ready']);

--- a/src/services/stateDetector/cursor.ts
+++ b/src/services/stateDetector/cursor.ts
@@ -1,6 +1,15 @@
 import {SessionState, Terminal} from '../../types/index.js';
 import {BaseStateDetector} from './base.js';
 
+// Spinner symbols used by Cursor during active processing
+const CURSOR_SPINNER_CHARS = '⬡⬢';
+
+// Like Claude's spinner activity: "<symbol> <word>ing…"; Cursor often uses ASCII dots (.. or …)
+const SPINNER_ACTIVITY_PATTERN = new RegExp(
+	`^\\s*[${CURSOR_SPINNER_CHARS}] \\S+ing(?:.*\u2026|.*\\.{2,})`,
+	'm',
+);
+
 export class CursorStateDetector extends BaseStateDetector {
 	detectState(terminal: Terminal, _currentState: SessionState): SessionState {
 		const content = this.getTerminalContent(terminal, 30);
@@ -20,6 +29,11 @@ export class CursorStateDetector extends BaseStateDetector {
 
 		// Check for busy state - Priority 2
 		if (lowerContent.includes('ctrl+c to stop')) {
+			return 'busy';
+		}
+
+		// Spinner activity (e.g. "⬡ Grepping..", "⬢ Reading…") — case-sensitive on original buffer
+		if (SPINNER_ACTIVITY_PATTERN.test(content)) {
 			return 'busy';
 		}
 


### PR DESCRIPTION
## Summary
Treats Cursor agent spinner lines (e.g. `⬡ Grepping..`, `⬢ Reading...`) as **busy**, aligned with Claude’s `<symbol> <word>ing…` pattern. Supports Unicode ellipsis (`…`) and ASCII dot suffixes.

## Changes
- `CursorStateDetector`: regex for `⬡`/`⬢` + `*ing` + ellipsis/dots; checked after `waiting_input` and `ctrl+c to stop`.
- Tests for sample lines and Unicode ellipsis.

## Verification
- `npx vitest run src/services/stateDetector/cursor.test.ts` (passes).
- Full `npm run test` may still fail locally on unrelated suites (e.g. git global config lock, Unicode spinner env).

Made with [Cursor](https://cursor.com)