### PR TITLE
fix: use fullLowerContent for Claude busy interrupt detection

### DIFF
--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -546,7 +546,7 @@ describe('ClaudeStateDetector', () => {
 			expect(state).toBe('idle');
 		});
 
-		it('should ignore stale interrupt text outside the latest block above the prompt box', () => {
+		it('should detect busy when "esc to interrupt" is in viewport (full lower content)', () => {
 			terminal = createMockTerminal([
 				'Press esc to interrupt',
 				'Working...',
@@ -560,11 +560,10 @@ describe('ClaudeStateDetector', () => {
 
 			const state = detector.detectState(terminal, 'busy');
 
-			expect(state).toBe('idle');
+			expect(state).toBe('busy');
 		});
 
-		it('should ignore "esc to interrupt" inside prompt box', () => {
-			// Arrange - "esc to interrupt" is inside the prompt box, not above it
+		it('should detect busy when "esc to interrupt" is inside prompt box (full lower content)', () => {
 			terminal = createMockTerminal([
 				'Some idle output',
 				'──────────────────────────────',
@@ -572,11 +571,9 @@ describe('ClaudeStateDetector', () => {
 				'──────────────────────────────',
 			]);
 
-			// Act
 			const state = detector.detectState(terminal, 'idle');
 
-			// Assert - should be idle because "esc to interrupt" is inside prompt box
-			expect(state).toBe('idle');
+			expect(state).toBe('busy');
 		});
 
 		it('should detect "esc to cancel" inside prompt box as waiting_input', () => {

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -119,17 +119,16 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			return 'waiting_input';
 		}
 
-		// Content above the prompt box only for busy detection
-		const abovePromptBox = this.getRecentContentAbovePromptBox(terminal, 30);
-		const aboveLowerContent = abovePromptBox.toLowerCase();
-
-		// Check for busy state
+		// Check for busy state (full viewport lower content; Claude Code layout)
 		if (
-			aboveLowerContent.includes('esc to interrupt') ||
-			aboveLowerContent.includes('ctrl+c to interrupt')
+			fullLowerContent.includes('esc to interrupt') ||
+			fullLowerContent.includes('ctrl+c to interrupt')
 		) {
 			return 'busy';
 		}
+
+		// Spinner labels: inspect the block above the prompt box only (xterm redraw noise)
+		const abovePromptBox = this.getRecentContentAbovePromptBox(terminal, 30);
 
 		// Check for spinner activity label (e.g., "✽ Tempering…", "✳ Simplifying…")
 		if (SPINNER_ACTIVITY_PATTERN.test(abovePromptBox)) {


### PR DESCRIPTION
## Summary
Claude Code’s updated layout means interrupt hints (`esc to interrupt`, `ctrl+c to interrupt`) should be matched against the full visible viewport (lowercased), not only the slice above the prompt box.

## Changes
- Busy detection for interrupt strings uses `fullLowerContent` (from `getTerminalContent`) instead of `aboveLowerContent` from `getRecentContentAbovePromptBox`.
- Spinner activity labels still use `getRecentContentAbovePromptBox` to avoid xterm redraw noise.

## Testing
- `npx vitest run src/services/stateDetector/claude.test.ts`
- `npm run lint` and `npm run typecheck`

Made with [Cursor](https://cursor.com)