### PR TITLE
fix(claude): keep spinner + tokens visible in long TodoWrite blocks

### DIFF
--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -557,6 +557,30 @@ describe('ClaudeStateDetector', () => {
 			expect(state).toBe('idle');
 		});
 
+		it('should detect busy when spinner + token stats header is followed by a long TodoWrite checklist', () => {
+			// Regression: the recent block contains a spinner/token header and
+			// many checklist items with no internal blank line. All lines are
+			// part of the same contiguous update and should be inspected.
+			terminal = createMockTerminal([
+				'✽ Add GitHub Actions workflow and commit… (50s · ↓ 794 tokens)',
+				'  ⎿  ✔ Create docs/index.config.json',
+				'     ✔ Reorganize existing docs into topic directories',
+				'     ✔ Add frontmatter to existing docs',
+				'     ✔ Create docs/INDEX.md, docs/README.md, templates, workflow',
+				'     ✔ Create root AGENTS.md and README.md',
+				'     ✔ Write manifest generation Go script',
+				'     ✔ Add Makefile tasks and run first generation',
+				'     ◼ Add GitHub Actions workflow and commit',
+				'──────────────────────────────',
+				'❯',
+				'──────────────────────────────',
+			]);
+
+			const state = detector.detectState(terminal, 'idle');
+
+			expect(state).toBe('busy');
+		});
+
 		it('should ignore stale spinner output outside the latest block above the prompt box', () => {
 			terminal = createMockTerminal([
 				'✻ Seasoning… (44s · ↓ 247 tokens)',

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -14,8 +14,6 @@ const SPINNER_ACTIVITY_PATTERN = new RegExp(
 // Session stats above the prompt, e.g. "(9m 21s · ↓ 13.7k tokens)" — requires parens, a digit, and "tokens"
 const TOKEN_STATS_LINE_PATTERN = /\([^)]*\d[^)]*tokens\s*\)/i;
 
-const BUSY_LOOKBACK_LINES = 5;
-
 // Workaround: Claude Code sometimes appears idle in terminal output while
 // still actively processing (busy). To mitigate false idle transitions,
 // require terminal output to remain unchanged for this duration before
@@ -118,8 +116,7 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			start--;
 		}
 
-		const recentBlock = lines.slice(Math.max(start, 0));
-		return recentBlock.slice(-BUSY_LOOKBACK_LINES).join('\n');
+		return lines.slice(Math.max(start, 0)).join('\n');
 	}
 
 	detectState(terminal: Terminal, currentState: SessionState): SessionState {


### PR DESCRIPTION
## Summary
- Remove the `BUSY_LOOKBACK_LINES = 5` slice in `getRecentContentAbovePromptBox`. When Claude Code's TodoWrite renders a long checklist inside the same recent block as the spinner header, the cap dropped the spinner + token stats lines and the detector fell through to idle.
- The empty-line boundary introduced in #249 already separates stale redraw fragments, so the additional cap was redundant and only caused false idle detections on long updates.

## Repro (before fix)

Claude Code was rendering the following block above the prompt and ccmanager kept the session in idle instead of busy:

```
✽ Add GitHub Actions workflow and commit… (50s · ↓ 794 tokens)
  ⎿  ✔ Create docs/index.config.json
     ✔ Reorganize existing docs into topic directories
     ✔ Add frontmatter to existing docs
     ✔ Create docs/INDEX.md, docs/README.md, templates, workflow
     ✔ Create root AGENTS.md and README.md
     ✔ Write manifest generation Go script
     ✔ Add Makefile tasks and run first generation
     ◼ Add GitHub Actions workflow and commit
```

The spinner + tokens line on row 1 was pushed out of the 5-line window by 8 checklist items; none of the remaining 5 lines contained a recognizable busy indicator.

## Test plan
- [x] `npm run test -- src/services/stateDetector/claude.test.ts` (68 passed, including the two stale-guard tests from #249 and the new TodoWrite regression test)
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Full `npm run test`