### PR TITLE
fix: exclude scrollback from session restore snapshot

### DIFF
--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1156,7 +1156,7 @@ describe('SessionManager', () => {
 
 			sessionManager.setSessionActive(session.id, true);
 
-			expect(serializeMock).toHaveBeenCalledWith({scrollback: 5000});
+			expect(serializeMock).toHaveBeenCalledWith({scrollback: 0});
 			expect(restoreHandler).toHaveBeenCalledWith(
 				session,
 				'\u001b[31mrestored\u001b[0m',

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -302,7 +302,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 
 	private getRestoreSnapshot(session: Session): string {
 		return session.serializer.serialize({
-			scrollback: TERMINAL_SCROLLBACK_LINES,
+			scrollback: 0,
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Serialize session restore snapshot with `scrollback: 0` instead of `scrollback: 5000`
- Fixes duplicate lines appearing when switching between sessions
- Fixes cleared output (via `clear` / `\x1B[2J`) reappearing on session restore

## Root Cause
PR #271 introduced `@xterm/addon-serialize` for session restore. The serializer included 5000 lines of scrollback, which caused:
1. **Duplicate lines**: All scrollback content scrolled through the real terminal viewport before the visible viewport was rendered on top
2. **Clear not honored**: xterm.js moves cleared content to scrollback rather than deleting it, so the serializer faithfully replayed "cleared" content

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (updated test expectation)
- [ ] Manual: start ccmanager, open session, let output accumulate, switch to menu and back — no duplicate lines
- [ ] Manual: run `clear` in session, switch to menu and back — cleared content does not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)