### PR TITLE
fix: defer auto-wrap disable until after restore snapshot write

### DIFF
--- a/src/components/Session.test.tsx
+++ b/src/components/Session.test.tsx
@@ -119,6 +119,7 @@ describe('Session', () => {
 		expect(terminalResize.mock.invocationCallOrder[0] ?? 0).toBeLessThan(
 			setSessionActive.mock.invocationCallOrder[0] ?? 0,
 		);
-		expect(testState.stdout?.write).toHaveBeenNthCalledWith(3, '\nrestored');
+		expect(testState.stdout?.write).toHaveBeenNthCalledWith(2, '\nrestored');
+		expect(testState.stdout?.write).toHaveBeenNthCalledWith(3, '\x1b[?7l');
 	});
 });

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -86,13 +86,14 @@ const Session: React.FC<SessionProps> = ({
 
 		stdin.on('data', handleStdinData);
 
-		// Prevent line wrapping from drifting redraws in TUIs that rely on cursor-up clears.
-		stdout.write('\x1b[?7l');
-
 		// Clear screen when entering session
 		stdout.write('\x1B[2J\x1B[H');
 
 		// Restore the current terminal state from the headless xterm snapshot.
+		// The xterm serialize addon relies on auto-wrap (DECAWM) being enabled to
+		// render wrapped lines — it omits row separators for wrapped rows, expecting
+		// characters to naturally overflow to the next line.  We therefore keep
+		// auto-wrap enabled while writing the snapshot and only disable it afterward.
 		const handleSessionRestore = (
 			restoredSession: ISession,
 			restoreSnapshot: string,
@@ -143,8 +144,17 @@ const Session: React.FC<SessionProps> = ({
 		}
 
 		// Mark session as active after resizing so the restore snapshot matches
-		// the current terminal dimensions.
+		// the current terminal dimensions.  setSessionActive synchronously emits
+		// the 'sessionRestore' event, so the snapshot is written to stdout before
+		// we proceed.
 		sessionManager.setSessionActive(session.id, true);
+
+		// Prevent line wrapping from drifting redraws in TUIs that rely on
+		// cursor-up clears.  This MUST come after the restore snapshot write
+		// because the xterm serialize addon relies on auto-wrap (DECAWM) being
+		// enabled — it omits row separators for wrapped rows, expecting characters
+		// to naturally overflow to the next line.
+		stdout.write('\x1b[?7l');
 
 		// Handle terminal resize
 		const handleResize = () => {


### PR DESCRIPTION
## Summary
- xterm serialize addon omits row separators for wrapped lines, relying on auto-wrap (DECAWM) to advance the cursor to the next row
- `\x1b[?7l` was written **before** the restore snapshot, causing wrapped lines to overlap instead of rendering on separate rows
- Moved auto-wrap disable to **after** `setSessionActive()` so the snapshot renders correctly, then disables it for live TUI output

Fixes rendering overlap/duplicate lines introduced in #271 and not fully resolved by #274.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes  
- [x] `npm run test` passes (updated Session.test.tsx for new write order)
- [ ] Manual: switch between sessions with long wrapped lines — verify no overlap or duplicate rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)