### PR TITLE
fix: remove numbered selection prompt detection

### DIFF
--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -249,39 +249,6 @@ describe('ClaudeStateDetector', () => {
 			expect(state).toBe('waiting_input');
 		});
 
-		it('should detect waiting_input when plan submit prompt with ❯ cursor is present', () => {
-			// Arrange
-			terminal = createMockTerminal([
-				'Ready to submit your answers?',
-				'',
-				'❯ 1. Submit answers',
-				'  2. Cancel',
-			]);
-
-			// Act
-			const state = detector.detectState(terminal, 'idle');
-
-			// Assert
-			expect(state).toBe('waiting_input');
-		});
-
-		it('should detect waiting_input for generic ❯ numbered selection prompt', () => {
-			// Arrange
-			terminal = createMockTerminal([
-				'Select an option:',
-				'',
-				'❯ 1. Option A',
-				'  2. Option B',
-				'  3. Option C',
-			]);
-
-			// Act
-			const state = detector.detectState(terminal, 'idle');
-
-			// Assert
-			expect(state).toBe('waiting_input');
-		});
-
 		it('should detect waiting_input when "esc to cancel" is above prompt box', () => {
 			// Arrange
 			terminal = createMockTerminal([

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -109,11 +109,6 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			return 'waiting_input';
 		}
 
-		// Check for selection prompt with ❯ cursor indicator and numbered options
-		if (/❯\s+\d+\./.test(fullContent)) {
-			return 'waiting_input';
-		}
-
 		// Check for "esc to cancel" - indicates waiting for user input
 		if (fullLowerContent.includes('esc to cancel')) {
 			return 'waiting_input';


### PR DESCRIPTION
## Summary
- Remove the `❯\s+\d+\.` regex check from Claude state detector that matched numbered selection prompts
- Remove 2 related tests that depended solely on this pattern
- Other waiting_input checks (Do you want/Would you like, esc to cancel) already cover relevant prompts

## Test plan
- [x] All 58 existing tests pass after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)