### PR TITLE
feat: detect Cursor file write confirmation as waiting_input

### DIFF
--- a/src/services/stateDetector/cursor.test.ts
+++ b/src/services/stateDetector/cursor.test.ts
@@ -145,6 +145,24 @@ describe('CursorStateDetector', () => {
 		expect(state).toBe('waiting_input');
 	});
 
+	it('should detect waiting_input state for Write to this file? prompt', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			' │ Write to this file?                                                                                                                                                                                                                                                                                                                                                                  │',
+			' │ in /Users/kbwo/go/projects/github.com/kbwo/ccmanager--feature-takt/src/services/stateDetector/takt.ts                                                                                                                                                                                                                                                                                │',
+			' │  → Proceed (y)                                                                                                                                                                                                                                                                                                                                                                       │',
+			' │    Reject & propose changes (esc or n or p)                                                                                                                                                                                                                                                                                                                                          │',
+			' │    Add Write(/Users/.../takt.ts) to allowlist? (tab)                                                                                                                                                                                                                                                                                                                                 │',
+			' │    Run Everything (shift+tab)                                                                                                                                                                                                                                                                                                                                                        │',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal, 'idle');
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
+
 	it('should detect busy state for ctrl+c to stop pattern', () => {
 		// Arrange
 		terminal = createMockTerminal([

--- a/src/services/stateDetector/cursor.ts
+++ b/src/services/stateDetector/cursor.ts
@@ -13,7 +13,11 @@ export class CursorStateDetector extends BaseStateDetector {
 			/auto .* \(shift\+tab\)/.test(lowerContent) ||
 			/allow .+ \(y\)/.test(lowerContent) ||
 			/run .+ \(y\)/.test(lowerContent) ||
-			lowerContent.includes('skip (esc or n)')
+			lowerContent.includes('skip (esc or n)') ||
+			lowerContent.includes('write to this file?') ||
+			lowerContent.includes('reject & propose changes') ||
+			(lowerContent.includes('add write(') &&
+				lowerContent.includes('allowlist'))
 		) {
 			return 'waiting_input';
 		}


### PR DESCRIPTION
## Summary

Treats Cursor’s **Write to this file?** confirmation (Proceed / Reject & propose / allowlist / Run Everything) as `waiting_input` in `CursorStateDetector`.

## Changes

- Match `write to this file?`, `reject & propose changes`, or `add write(` + `allowlist` in terminal capture.
- Add Vitest coverage for the framed prompt lines.

## Verification

- `npm run test -- src/services/stateDetector/cursor.test.ts`
- `npm run lint` (on touched files)

Made with [Cursor](https://cursor.com)