### PR TITLE
feat: allow selecting remote branches in new worktree

### DIFF
--- a/src/components/ConfigureWorktree.tsx
+++ b/src/components/ConfigureWorktree.tsx
@@ -38,6 +38,9 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 	const [autoUseDefaultBranch, setAutoUseDefaultBranch] = useState(
 		worktreeConfig.autoUseDefaultBranch ?? false,
 	);
+	const [includeRemoteBranches, setIncludeRemoteBranches] = useState(
+		worktreeConfig.includeRemoteBranches ?? false,
+	);
 	const [editMode, setEditMode] = useState<EditMode>('menu');
 	const [tempPattern, setTempPattern] = useState(pattern);
 
@@ -80,6 +83,10 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 			value: 'toggleAutoUseDefault',
 		},
 		{
+			label: `Include Remote Branches: ${includeRemoteBranches ? '✅ Enabled' : '❌ Disabled'}`,
+			value: 'toggleIncludeRemote',
+		},
+		{
 			label: '💾 Save Changes',
 			value: 'save',
 		},
@@ -107,6 +114,9 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 			case 'toggleAutoUseDefault':
 				setAutoUseDefaultBranch(!autoUseDefaultBranch);
 				break;
+			case 'toggleIncludeRemote':
+				setIncludeRemoteBranches(!includeRemoteBranches);
+				break;
 			case 'save':
 				// Save the configuration
 				configEditor.setWorktreeConfig({
@@ -115,6 +125,7 @@ const ConfigureWorktree: React.FC<ConfigureWorktreeProps> = ({onComplete}) => {
 					copySessionData,
 					sortByLastSession,
 					autoUseDefaultBranch,
+					includeRemoteBranches,
 				});
 				onComplete();
 				break;

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -68,6 +68,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	const presetsConfig = configReader.getCommandPresets();
 	const isAutoDirectory = worktreeConfig.autoDirectory;
 	const isAutoUseDefaultBranch = worktreeConfig.autoUseDefaultBranch ?? false;
+	const includeRemoteBranches = worktreeConfig.includeRemoteBranches ?? false;
 	const limit = 10;
 
 	const getInitialStep = (): Step => {
@@ -94,6 +95,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	const [isLoadingBranches, setIsLoadingBranches] = useState(true);
 	const [branchLoadError, setBranchLoadError] = useState<string | null>(null);
 	const [branches, setBranches] = useState<string[]>([]);
+	const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
 	const [defaultBranch, setDefaultBranch] = useState<string>('main');
 
 	useEffect(() => {
@@ -101,8 +103,15 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 		const service = new WorktreeService(projectPath);
 
 		const loadBranches = async () => {
+			const branchesEffect = includeRemoteBranches
+				? service.getBranchesWithRemotesEffect()
+				: Effect.map(service.getAllBranchesEffect(), (list: string[]) => ({
+						local: list,
+						remote: [] as string[],
+					}));
+
 			const workflow = Effect.all(
-				[service.getAllBranchesEffect(), service.getDefaultBranchEffect()],
+				[branchesEffect, service.getDefaultBranchEffect()],
 				{concurrency: 2},
 			);
 
@@ -112,9 +121,13 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 						type: 'error' as const,
 						message: formatError(error),
 					}),
-					onSuccess: ([branchList, defaultBr]: [string[], string]) => ({
+					onSuccess: ([branchData, defaultBr]: [
+						{local: string[]; remote: string[]},
+						string,
+					]) => ({
 						type: 'success' as const,
-						branches: branchList,
+						local: branchData.local,
+						remote: branchData.remote,
 						defaultBranch: defaultBr,
 					}),
 				}),
@@ -125,7 +138,8 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 					setBranchLoadError(result.message);
 					setIsLoadingBranches(false);
 				} else {
-					setBranches(result.branches);
+					setBranches(result.local);
+					setRemoteBranches(result.remote);
 					setDefaultBranch(result.defaultBranch);
 					setIsLoadingBranches(false);
 
@@ -149,17 +163,29 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 		return () => {
 			cancelled = true;
 		};
-	}, [projectPath, isAutoUseDefaultBranch]);
+	}, [projectPath, isAutoUseDefaultBranch, includeRemoteBranches]);
 
-	const allBranchItems: BranchItem[] = useMemo(
-		() => [
+	const allBranchItems: BranchItem[] = useMemo(() => {
+		const defaultRemoteSuffix = `/${defaultBranch}`;
+		const defaultRemotes = remoteBranches.filter(br =>
+			br.endsWith(defaultRemoteSuffix),
+		);
+		const otherRemotes = remoteBranches.filter(
+			br => !br.endsWith(defaultRemoteSuffix),
+		);
+
+		return [
 			{label: `${defaultBranch} (default)`, value: defaultBranch},
+			...defaultRemotes.map(br => ({
+				label: `${br} (default remote)`,
+				value: br,
+			})),
 			...branches
 				.filter(br => br !== defaultBranch)
 				.map(br => ({label: br, value: br})),
-		],
-		[branches, defaultBranch],
-	);
+			...otherRemotes.map(br => ({label: br, value: br})),
+		];
+	}, [branches, remoteBranches, defaultBranch]);
 
 	const {isSearchMode, searchQuery, selectedIndex, setSearchQuery} =
 		useSearchMode(allBranchItems.length, {
@@ -462,6 +488,14 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 					{!isSearchMode && (
 						<Box marginTop={1}>
 							<Text dimColor>Press / to search</Text>
+						</Box>
+					)}
+					{includeRemoteBranches && (
+						<Box marginTop={1}>
+							<Text dimColor>
+								Tip: If the branch list feels slow, disable &quot;Include Remote
+								Branches&quot; in Configuration → Configure Worktree Settings.
+							</Text>
 						</Box>
 					)}
 				</Box>

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -7,6 +7,7 @@ import {configReader} from '../services/config/configReader.js';
 import {generateWorktreeDirectory} from '../utils/worktreeUtils.js';
 import {WorktreeService} from '../services/worktreeService.js';
 import {useSearchMode} from '../hooks/useSearchMode.js';
+import {useDynamicLimit} from '../hooks/useDynamicLimit.js';
 import SearchableList from './SearchableList.js';
 import {Effect} from 'effect';
 import type {AppError} from '../types/errors.js';
@@ -69,7 +70,6 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	const isAutoDirectory = worktreeConfig.autoDirectory;
 	const isAutoUseDefaultBranch = worktreeConfig.autoUseDefaultBranch ?? false;
 	const includeRemoteBranches = worktreeConfig.includeRemoteBranches ?? false;
-	const limit = 10;
 
 	const getInitialStep = (): Step => {
 		if (isAutoDirectory) {
@@ -191,6 +191,12 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 		useSearchMode(allBranchItems.length, {
 			isDisabled: step !== 'base-branch',
 		});
+
+	const limit = useDynamicLimit({
+		fixedRows: includeRemoteBranches ? 10 : 8,
+		isSearchMode,
+		hasError: !!branchLoadError,
+	});
 
 	const branchItems = useMemo(() => {
 		if (!searchQuery) return allBranchItems;

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -592,6 +592,56 @@ export class WorktreeService {
 	}
 
 	/**
+	 * Effect-based getBranchesWithRemotes operation
+	 * Returns local and remote branches separately so callers can distinguish them.
+	 * Remote branches keep their `<remote>/<branch>` prefix (e.g. `origin/main`).
+	 *
+	 * @returns {Effect.Effect<{local: string[]; remote: string[]}, GitError, never>}
+	 */
+	getBranchesWithRemotesEffect(): Effect.Effect<
+		{local: string[]; remote: string[]},
+		GitError,
+		never
+	> {
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const self = this;
+		return Effect.catchAll(
+			Effect.try({
+				try: () => {
+					const output = execSync(
+						"git branch -a --format='%(refname:short)' | grep -v HEAD | sort -u",
+						{
+							cwd: self.rootPath,
+							encoding: 'utf8',
+							shell: '/bin/bash',
+						},
+					);
+
+					const remotes = self.getAllRemotes();
+					const remotePrefixes = remotes.map(r => `${r}/`);
+
+					const local: string[] = [];
+					const remote: string[] = [];
+
+					for (const raw of output.trim().split('\n')) {
+						const branch = raw.trim();
+						if (!branch) continue;
+						if (remotePrefixes.some(prefix => branch.startsWith(prefix))) {
+							remote.push(branch);
+						} else {
+							local.push(branch);
+						}
+					}
+
+					return {local, remote};
+				},
+				catch: (error: unknown) => error,
+			}),
+			(_error: unknown) => Effect.succeed({local: [], remote: []}),
+		);
+	}
+
+	/**
 	 * Effect-based getCurrentBranch operation
 	 * Returns Effect that may fail with GitError
 	 *

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -140,6 +140,7 @@ export interface WorktreeConfig {
 	copySessionData?: boolean; // Whether to copy Claude session data by default
 	sortByLastSession?: boolean; // Whether to sort worktrees by last opened session
 	autoUseDefaultBranch?: boolean; // Whether to automatically use default branch as base branch
+	includeRemoteBranches?: boolean; // Whether to include remote branches in base branch selection
 }
 
 export interface MergeConfig {


### PR DESCRIPTION
## Summary
- Add an **Include Remote Branches** toggle under Configure Worktree Settings. When on, `NewWorktree`'s base-branch selector shows remote refs (e.g. `origin/main`) alongside local branches. The default branch's remote is placed directly after the default local branch and labeled `(default remote)`.
- New `WorktreeService#getBranchesWithRemotesEffect()` returns local and remote branches separately, using each configured remote's prefix (not just hard-coded `origin/`).
- `NewWorktree` now uses the existing `useDynamicLimit` hook (the same one `Menu` uses) so the branch list grows with terminal height instead of being hard-capped at 10. `fixedRows` is bumped by 2 when the remote-inclusion tip is visible.
- Shows a dim tip in the base-branch step suggesting users disable the option in Configuration if the list feels slow.

## Test plan
- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] Manual: enable "Include Remote Branches" in Configure Worktree Settings, open `New Worktree`, confirm `origin/<default>` appears as `(default remote)` right below the default local branch and other remote refs appear at the bottom of the list.
- [ ] Manual: disable the setting, confirm the list returns to local-only behaviour.
- [ ] Manual: resize the terminal while on the base-branch step — the visible slice should grow/shrink instead of staying at 10 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)