### PR TITLE
fix: pin Bun to v1.3.11 to fix broken darwin-arm64 release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
+        bun-version: "1.3.11"
 
     - name: Install dependencies
       run: bun install

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Setup Node.js (for npm publish)
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Pin Bun version from `latest` to `1.3.11` in both CI and npm-publish workflows to fix broken darwin-arm64 release binaries

## Problem

Since v4.1.3, the released `ccmanager` binary silently exits on macOS arm64 (Apple Silicon) without doing anything. This affects both v4.1.3 and v4.1.4 releases.

## Root Cause

Bun v1.3.12 introduced a regression ([oven-sh/bun#29120](https://github.com/oven-sh/bun/issues/29120)) where `bun build --compile` produces darwin-arm64 binaries with a **truncated code signature**.

The Bun runtime binary grew by ~337KB in v1.3.12 (due to Zig compiler changes), triggering a latent bug in `macho.zig`'s `sig_size` calculation:

| | Bun 1.3.11 | Bun 1.3.12 |
|--|-----------|-----------|
| Binary size | 68,483,104 | 68,819,776 (+337KB) |
| LC_CODE_SIGNATURE datasize | 550,192 ✅ | 196,592 ❌ |
| codesign status | `Signature=adhoc` | `code object is not signed at all` |

macOS requires all arm64 binaries to be at least ad-hoc signed. The unsigned binary is immediately killed with SIGKILL (exit 137). The `bin/cli.js` wrapper then swallows this error silently (since `error.status` is `null`, not `undefined`, it calls `process.exit(null)` → exit code 0).

## Evidence

- **v4.1.2 (last working release)**: built with Bun v1.3.11 ([CI run](https://github.com/kbwo/ccmanager/actions/runs/24075809811))
- **v4.1.3 (broken)**: built with Bun v1.3.12 ([CI run](https://github.com/kbwo/ccmanager/actions/runs/24285207021))
- **v4.1.4 (broken)**: built with Bun v1.3.12 ([CI run](https://github.com/kbwo/ccmanager/actions/runs/24296958808))
- Locally confirmed: running `codesign --remove-signature && codesign -s -` on the broken binary restores it to working state

## Test plan

- [ ] Merge and create a new release
- [ ] Verify CI uses Bun v1.3.11 in the publish workflow
- [ ] Install the new release via npm and confirm `ccmanager` runs on macOS arm64
- [ ] Unpin Bun version once [oven-sh/bun#29120](https://github.com/oven-sh/bun/issues/29120) is fixed upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)