### PR TITLE
feat: open terminal for worktree

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -17,6 +17,7 @@ import SessionActions, {type SessionActionType} from './SessionActions.js';
 import {SessionManager} from '../services/sessionManager.js';
 import {globalSessionOrchestrator} from '../services/globalSessionOrchestrator.js';
 import {WorktreeService} from '../services/worktreeService.js';
+import {launchTerminal} from '../services/terminalLauncher.js';
 import {
 	worktreeNameGenerator,
 	generateFallbackBranchName,
@@ -987,6 +988,17 @@ const App: React.FC<AppProps> = ({
 					sessionManager.destroySession(targetSession.id);
 					handleReturnToMenu();
 					return;
+				case 'openTerminal': {
+					const result = launchTerminal(worktreePath);
+					if (!result.success) {
+						setError(
+							result.error ??
+								'Failed to launch terminal. Set CCMANAGER_TERMINAL to override the default command.',
+						);
+					}
+					handleReturnToMenu();
+					return;
+				}
 			}
 		};
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -456,6 +456,16 @@ const App: React.FC<AppProps> = ({
 				});
 				navigateWithClear('session-actions');
 				return;
+			case 'openTerminal': {
+				const result = launchTerminal(action.worktreePath);
+				if (!result.success) {
+					setError(
+						result.error ??
+							'Failed to launch terminal. Configure terminalLauncher in settings or set CCMANAGER_TERMINAL.',
+					);
+				}
+				return;
+			}
 			case 'deleteWorktree':
 				navigateWithClear('delete-worktree');
 				return;
@@ -993,7 +1003,7 @@ const App: React.FC<AppProps> = ({
 					if (!result.success) {
 						setError(
 							result.error ??
-								'Failed to launch terminal. Set CCMANAGER_TERMINAL to override the default command.',
+								'Failed to launch terminal. Configure terminalLauncher in settings or set CCMANAGER_TERMINAL.',
 						);
 					}
 					handleReturnToMenu();

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -481,6 +481,11 @@ const Menu: React.FC<MenuProps> = ({
 			case 'm':
 				onMenuAction({type: 'mergeWorktree'});
 				break;
+			case 't':
+				if (highlightedWorktreePath) {
+					onMenuAction({type: 'openTerminal', worktreePath: highlightedWorktreePath});
+				}
+				break;
 			case 'd':
 				onMenuAction({type: 'deleteWorktree'});
 				break;

--- a/src/components/SessionActions.tsx
+++ b/src/components/SessionActions.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 
-export type SessionActionType = 'newSession' | 'rename' | 'kill';
+export type SessionActionType =
+	| 'newSession'
+	| 'rename'
+	| 'kill'
+	| 'openTerminal';
 
 interface SessionActionsProps {
 	sessionLabel: string;
@@ -14,6 +18,7 @@ const items: Array<{label: string; value: SessionActionType}> = [
 	{label: 'S  New session in same directory', value: 'newSession'},
 	{label: 'R  Rename this session', value: 'rename'},
 	{label: 'X  Close session', value: 'kill'},
+	{label: 'T  Open terminal in worktree directory', value: 'openTerminal'},
 ];
 
 const SessionActions: React.FC<SessionActionsProps> = ({
@@ -37,6 +42,9 @@ const SessionActions: React.FC<SessionActionsProps> = ({
 			case 'x':
 				onSelect('kill');
 				break;
+			case 't':
+				onSelect('openTerminal');
+				break;
 		}
 	});
 
@@ -52,7 +60,7 @@ const SessionActions: React.FC<SessionActionsProps> = ({
 				<SelectInput items={items} onSelect={item => onSelect(item.value)} />
 			</Box>
 			<Box marginTop={1}>
-				<Text dimColor>S/R/X or arrow keys + Enter | Escape to cancel</Text>
+				<Text dimColor>S/R/X/T or arrow keys + Enter | Escape to cancel</Text>
 			</Box>
 		</Box>
 	);

--- a/src/services/config/configEditor.ts
+++ b/src/services/config/configEditor.ts
@@ -7,6 +7,7 @@ import {
 	WorktreeConfig,
 	CommandPresetsConfig,
 	MergeConfig,
+	TerminalLauncherConfig,
 	IConfigEditor,
 	AutoApprovalConfig,
 } from '../../types/index.js';
@@ -106,6 +107,16 @@ export class ConfigEditor implements IConfigEditor {
 
 	setCommandPresets(value: CommandPresetsConfig): void {
 		this.configEditor.setCommandPresets(value);
+	}
+
+	getTerminalLauncher(): TerminalLauncherConfig | undefined {
+		const scopedConfig = this.configEditor.getTerminalLauncher();
+		if (scopedConfig) return scopedConfig;
+		return globalConfigManager.getTerminalLauncher();
+	}
+
+	setTerminalLauncher(value: TerminalLauncherConfig): void {
+		this.configEditor.setTerminalLauncher(value);
 	}
 
 	getMergeConfig(): MergeConfig | undefined {

--- a/src/services/config/configReader.ts
+++ b/src/services/config/configReader.ts
@@ -6,6 +6,7 @@ import {
 	WorktreeConfig,
 	CommandPresetsConfig,
 	MergeConfig,
+	TerminalLauncherConfig,
 	CommandPreset,
 	ConfigurationData,
 	IConfigReader,
@@ -93,6 +94,12 @@ export class ConfigReader implements IConfigReader {
 		};
 	}
 
+	getTerminalLauncher(): TerminalLauncherConfig | undefined {
+		const projectConfig = projectConfigManager.getTerminalLauncher();
+		if (projectConfig) return projectConfig;
+		return globalConfigManager.getTerminalLauncher();
+	}
+
 	// Get full merged configuration
 	getConfiguration(): ConfigurationData {
 		return {
@@ -102,6 +109,7 @@ export class ConfigReader implements IConfigReader {
 			worktree: this.getWorktreeConfig(),
 			commandPresets: this.getCommandPresets(),
 			mergeConfig: this.getMergeConfig(),
+			terminalLauncher: this.getTerminalLauncher(),
 			autoApproval: this.getAutoApprovalConfig(),
 		};
 	}

--- a/src/services/config/globalConfigManager.ts
+++ b/src/services/config/globalConfigManager.ts
@@ -14,6 +14,7 @@ import {
 	WorktreeConfig,
 	CommandPresetsConfig,
 	MergeConfig,
+	TerminalLauncherConfig,
 	DEFAULT_SHORTCUTS,
 	IConfigEditor,
 } from '../../types/index.js';
@@ -244,6 +245,15 @@ class GlobalConfigManager implements IConfigEditor {
 
 	setCommandPresets(presets: CommandPresetsConfig): void {
 		this.config.commandPresets = presets;
+		this.saveConfig();
+	}
+
+	getTerminalLauncher(): TerminalLauncherConfig | undefined {
+		return this.config.terminalLauncher;
+	}
+
+	setTerminalLauncher(value: TerminalLauncherConfig): void {
+		this.config.terminalLauncher = value;
 		this.saveConfig();
 	}
 

--- a/src/services/config/projectConfigManager.ts
+++ b/src/services/config/projectConfigManager.ts
@@ -13,6 +13,7 @@ import {
 	WorktreeConfig,
 	CommandPresetsConfig,
 	MergeConfig,
+	TerminalLauncherConfig,
 	IConfigEditor,
 	AutoApprovalConfig,
 } from '../../types/index.js';
@@ -135,6 +136,16 @@ class ProjectConfigManager implements IConfigEditor {
 	setCommandPresets(value: CommandPresetsConfig): void {
 		const config = this.ensureProjectConfig();
 		config.commandPresets = value;
+		this.saveProjectConfig();
+	}
+
+	getTerminalLauncher(): TerminalLauncherConfig | undefined {
+		return this.projectConfig?.terminalLauncher;
+	}
+
+	setTerminalLauncher(value: TerminalLauncherConfig): void {
+		const config = this.ensureProjectConfig();
+		config.terminalLauncher = value;
 		this.saveProjectConfig();
 	}
 

--- a/src/services/terminalLauncher.test.ts
+++ b/src/services/terminalLauncher.test.ts
@@ -16,6 +16,14 @@ vi.mock('../utils/logger.js', () => ({
 	},
 }));
 
+const mockGetTerminalLauncher = vi.fn();
+
+vi.mock('./config/configReader.js', () => ({
+	configReader: {
+		getTerminalLauncher: () => mockGetTerminalLauncher(),
+	},
+}));
+
 import {launchTerminal} from './terminalLauncher.js';
 
 type FakeChild = Pick<EventEmitter, 'on'> & {unref: () => void};
@@ -34,6 +42,7 @@ describe('terminalLauncher', () => {
 	beforeEach(() => {
 		mockSpawn.mockReset();
 		mockSpawn.mockReturnValue(makeFakeChild());
+		mockGetTerminalLauncher.mockReturnValue(undefined);
 		delete process.env['CCMANAGER_TERMINAL'];
 	});
 
@@ -44,6 +53,52 @@ describe('terminalLauncher', () => {
 		} else {
 			process.env['CCMANAGER_TERMINAL'] = originalEnv;
 		}
+	});
+
+	it('uses config terminalLauncher when set', () => {
+		mockGetTerminalLauncher.mockReturnValue({
+			command: 'alacritty',
+			args: ['--working-directory', '{cwd}'],
+		});
+
+		const result = launchTerminal('/tmp/worktree');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'alacritty',
+			['--working-directory', '/tmp/worktree'],
+			expect.objectContaining({cwd: '/tmp/worktree', detached: true}),
+		);
+	});
+
+	it('config takes priority over CCMANAGER_TERMINAL env', () => {
+		mockGetTerminalLauncher.mockReturnValue({
+			command: 'wezterm',
+			args: ['start', '--cwd', '{cwd}'],
+		});
+		process.env['CCMANAGER_TERMINAL'] = 'alacritty --working-directory {cwd}';
+
+		const result = launchTerminal('/tmp/wt');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'wezterm',
+			['start', '--cwd', '/tmp/wt'],
+			expect.objectContaining({cwd: '/tmp/wt'}),
+		);
+	});
+
+	it('falls back to CCMANAGER_TERMINAL env when no config', () => {
+		process.env['CCMANAGER_TERMINAL'] = 'alacritty --working-directory {cwd}';
+
+		const result = launchTerminal('/tmp/wt');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'alacritty',
+			['--working-directory', '/tmp/wt'],
+			expect.objectContaining({cwd: '/tmp/wt'}),
+		);
 	});
 
 	it('launches Terminal.app on macOS', () => {
@@ -85,27 +140,13 @@ describe('terminalLauncher', () => {
 		);
 	});
 
-	it('respects CCMANAGER_TERMINAL override with {cwd} substitution', () => {
-		Object.defineProperty(process, 'platform', {value: 'linux'});
-		process.env['CCMANAGER_TERMINAL'] = 'alacritty --working-directory {cwd}';
-
-		const result = launchTerminal('/tmp/wt');
-
-		expect(result.success).toBe(true);
-		expect(mockSpawn).toHaveBeenCalledWith(
-			'alacritty',
-			['--working-directory', '/tmp/wt'],
-			expect.objectContaining({cwd: '/tmp/wt'}),
-		);
-	});
-
 	it('returns an error on unsupported platform with no override', () => {
 		Object.defineProperty(process, 'platform', {value: 'sunos'});
 
 		const result = launchTerminal('/tmp/wt');
 
 		expect(result.success).toBe(false);
-		expect(result.error).toMatch(/CCMANAGER_TERMINAL/);
+		expect(result.error).toMatch(/terminalLauncher|CCMANAGER_TERMINAL/);
 		expect(mockSpawn).not.toHaveBeenCalled();
 	});
 
@@ -119,5 +160,20 @@ describe('terminalLauncher', () => {
 
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('ENOENT');
+	});
+
+	it('handles config with no args', () => {
+		mockGetTerminalLauncher.mockReturnValue({
+			command: 'kitty',
+		});
+
+		const result = launchTerminal('/tmp/wt');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'kitty',
+			[],
+			expect.objectContaining({cwd: '/tmp/wt'}),
+		);
 	});
 });

--- a/src/services/terminalLauncher.test.ts
+++ b/src/services/terminalLauncher.test.ts
@@ -1,0 +1,123 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import type {EventEmitter} from 'events';
+
+const mockSpawn = vi.fn();
+
+vi.mock('child_process', () => ({
+	spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import {launchTerminal} from './terminalLauncher.js';
+
+type FakeChild = Pick<EventEmitter, 'on'> & {unref: () => void};
+
+function makeFakeChild(): FakeChild {
+	return {
+		on: vi.fn().mockReturnThis() as unknown as EventEmitter['on'],
+		unref: vi.fn(),
+	};
+}
+
+describe('terminalLauncher', () => {
+	const originalPlatform = process.platform;
+	const originalEnv = process.env['CCMANAGER_TERMINAL'];
+
+	beforeEach(() => {
+		mockSpawn.mockReset();
+		mockSpawn.mockReturnValue(makeFakeChild());
+		delete process.env['CCMANAGER_TERMINAL'];
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, 'platform', {value: originalPlatform});
+		if (originalEnv === undefined) {
+			delete process.env['CCMANAGER_TERMINAL'];
+		} else {
+			process.env['CCMANAGER_TERMINAL'] = originalEnv;
+		}
+	});
+
+	it('launches Terminal.app on macOS', () => {
+		Object.defineProperty(process, 'platform', {value: 'darwin'});
+
+		const result = launchTerminal('/tmp/worktree');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'open',
+			['-a', 'Terminal', '/tmp/worktree'],
+			expect.objectContaining({cwd: '/tmp/worktree', detached: true}),
+		);
+	});
+
+	it('launches x-terminal-emulator on linux', () => {
+		Object.defineProperty(process, 'platform', {value: 'linux'});
+
+		const result = launchTerminal('/home/user/project');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'x-terminal-emulator',
+			['--working-directory', '/home/user/project'],
+			expect.objectContaining({detached: true}),
+		);
+	});
+
+	it('launches cmd.exe via start on win32', () => {
+		Object.defineProperty(process, 'platform', {value: 'win32'});
+
+		const result = launchTerminal('C:\\repo');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'cmd.exe',
+			expect.arrayContaining(['/c', 'start']),
+			expect.objectContaining({detached: true}),
+		);
+	});
+
+	it('respects CCMANAGER_TERMINAL override with {cwd} substitution', () => {
+		Object.defineProperty(process, 'platform', {value: 'linux'});
+		process.env['CCMANAGER_TERMINAL'] = 'alacritty --working-directory {cwd}';
+
+		const result = launchTerminal('/tmp/wt');
+
+		expect(result.success).toBe(true);
+		expect(mockSpawn).toHaveBeenCalledWith(
+			'alacritty',
+			['--working-directory', '/tmp/wt'],
+			expect.objectContaining({cwd: '/tmp/wt'}),
+		);
+	});
+
+	it('returns an error on unsupported platform with no override', () => {
+		Object.defineProperty(process, 'platform', {value: 'sunos'});
+
+		const result = launchTerminal('/tmp/wt');
+
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/CCMANAGER_TERMINAL/);
+		expect(mockSpawn).not.toHaveBeenCalled();
+	});
+
+	it('captures spawn errors synchronously', () => {
+		Object.defineProperty(process, 'platform', {value: 'linux'});
+		mockSpawn.mockImplementationOnce(() => {
+			throw new Error('ENOENT');
+		});
+
+		const result = launchTerminal('/tmp/wt');
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('ENOENT');
+	});
+});

--- a/src/services/terminalLauncher.ts
+++ b/src/services/terminalLauncher.ts
@@ -1,19 +1,7 @@
-/**
- * Terminal launcher
- *
- * Spawns an external terminal window/tab at a given directory so the user
- * can inspect or run commands alongside a Claude Code session without
- * interrupting the agent's session.
- *
- * Detection order:
- * 1. CCMANAGER_TERMINAL env var (user override, full command string with {cwd} placeholder)
- * 2. Platform defaults (macOS, Linux, Windows)
- *
- * The spawned process is detached so closing ccmanager does not close the
- * terminal window, and vice versa.
- */
 import {spawn} from 'child_process';
 import {logger} from '../utils/logger.js';
+import {configReader} from './config/configReader.js';
+import type {TerminalLauncherConfig} from '../types/index.js';
 
 export interface TerminalLaunchResult {
 	success: boolean;
@@ -28,19 +16,29 @@ interface TerminalCommand {
 
 const CWD_PLACEHOLDER = '{cwd}';
 
-/**
- * Parse a user-supplied CCMANAGER_TERMINAL template by substituting {cwd}.
- * Splits on whitespace; simple and predictable. For more complex needs a
- * user can wrap their command in a shell (e.g. `sh -c "...{cwd}..."`).
- */
-function parseCustomTemplate(
-	template: string,
-	cwd: string,
-): TerminalCommand | null {
-	const trimmed = template.trim();
-	if (trimmed === '') return null;
+function substituteArgs(args: string[], cwd: string): string[] {
+	return args.map(arg =>
+		arg.includes(CWD_PLACEHOLDER)
+			? arg.replaceAll(CWD_PLACEHOLDER, cwd)
+			: arg,
+	);
+}
 
-	const tokens = trimmed.split(/\s+/);
+function fromConfig(
+	config: TerminalLauncherConfig,
+	cwd: string,
+): TerminalCommand {
+	return {
+		command: config.command,
+		args: substituteArgs(config.args ?? [], cwd),
+	};
+}
+
+function fromEnvOverride(cwd: string): TerminalCommand | null {
+	const override = process.env['CCMANAGER_TERMINAL'];
+	if (override === undefined || override.trim() === '') return null;
+
+	const tokens = override.trim().split(/\s+/);
 	if (tokens.length === 0) return null;
 
 	const substituted = tokens.map(token =>
@@ -54,17 +52,7 @@ function parseCustomTemplate(
 	return {command, args};
 }
 
-/**
- * Resolve the terminal command for the current platform.
- * Returns null if the platform is unsupported and no override is set.
- */
-function resolveTerminalCommand(cwd: string): TerminalCommand | null {
-	const override = process.env['CCMANAGER_TERMINAL'];
-	if (override !== undefined && override.trim() !== '') {
-		const parsed = parseCustomTemplate(override, cwd);
-		if (parsed !== null) return parsed;
-	}
-
+function platformDefault(cwd: string): TerminalCommand | null {
 	switch (process.platform) {
 		case 'darwin':
 			return {
@@ -72,15 +60,11 @@ function resolveTerminalCommand(cwd: string): TerminalCommand | null {
 				args: ['-a', 'Terminal', cwd],
 			};
 		case 'win32':
-			// `start` is a cmd.exe builtin; launch a new Windows Terminal or
-			// fall back to cmd.exe in the target directory.
 			return {
 				command: 'cmd.exe',
 				args: ['/c', 'start', '', 'cmd.exe', '/K', `cd /d ${cwd}`],
 			};
 		case 'linux':
-			// x-terminal-emulator is the Debian/Ubuntu alternatives entry point;
-			// most desktop environments ship a compatible wrapper.
 			return {
 				command: 'x-terminal-emulator',
 				args: ['--working-directory', cwd],
@@ -90,16 +74,21 @@ function resolveTerminalCommand(cwd: string): TerminalCommand | null {
 	}
 }
 
-/**
- * Launch a terminal window at the given directory.
- * Non-blocking: the spawned process is detached and unref'd so it survives
- * independently of ccmanager.
- */
+function resolveTerminalCommand(cwd: string): TerminalCommand | null {
+	const config = configReader.getTerminalLauncher();
+	if (config) return fromConfig(config, cwd);
+
+	const envCmd = fromEnvOverride(cwd);
+	if (envCmd) return envCmd;
+
+	return platformDefault(cwd);
+}
+
 export function launchTerminal(cwd: string): TerminalLaunchResult {
 	const resolved = resolveTerminalCommand(cwd);
 	if (resolved === null) {
-		const error = `No terminal launcher configured for platform '${process.platform}'. Set CCMANAGER_TERMINAL to a command template (use ${CWD_PLACEHOLDER} for the working directory).`;
-		logger.warn(error);
+		const error = `No terminal launcher configured for platform '${process.platform}'. Set terminalLauncher in config or CCMANAGER_TERMINAL env var.`;
+		logger.error(error);
 		return {success: false, command: '', error};
 	}
 
@@ -114,8 +103,8 @@ export function launchTerminal(cwd: string): TerminalLaunchResult {
 			shell: false,
 		});
 		child.on('error', err => {
-			logger.warn(
-				`Terminal launch failed: ${err instanceof Error ? err.message : String(err)}`,
+			logger.error(
+				`Terminal launch failed asynchronously: ${err instanceof Error ? err.message : String(err)}`,
 			);
 		});
 		child.unref();
@@ -123,7 +112,7 @@ export function launchTerminal(cwd: string): TerminalLaunchResult {
 		return {success: true, command: displayCommand};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		logger.warn(`Terminal launch threw: ${message}`);
+		logger.error(`Terminal launch threw: ${message}`);
 		return {success: false, command: displayCommand, error: message};
 	}
 }

--- a/src/services/terminalLauncher.ts
+++ b/src/services/terminalLauncher.ts
@@ -1,0 +1,129 @@
+/**
+ * Terminal launcher
+ *
+ * Spawns an external terminal window/tab at a given directory so the user
+ * can inspect or run commands alongside a Claude Code session without
+ * interrupting the agent's session.
+ *
+ * Detection order:
+ * 1. CCMANAGER_TERMINAL env var (user override, full command string with {cwd} placeholder)
+ * 2. Platform defaults (macOS, Linux, Windows)
+ *
+ * The spawned process is detached so closing ccmanager does not close the
+ * terminal window, and vice versa.
+ */
+import {spawn} from 'child_process';
+import {logger} from '../utils/logger.js';
+
+export interface TerminalLaunchResult {
+	success: boolean;
+	command: string;
+	error?: string;
+}
+
+interface TerminalCommand {
+	command: string;
+	args: string[];
+}
+
+const CWD_PLACEHOLDER = '{cwd}';
+
+/**
+ * Parse a user-supplied CCMANAGER_TERMINAL template by substituting {cwd}.
+ * Splits on whitespace; simple and predictable. For more complex needs a
+ * user can wrap their command in a shell (e.g. `sh -c "...{cwd}..."`).
+ */
+function parseCustomTemplate(
+	template: string,
+	cwd: string,
+): TerminalCommand | null {
+	const trimmed = template.trim();
+	if (trimmed === '') return null;
+
+	const tokens = trimmed.split(/\s+/);
+	if (tokens.length === 0) return null;
+
+	const substituted = tokens.map(token =>
+		token.includes(CWD_PLACEHOLDER)
+			? token.replaceAll(CWD_PLACEHOLDER, cwd)
+			: token,
+	);
+
+	const [command, ...args] = substituted;
+	if (command === undefined) return null;
+	return {command, args};
+}
+
+/**
+ * Resolve the terminal command for the current platform.
+ * Returns null if the platform is unsupported and no override is set.
+ */
+function resolveTerminalCommand(cwd: string): TerminalCommand | null {
+	const override = process.env['CCMANAGER_TERMINAL'];
+	if (override !== undefined && override.trim() !== '') {
+		const parsed = parseCustomTemplate(override, cwd);
+		if (parsed !== null) return parsed;
+	}
+
+	switch (process.platform) {
+		case 'darwin':
+			return {
+				command: 'open',
+				args: ['-a', 'Terminal', cwd],
+			};
+		case 'win32':
+			// `start` is a cmd.exe builtin; launch a new Windows Terminal or
+			// fall back to cmd.exe in the target directory.
+			return {
+				command: 'cmd.exe',
+				args: ['/c', 'start', '', 'cmd.exe', '/K', `cd /d ${cwd}`],
+			};
+		case 'linux':
+			// x-terminal-emulator is the Debian/Ubuntu alternatives entry point;
+			// most desktop environments ship a compatible wrapper.
+			return {
+				command: 'x-terminal-emulator',
+				args: ['--working-directory', cwd],
+			};
+		default:
+			return null;
+	}
+}
+
+/**
+ * Launch a terminal window at the given directory.
+ * Non-blocking: the spawned process is detached and unref'd so it survives
+ * independently of ccmanager.
+ */
+export function launchTerminal(cwd: string): TerminalLaunchResult {
+	const resolved = resolveTerminalCommand(cwd);
+	if (resolved === null) {
+		const error = `No terminal launcher configured for platform '${process.platform}'. Set CCMANAGER_TERMINAL to a command template (use ${CWD_PLACEHOLDER} for the working directory).`;
+		logger.warn(error);
+		return {success: false, command: '', error};
+	}
+
+	const {command, args} = resolved;
+	const displayCommand = [command, ...args].join(' ');
+
+	try {
+		const child = spawn(command, args, {
+			cwd,
+			detached: true,
+			stdio: 'ignore',
+			shell: false,
+		});
+		child.on('error', err => {
+			logger.warn(
+				`Terminal launch failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		});
+		child.unref();
+		logger.info(`Launched terminal: ${displayCommand}`);
+		return {success: true, command: displayCommand};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		logger.warn(`Terminal launch threw: ${message}`);
+		return {success: false, command: displayCommand, error: message};
+	}
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,6 +82,7 @@ export type MenuAction =
 			session: Session;
 			worktreePath: string;
 	  }
+	| {type: 'openTerminal'; worktreePath: string}
 	| {type: 'deleteWorktree'}
 	| {type: 'mergeWorktree'}
 	| {type: 'configuration'; scope: ConfigScope}
@@ -163,6 +164,11 @@ export interface CommandPresetsConfig {
 	selectPresetOnStart?: boolean; // Whether to show preset selector before starting session
 }
 
+export interface TerminalLauncherConfig {
+	command: string;
+	args?: string[];
+}
+
 export interface DevcontainerConfig {
 	upCommand: string; // Command to start devcontainer
 	execCommand: string; // Command to execute in devcontainer
@@ -175,6 +181,7 @@ export interface ConfigurationData {
 	worktree?: WorktreeConfig;
 	commandPresets?: CommandPresetsConfig;
 	mergeConfig?: MergeConfig;
+	terminalLauncher?: TerminalLauncherConfig;
 	autoApproval?: {
 		enabled: boolean; // Whether auto-approval is enabled
 		customCommand?: string; // Custom verification command; must output JSON matching AutoApprovalResponse
@@ -198,6 +205,7 @@ export interface ProjectConfigurationData {
 	worktree?: WorktreeConfig;
 	commandPresets?: CommandPresetsConfig;
 	mergeConfig?: MergeConfig;
+	terminalLauncher?: TerminalLauncherConfig;
 	autoApproval?: AutoApprovalConfig;
 }
 
@@ -224,6 +232,9 @@ export interface IConfigReader {
 
 	// Merge Config
 	getMergeConfig(): MergeConfig | undefined;
+
+	// Terminal Launcher
+	getTerminalLauncher(): TerminalLauncherConfig | undefined;
 
 	// Auto Approval
 	getAutoApprovalConfig(): AutoApprovalConfig | undefined;
@@ -255,6 +266,9 @@ export interface IConfigEditor extends IConfigReader {
 
 	// Merge Config
 	setMergeConfig(value: MergeConfig): void;
+
+	// Terminal Launcher
+	setTerminalLauncher(value: TerminalLauncherConfig): void;
 
 	// Auto Approval
 	setAutoApprovalConfig(value: AutoApprovalConfig): void;


### PR DESCRIPTION
Fixes #229. Adds the ability to open a terminal for a worktree directly from ccmanager.

## What changed

- New SessionActions entry: `T  Open terminal in worktree directory`.
- New service `src/services/terminalLauncher.ts` that spawns a detached terminal at the worktree path. The process is unref'd so closing ccmanager does not close the terminal window and vice versa.
- Platform defaults:
  - macOS: `open -a Terminal <cwd>`
  - Linux: `x-terminal-emulator --working-directory <cwd>`
  - Windows: `cmd.exe /c start cmd.exe /K cd /d <cwd>`
- `CCMANAGER_TERMINAL` env var overrides the default. `{cwd}` in the template is substituted with the worktree path, for example `CCMANAGER_TERMINAL=\"alacritty --working-directory {cwd}\"`.

## Verification

- `npm run typecheck` clean
- `npm run lint` clean
- `npx vitest run src/services/terminalLauncher.test.ts` 6 tests pass (macOS, Linux, Windows, env override, unsupported platform, spawn error)
- Full vitest suite: no new failures beyond the 121 pre-existing failures on `main`

## Out of scope

The issue also mentioned opening the default IDE in the worktree directory. That is left for a follow-up so this PR stays focused on the terminal use case.