### PR TITLE
feat: debounce idle state transition to mitigate false idle detection

### DIFF
--- a/src/services/sessionManager.statePersistence.test.ts
+++ b/src/services/sessionManager.statePersistence.test.ts
@@ -8,6 +8,7 @@ import {
 	STATE_CHECK_INTERVAL_MS,
 	STATE_MINIMUM_DURATION_MS,
 } from '../constants/statePersistence.js';
+import {IDLE_DEBOUNCE_MS} from './stateDetector/claude.js';
 
 vi.mock('./bunTerminal.js', () => ({
 	spawn: vi.fn(function () {
@@ -118,8 +119,11 @@ describe('SessionManager - State Persistence', () => {
 		// Simulate output that would trigger idle state
 		eventEmitter.emit('data', 'Some output without busy indicators');
 
-		// Advance time less than persistence duration (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS * 2);
+		// Advance time past idle debounce so detector starts returning idle,
+		// but not enough for persistence to confirm
+		await vi.advanceTimersByTimeAsync(
+			IDLE_DEBOUNCE_MS + STATE_CHECK_INTERVAL_MS,
+		);
 
 		// State should still be busy, but pending state should be set
 		expect(session.stateMutex.getSnapshot().state).toBe('busy');
@@ -143,8 +147,10 @@ describe('SessionManager - State Persistence', () => {
 		// Simulate output that would trigger idle state
 		eventEmitter.emit('data', 'Some output without busy indicators');
 
-		// Advance time less than persistence duration (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS * 2);
+		// Advance time past idle debounce but not persistence+minimum
+		await vi.advanceTimersByTimeAsync(
+			IDLE_DEBOUNCE_MS + STATE_CHECK_INTERVAL_MS,
+		);
 		expect(session.stateMutex.getSnapshot().state).toBe('busy');
 		expect(stateChangeHandler).not.toHaveBeenCalled();
 
@@ -171,8 +177,10 @@ describe('SessionManager - State Persistence', () => {
 		// Simulate output that would trigger idle state
 		eventEmitter.emit('data', 'Some output without busy indicators');
 
-		// Advance time less than persistence duration (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS * 2);
+		// Advance time past idle debounce so detector starts returning idle
+		await vi.advanceTimersByTimeAsync(
+			IDLE_DEBOUNCE_MS + STATE_CHECK_INTERVAL_MS,
+		);
 		expect(session.stateMutex.getSnapshot().pendingState).toBe('idle');
 
 		// Simulate output that would trigger waiting_input state
@@ -199,8 +207,10 @@ describe('SessionManager - State Persistence', () => {
 		// Simulate output that would trigger idle state
 		eventEmitter.emit('data', 'Some output without busy indicators');
 
-		// Advance time less than persistence duration (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS * 2);
+		// Advance time past idle debounce so detector starts returning idle
+		await vi.advanceTimersByTimeAsync(
+			IDLE_DEBOUNCE_MS + STATE_CHECK_INTERVAL_MS,
+		);
 		expect(session.stateMutex.getSnapshot().pendingState).toBe('idle');
 		expect(session.stateMutex.getSnapshot().pendingStateStart).toBeDefined();
 
@@ -232,8 +242,10 @@ describe('SessionManager - State Persistence', () => {
 		// Try to change to idle
 		eventEmitter.emit('data', 'Some idle output\n');
 
-		// Wait for detection but not full persistence (less than 200ms) (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS); // 100ms
+		// Wait past idle debounce so detector returns idle, then one check
+		await vi.advanceTimersByTimeAsync(
+			IDLE_DEBOUNCE_MS + STATE_CHECK_INTERVAL_MS,
+		);
 
 		// Should have pending state but not confirmed
 		expect(session.stateMutex.getSnapshot().state).toBe('busy');
@@ -246,8 +258,8 @@ describe('SessionManager - State Persistence', () => {
 			'\x1b[2J\x1b[HDo you want to continue?\n❯ 1. Yes',
 		);
 
-		// Advance time to detect new state but still less than persistence duration from first change (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS); // Another 100ms, total 200ms exactly at threshold
+		// Advance time to detect new state
+		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS);
 
 		// Pending state should have changed to waiting_input
 		expect(session.stateMutex.getSnapshot().state).toBe('busy'); // Still original state
@@ -267,8 +279,10 @@ describe('SessionManager - State Persistence', () => {
 		// Simulate output that would trigger idle state
 		eventEmitter.emit('data', 'Some output without busy indicators');
 
-		// Advance time less than persistence duration (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS * 2);
+		// Advance time past idle debounce so detector returns idle
+		await vi.advanceTimersByTimeAsync(
+			IDLE_DEBOUNCE_MS + STATE_CHECK_INTERVAL_MS,
+		);
 		expect(session.stateMutex.getSnapshot().pendingState).toBe('idle');
 		expect(session.stateMutex.getSnapshot().pendingStateStart).toBeDefined();
 
@@ -297,9 +311,11 @@ describe('SessionManager - State Persistence', () => {
 		// Simulate output that would trigger idle state
 		eventEmitter.emit('data', 'Some output without busy indicators');
 
-		// Advance time less than persistence duration so transition is not yet confirmed
+		// Advance past idle debounce but not past persistence + minimum duration
 		await vi.advanceTimersByTimeAsync(
-			STATE_PERSISTENCE_DURATION_MS - STATE_CHECK_INTERVAL_MS,
+			IDLE_DEBOUNCE_MS +
+				STATE_PERSISTENCE_DURATION_MS -
+				STATE_CHECK_INTERVAL_MS,
 		);
 
 		// State should still be busy because minimum duration hasn't elapsed
@@ -323,9 +339,9 @@ describe('SessionManager - State Persistence', () => {
 		// Simulate output that would trigger idle state
 		eventEmitter.emit('data', 'Some output without busy indicators');
 
-		// Advance time past STATE_MINIMUM_DURATION_MS (which is longer than STATE_PERSISTENCE_DURATION_MS)
+		// Advance past idle debounce + persistence/minimum duration
 		await vi.advanceTimersByTimeAsync(
-			STATE_MINIMUM_DURATION_MS + STATE_CHECK_INTERVAL_MS,
+			IDLE_DEBOUNCE_MS + STATE_MINIMUM_DURATION_MS + STATE_CHECK_INTERVAL_MS,
 		);
 
 		// State should now be idle since both durations are satisfied
@@ -355,17 +371,13 @@ describe('SessionManager - State Persistence', () => {
 
 		// Now simulate a brief screen redraw: busy indicators disappear temporarily
 		eventEmitter.emit('data', '\x1b[2J\x1b[H'); // Clear screen
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS); // 100ms
 
-		// Pending state should be set to idle
-		expect(session.stateMutex.getSnapshot().pendingState).toBe('idle');
+		// Idle debounce prevents the detector from returning idle for IDLE_DEBOUNCE_MS,
+		// so during a brief redraw (< 1500ms), no pending idle state is set.
+		// Advance a short time — still within the idle debounce window
+		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS * 3); // 300ms
 
-		// Advance past half the persistence duration but not fully
-		// Since stateConfirmedAt was updated at ~2000ms, this is not enough
-		// for the pending state to be confirmed
-		await vi.advanceTimersByTimeAsync(STATE_PERSISTENCE_DURATION_MS / 2);
-
-		// State should still be busy because minimum duration since last busy detection hasn't elapsed
+		// State should still be busy — idle debounce hasn't elapsed
 		expect(session.stateMutex.getSnapshot().state).toBe('busy');
 		expect(stateChangeHandler).not.toHaveBeenCalled();
 
@@ -398,24 +410,16 @@ describe('SessionManager - State Persistence', () => {
 		// Session 1 goes to idle
 		eventEmitter1.emit('data', 'Idle output for session 1');
 
-		// Session 2 goes to waiting_input
+		// Session 2 goes to waiting_input (no idle debounce for waiting_input)
 		eventEmitter2.emit('data', 'Do you want to continue?\n❯ 1. Yes');
 
-		// Advance time to check but not confirm (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_CHECK_INTERVAL_MS * 2);
-
-		// Both should have pending states but not changed yet
-		expect(session1.stateMutex.getSnapshot().state).toBe('busy');
-		expect(session1.stateMutex.getSnapshot().pendingState).toBe('idle');
-		expect(session2.stateMutex.getSnapshot().state).toBe('busy');
-		expect(session2.stateMutex.getSnapshot().pendingState).toBe(
-			'waiting_input',
+		// Advance past idle debounce for session 1 + persistence/minimum for both
+		await vi.advanceTimersByTimeAsync(
+			IDLE_DEBOUNCE_MS + STATE_MINIMUM_DURATION_MS + STATE_CHECK_INTERVAL_MS,
 		);
 
-		// Advance time to confirm both - need to exceed STATE_MINIMUM_DURATION_MS (use async to process mutex updates)
-		await vi.advanceTimersByTimeAsync(STATE_MINIMUM_DURATION_MS);
-
 		// Both should now be in their new states
+		// Session 2 (waiting_input) transitions faster since it's not debounced
 		expect(session1.stateMutex.getSnapshot().state).toBe('idle');
 		expect(session1.stateMutex.getSnapshot().pendingState).toBeUndefined();
 		expect(session2.stateMutex.getSnapshot().state).toBe('waiting_input');

--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -1,5 +1,5 @@
-import {describe, it, expect, beforeEach} from 'vitest';
-import {ClaudeStateDetector} from './claude.js';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {ClaudeStateDetector, IDLE_DEBOUNCE_MS} from './claude.js';
 import type {Terminal} from '../../types/index.js';
 import {createMockTerminal} from './testUtils.js';
 
@@ -8,8 +8,27 @@ describe('ClaudeStateDetector', () => {
 	let terminal: Terminal;
 
 	beforeEach(() => {
+		vi.useFakeTimers();
 		detector = new ClaudeStateDetector();
 	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	/**
+	 * Helper: call detectState, advance time past IDLE_DEBOUNCE_MS,
+	 * then call again with the same terminal to get the debounced result.
+	 */
+	const detectStateAfterDebounce = (
+		det: ClaudeStateDetector,
+		term: Terminal,
+		currentState: 'idle' | 'busy' | 'waiting_input' = 'idle',
+	) => {
+		det.detectState(term, currentState);
+		vi.advanceTimersByTime(IDLE_DEBOUNCE_MS);
+		return det.detectState(term, currentState);
+	};
 
 	describe('detectState', () => {
 		it('should detect busy when "ESC to interrupt" is above prompt box', () => {
@@ -60,7 +79,7 @@ describe('ClaudeStateDetector', () => {
 			expect(state).toBe('busy');
 		});
 
-		it('should detect idle when no specific patterns are found', () => {
+		it('should detect idle when no specific patterns are found (after debounce)', () => {
 			// Arrange
 			terminal = createMockTerminal([
 				'Command completed successfully',
@@ -69,7 +88,7 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const state = detector.detectState(terminal, 'idle');
+			const state = detectStateAfterDebounce(detector, terminal, 'idle');
 
 			// Assert
 			expect(state).toBe('idle');
@@ -80,7 +99,7 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal([]);
 
 			// Act
-			const state = detector.detectState(terminal, 'idle');
+			const state = detectStateAfterDebounce(detector, terminal, 'idle');
 
 			// Assert
 			expect(state).toBe('idle');
@@ -349,7 +368,7 @@ describe('ClaudeStateDetector', () => {
 			);
 
 			// Act
-			const state = detector.detectState(terminal, 'busy');
+			const state = detectStateAfterDebounce(detector, terminal, 'busy');
 
 			// Assert - Should detect idle because viewport shows lines 5-7
 			expect(state).toBe('idle');
@@ -476,7 +495,7 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal(['✽ Some random text', '❯']);
 
 			// Act
-			const state = detector.detectState(terminal, 'idle');
+			const state = detectStateAfterDebounce(detector, terminal, 'idle');
 
 			// Assert
 			expect(state).toBe('idle');
@@ -487,7 +506,7 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal(['⌕ Search…', '✽ Tempering…']);
 
 			// Act
-			const state = detector.detectState(terminal, 'busy');
+			const state = detectStateAfterDebounce(detector, terminal, 'busy');
 
 			// Assert - Search prompt takes precedence
 			expect(state).toBe('idle');
@@ -498,7 +517,7 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal(['⌕ Search…', 'Some content']);
 
 			// Act
-			const state = detector.detectState(terminal, 'busy');
+			const state = detectStateAfterDebounce(detector, terminal, 'busy');
 
 			// Assert
 			expect(state).toBe('idle');
@@ -509,7 +528,7 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal(['⌕ Search…', 'esc to cancel']);
 
 			// Act
-			const state = detector.detectState(terminal, 'idle');
+			const state = detectStateAfterDebounce(detector, terminal, 'idle');
 
 			// Assert - Should be idle because search prompt takes precedence
 			expect(state).toBe('idle');
@@ -520,7 +539,7 @@ describe('ClaudeStateDetector', () => {
 			terminal = createMockTerminal(['⌕ Search…', 'Press esc to interrupt']);
 
 			// Act
-			const state = detector.detectState(terminal, 'idle');
+			const state = detectStateAfterDebounce(detector, terminal, 'idle');
 
 			// Assert - Should be idle because search prompt takes precedence
 			expect(state).toBe('idle');
@@ -541,7 +560,7 @@ describe('ClaudeStateDetector', () => {
 				'──────────────────────────────',
 			]);
 
-			const state = detector.detectState(terminal, 'busy');
+			const state = detectStateAfterDebounce(detector, terminal, 'busy');
 
 			expect(state).toBe('idle');
 		});
@@ -558,7 +577,7 @@ describe('ClaudeStateDetector', () => {
 				'──────────────────────────────',
 			]);
 
-			const state = detector.detectState(terminal, 'busy');
+			const state = detectStateAfterDebounce(detector, terminal, 'busy');
 
 			expect(state).toBe('idle');
 		});
@@ -573,7 +592,7 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const state = detector.detectState(terminal, 'idle');
+			const state = detectStateAfterDebounce(detector, terminal, 'idle');
 
 			// Assert - should be idle because "esc to interrupt" is inside prompt box
 			expect(state).toBe('idle');
@@ -622,10 +641,84 @@ describe('ClaudeStateDetector', () => {
 			]);
 
 			// Act
-			const state = detector.detectState(terminal, 'idle');
+			const state = detectStateAfterDebounce(detector, terminal, 'idle');
 
 			// Assert - should be idle because spinner is inside prompt box
 			expect(state).toBe('idle');
+		});
+
+		describe('idle debounce', () => {
+			it('should not return idle immediately when output just appeared', () => {
+				terminal = createMockTerminal(['Command completed successfully', '> ']);
+
+				const state = detector.detectState(terminal, 'busy');
+
+				// Should remain busy because debounce hasn't elapsed
+				expect(state).toBe('busy');
+			});
+
+			it('should return idle after output is stable for IDLE_DEBOUNCE_MS', () => {
+				terminal = createMockTerminal(['Command completed successfully', '> ']);
+
+				// First call registers the content
+				detector.detectState(terminal, 'busy');
+
+				// Advance time past debounce threshold
+				vi.advanceTimersByTime(IDLE_DEBOUNCE_MS);
+
+				// Second call with same content should return idle
+				const state = detector.detectState(terminal, 'busy');
+				expect(state).toBe('idle');
+			});
+
+			it('should reset debounce timer when output changes', () => {
+				terminal = createMockTerminal(['Output v1', '> ']);
+				detector.detectState(terminal, 'busy');
+
+				// Advance almost to threshold
+				vi.advanceTimersByTime(IDLE_DEBOUNCE_MS - 100);
+
+				// Output changes
+				terminal = createMockTerminal(['Output v2', '> ']);
+				const state1 = detector.detectState(terminal, 'busy');
+				expect(state1).toBe('busy');
+
+				// Advance past original threshold but not new one
+				vi.advanceTimersByTime(200);
+				const state2 = detector.detectState(terminal, 'busy');
+				expect(state2).toBe('busy');
+
+				// Advance to meet new threshold
+				vi.advanceTimersByTime(IDLE_DEBOUNCE_MS);
+				const state3 = detector.detectState(terminal, 'busy');
+				expect(state3).toBe('idle');
+			});
+
+			it('should not debounce busy transitions', () => {
+				terminal = createMockTerminal([
+					'Processing...',
+					'Press ESC to interrupt',
+					'──────────────────────────────',
+					'❯',
+					'──────────────────────────────',
+				]);
+
+				// Busy should be detected immediately without debounce
+				const state = detector.detectState(terminal, 'idle');
+				expect(state).toBe('busy');
+			});
+
+			it('should not debounce waiting_input transitions', () => {
+				terminal = createMockTerminal([
+					'Do you want to continue?',
+					'❯ 1. Yes',
+					'  2. No',
+				]);
+
+				// waiting_input should be detected immediately
+				const state = detector.detectState(terminal, 'idle');
+				expect(state).toBe('waiting_input');
+			});
 		});
 	});
 

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -12,7 +12,42 @@ const SPINNER_ACTIVITY_PATTERN = new RegExp(
 
 const BUSY_LOOKBACK_LINES = 5;
 
+// Workaround: Claude Code sometimes appears idle in terminal output while
+// still actively processing (busy). To mitigate false idle transitions,
+// require terminal output to remain unchanged for this duration before
+// confirming the idle state.
+export const IDLE_DEBOUNCE_MS = 1500;
+
 export class ClaudeStateDetector extends BaseStateDetector {
+	private lastContentHash: string = '';
+	private contentStableSince: number = 0;
+
+	/**
+	 * Debounce idle transitions: only return 'idle' when the terminal
+	 * content has been unchanged for IDLE_DEBOUNCE_MS.
+	 * Returns currentState if output is still changing.
+	 *
+	 * This is a workaround for Claude Code occasionally showing idle-like
+	 * terminal output while still busy (e.g. during screen redraws).
+	 */
+	private debounceIdle(
+		terminal: Terminal,
+		currentState: SessionState,
+		now: number = Date.now(),
+	): SessionState {
+		const content = this.getTerminalContent(terminal, 30);
+		if (content !== this.lastContentHash) {
+			this.lastContentHash = content;
+			this.contentStableSince = now;
+		}
+
+		const stableDuration = now - this.contentStableSince;
+		if (stableDuration >= IDLE_DEBOUNCE_MS) {
+			return 'idle';
+		}
+
+		return currentState;
+	}
 	/**
 	 * Extract content above the prompt box.
 	 * The prompt box is delimited by ─ border lines:
@@ -84,10 +119,10 @@ export class ClaudeStateDetector extends BaseStateDetector {
 	}
 
 	detectState(terminal: Terminal, currentState: SessionState): SessionState {
-		// Check for search prompt (⌕ Search…) within 200 lines - always idle
+		// Check for search prompt (⌕ Search…) within 200 lines - always idle (debounced)
 		const extendedContent = this.getTerminalContent(terminal, 200);
 		if (extendedContent.includes('⌕ Search…')) {
-			return 'idle';
+			return this.debounceIdle(terminal, currentState);
 		}
 
 		// Full content (including prompt box) for waiting_input detection
@@ -136,8 +171,8 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			return 'busy';
 		}
 
-		// Otherwise idle
-		return 'idle';
+		// Otherwise idle (debounced)
+		return this.debounceIdle(terminal, currentState);
 	}
 
 	detectBackgroundTask(terminal: Terminal): number {


### PR DESCRIPTION
## Summary

- Workaround for Claude Code occasionally appearing idle in terminal output while still actively processing (busy)
- Debounce only idle transitions: require terminal output to remain unchanged for 1500ms before confirming idle state
- Busy and waiting_input transitions remain immediate (no debounce)

## Changes

- Add `debounceIdle()` method to `ClaudeStateDetector` to track terminal output changes
- Add `IDLE_DEBOUNCE_MS = 1500` constant (commented as a workaround)
- Add 5 debounce-specific unit tests
- Adjust timing in `sessionManager.statePersistence.test.ts` to account for the additional debounce delay

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` — all 825 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)