### PR TITLE
fix: stabilize xterm session restore under Claude busy animations

### DIFF
--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1378,7 +1378,9 @@ describe('SessionManager', () => {
 
 				await vi.advanceTimersByTimeAsync(120);
 				expect(restoreHandler).toHaveBeenCalledTimes(2);
-				expect(restoreHandler.mock.calls[1]?.[1]).toMatch(/^\u001b\[Hsnap/);
+				expect(restoreHandler.mock.calls[1]?.[1]).toMatch(
+					/^\u001b\[2J\u001b\[Hsnap/,
+				);
 				expect(serializeMock).toHaveBeenLastCalledWith({
 					scrollback: 0,
 					excludeAltBuffer: true,

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1162,6 +1162,7 @@ describe('SessionManager', () => {
 			const session = await Effect.runPromise(
 				sessionManager.createSessionWithPresetEffect('/test/worktree'),
 			);
+			await session.stateMutex.update(data => ({...data, state: 'idle'}));
 			const normalBuffer = session.terminal.buffer.normal as unknown as {
 				baseY: number;
 				length: number;
@@ -1191,6 +1192,46 @@ describe('SessionManager', () => {
 			expect(restoreHandler).toHaveBeenCalledWith(
 				session,
 				'\u001b[31mrestored\u001b[0m\u001b[8;12H',
+			);
+		});
+
+		it('should emit a viewport-only restore snapshot while session is busy', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			const normalBuffer = session.terminal.buffer.normal as unknown as {
+				baseY: number;
+				length: number;
+				cursorY: number;
+				cursorX: number;
+			};
+			normalBuffer.baseY = 260;
+			normalBuffer.length = 300;
+			normalBuffer.cursorY = 7;
+			normalBuffer.cursorX = 11;
+			session.restoreScrollbackBaseLine = 120;
+			const serializeMock = vi
+				.spyOn(session.serializer, 'serialize')
+				.mockReturnValue('\u001b[31mbusy-viewport\u001b[0m');
+			const restoreHandler = vi.fn();
+			sessionManager.on('sessionRestore', restoreHandler);
+
+			sessionManager.setSessionActive(session.id, true);
+
+			expect(serializeMock).toHaveBeenCalledWith({
+				scrollback: 0,
+				excludeAltBuffer: true,
+			});
+			expect(restoreHandler).toHaveBeenCalledWith(
+				session,
+				'\u001b[31mbusy-viewport\u001b[0m\u001b[8;12H',
 			);
 		});
 

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1379,7 +1379,7 @@ describe('SessionManager', () => {
 				await vi.advanceTimersByTimeAsync(120);
 				expect(restoreHandler).toHaveBeenCalledTimes(2);
 				expect(restoreHandler.mock.calls[1]?.[1]).toMatch(
-					/^\u001b\[2J\u001b\[Hsnap/,
+					/^\u001b\[\?7h\u001b\[2J\u001b\[Hsnap.*\u001b\[\?7l$/,
 				);
 				expect(serializeMock).toHaveBeenLastCalledWith({
 					scrollback: 0,

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1343,6 +1343,118 @@ describe('SessionManager', () => {
 
 			expect(eventOrder).toEqual(['restore', 'data']);
 		});
+
+		it('should re-emit a viewport-only snapshot after the PTY quiet period', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+					id: '1',
+					name: 'Main',
+					command: 'claude',
+				});
+				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+				const session = await Effect.runPromise(
+					sessionManager.createSessionWithPresetEffect('/test/worktree'),
+				);
+				(
+					session.terminal.buffer.normal as unknown as {
+						length: number;
+					}
+				).length = 1;
+				const serializeMock = vi
+					.spyOn(session.serializer, 'serialize')
+					.mockReturnValue('snap');
+				const restoreHandler = vi.fn();
+				sessionManager.on('sessionRestore', restoreHandler);
+
+				sessionManager.setSessionActive(session.id, true);
+				expect(restoreHandler).toHaveBeenCalledTimes(1);
+
+				await vi.advanceTimersByTimeAsync(50);
+				mockPty.emit('data', 'late-chunk');
+				await vi.advanceTimersByTimeAsync(50);
+				expect(restoreHandler).toHaveBeenCalledTimes(1);
+
+				await vi.advanceTimersByTimeAsync(120);
+				expect(restoreHandler).toHaveBeenCalledTimes(2);
+				expect(restoreHandler.mock.calls[1]?.[1]).toMatch(/^\u001b\[Hsnap/);
+				expect(serializeMock).toHaveBeenLastCalledWith({
+					scrollback: 0,
+					excludeAltBuffer: true,
+				});
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should force a refresh at the max-wait deadline even while data keeps streaming', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+					id: '1',
+					name: 'Main',
+					command: 'claude',
+				});
+				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+				const session = await Effect.runPromise(
+					sessionManager.createSessionWithPresetEffect('/test/worktree'),
+				);
+				(
+					session.terminal.buffer.normal as unknown as {
+						length: number;
+					}
+				).length = 1;
+				vi.spyOn(session.serializer, 'serialize').mockReturnValue('snap');
+				const restoreHandler = vi.fn();
+				sessionManager.on('sessionRestore', restoreHandler);
+
+				sessionManager.setSessionActive(session.id, true);
+				expect(restoreHandler).toHaveBeenCalledTimes(1);
+
+				for (let elapsed = 0; elapsed < 400; elapsed += 50) {
+					await vi.advanceTimersByTimeAsync(50);
+					mockPty.emit('data', 'chunk');
+				}
+				expect(restoreHandler).toHaveBeenCalledTimes(2);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should cancel a scheduled refresh when the session is deactivated', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+					id: '1',
+					name: 'Main',
+					command: 'claude',
+				});
+				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+				const session = await Effect.runPromise(
+					sessionManager.createSessionWithPresetEffect('/test/worktree'),
+				);
+				(
+					session.terminal.buffer.normal as unknown as {
+						length: number;
+					}
+				).length = 1;
+				vi.spyOn(session.serializer, 'serialize').mockReturnValue('snap');
+				const restoreHandler = vi.fn();
+				sessionManager.on('sessionRestore', restoreHandler);
+
+				sessionManager.setSessionActive(session.id, true);
+				expect(restoreHandler).toHaveBeenCalledTimes(1);
+
+				sessionManager.setSessionActive(session.id, false);
+				await vi.advanceTimersByTimeAsync(500);
+				expect(restoreHandler).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 	});
 
 	describe('static methods', () => {

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -419,11 +419,19 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		}
 		const snapshot = this.getRestoreSnapshot(session, {viewportOnly: true});
 		if (snapshot.length > 0) {
-			// Clear the viewport before repainting. Without the \x1b[2J, a refresh
-			// snapshot that is shorter than the already-displayed content leaves a
-			// "ghost tail" at the bottom — the pre-refresh rows beyond the new
-			// snapshot's last row keep rendering and produce visible duplicates.
-			this.emit('sessionRestore', session, `\x1b[2J\x1b[H${snapshot}`);
+			// \x1b[2J: clear the viewport before repainting — without this, a
+			//   refresh snapshot shorter than the already-displayed content leaves
+			//   a "ghost tail" of pre-refresh rows at the bottom.
+			// \x1b[?7h / \x1b[?7l: Session.tsx disables auto-wrap (DECAWM) after
+			//   the initial restore, but SerializeAddon omits row separators for
+			//   wrapped lines and relies on DECAWM to advance to the next row
+			//   (see PR #276). Re-enable auto-wrap just for the snapshot write so
+			//   wrapped viewport rows don't overlap, then restore the TUI default.
+			this.emit(
+				'sessionRestore',
+				session,
+				`\x1b[?7h\x1b[2J\x1b[H${snapshot}\x1b[?7l`,
+			);
 		}
 	}
 

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -33,6 +33,15 @@ const {Terminal} = pkg;
 const TERMINAL_CONTENT_MAX_LINES = 300;
 const TERMINAL_SCROLLBACK_LINES = 5000;
 const TERMINAL_RESTORE_SCROLLBACK_LINES = 200;
+// Claude Code's Ink-based renderer sometimes splits a single UI redraw across
+// multiple PTY writes with short time gaps. If we snapshot between chunks, the
+// resulting viewport can miss rows (e.g. empty middle area while the top/bottom
+// chrome already rendered). Re-emit the snapshot after the PTY output has been
+// quiet for this long so late chunks are accounted for.
+const RESTORE_REFRESH_QUIET_MS = 120;
+// Cap on how long we wait for quiet before forcing the refresh, so continuous
+// streaming output (e.g. a long busy turn) still produces an updated snapshot.
+const RESTORE_REFRESH_MAX_WAIT_MS = 400;
 
 export interface SessionCounts {
 	idle: number;
@@ -51,6 +60,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	private autoApprovalDisabledWorktrees: Set<string> = new Set();
 	private restoringSessions: Set<string> = new Set();
 	private bufferedRestoreData: Map<string, string[]> = new Map();
+	private restoreRefreshTimers: Map<string, NodeJS.Timeout> = new Map();
+	private restoreRefreshDeadlines: Map<string, number> = new Map();
 
 	private async spawn(
 		command: string,
@@ -306,7 +317,10 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		);
 	}
 
-	private getRestoreSnapshot(session: Session): string {
+	private getRestoreSnapshot(
+		session: Session,
+		options: {viewportOnly?: boolean} = {},
+	): string {
 		const activeBuffer = session.terminal.buffer.active;
 		if (activeBuffer.type !== 'normal') {
 			return session.serializer.serialize({
@@ -323,9 +337,11 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		// While the session is busy, cursor-addressed status-box redraws can push
 		// stale frames into scrollback (e.g. Claude's spinner + token stats line).
 		// Those ghost rows render as duplicated status bars when replayed, so
-		// restore only the viewport during busy state.
+		// restore only the viewport during busy state. Refresh re-emits also
+		// bypass scrollback to avoid duplicating history into real-terminal
+		// scrollback on top of the initial emit.
 		const isBusy = session.stateMutex.getSnapshot().state === 'busy';
-		if (isBusy) {
+		if (options.viewportOnly || isBusy) {
 			const snapshot = session.serializer.serialize({
 				scrollback: 0,
 				excludeAltBuffer: true,
@@ -356,6 +372,57 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		const cursorCol = normalBuffer.cursorX + 1;
 
 		return `${snapshot}\x1b[${cursorRow};${cursorCol}H`;
+	}
+
+	private scheduleRestoreRefresh(session: Session): void {
+		this.restoreRefreshDeadlines.set(
+			session.id,
+			Date.now() + RESTORE_REFRESH_MAX_WAIT_MS,
+		);
+		this.armRestoreRefreshTimer(session);
+	}
+
+	private armRestoreRefreshTimer(session: Session): void {
+		const deadline = this.restoreRefreshDeadlines.get(session.id);
+		if (deadline === undefined) {
+			return;
+		}
+		const existing = this.restoreRefreshTimers.get(session.id);
+		if (existing !== undefined) {
+			clearTimeout(existing);
+			this.restoreRefreshTimers.delete(session.id);
+		}
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			this.fireRestoreRefresh(session);
+			return;
+		}
+		const delay = Math.min(RESTORE_REFRESH_QUIET_MS, remaining);
+		const timer = setTimeout(() => this.fireRestoreRefresh(session), delay);
+		this.restoreRefreshTimers.set(session.id, timer);
+	}
+
+	private cancelRestoreRefresh(session: Session): void {
+		const existing = this.restoreRefreshTimers.get(session.id);
+		if (existing !== undefined) {
+			clearTimeout(existing);
+			this.restoreRefreshTimers.delete(session.id);
+		}
+		this.restoreRefreshDeadlines.delete(session.id);
+	}
+
+	private fireRestoreRefresh(session: Session): void {
+		this.restoreRefreshTimers.delete(session.id);
+		this.restoreRefreshDeadlines.delete(session.id);
+		if (!session.isActive) {
+			return;
+		}
+		const snapshot = this.getRestoreSnapshot(session, {viewportOnly: true});
+		if (snapshot.length > 0) {
+			// Home the cursor first so the viewport-only snapshot overwrites the
+			// real terminal in place rather than scrolling over the current view.
+			this.emit('sessionRestore', session, `\x1b[H${snapshot}`);
+		}
 	}
 
 	private async createSessionInternal(
@@ -498,6 +565,13 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			}
 
 			session.lastActivity = new Date();
+
+			// If a restore-refresh is pending, each incoming chunk resets the
+			// quiet timer so the follow-up snapshot only fires after Claude's
+			// multi-chunk redraw has settled.
+			if (this.restoreRefreshDeadlines.has(session.id)) {
+				this.armRestoreRefreshTimer(session);
+			}
 
 			// Only emit data events when session is active
 			if (session.isActive) {
@@ -705,9 +779,11 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 						}
 					}
 				}
+				this.scheduleRestoreRefresh(session);
 			} else {
 				this.restoringSessions.delete(session.id);
 				this.bufferedRestoreData.delete(session.id);
+				this.cancelRestoreRefresh(session);
 			}
 		}
 	}
@@ -792,6 +868,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			this.waitingWithBottomBorder.delete(sessionId);
 			this.restoringSessions.delete(sessionId);
 			this.bufferedRestoreData.delete(sessionId);
+			this.cancelRestoreRefresh(session);
 			this.emit('sessionDestroyed', session);
 		}
 	}
@@ -852,6 +929,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 
 				this.sessions.delete(sessionId);
 				this.waitingWithBottomBorder.delete(sessionId);
+				this.cancelRestoreRefresh(session);
 				this.emit('sessionDestroyed', session);
 			},
 			catch: (error: unknown) => {

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -419,9 +419,11 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		}
 		const snapshot = this.getRestoreSnapshot(session, {viewportOnly: true});
 		if (snapshot.length > 0) {
-			// Home the cursor first so the viewport-only snapshot overwrites the
-			// real terminal in place rather than scrolling over the current view.
-			this.emit('sessionRestore', session, `\x1b[H${snapshot}`);
+			// Clear the viewport before repainting. Without the \x1b[2J, a refresh
+			// snapshot that is shorter than the already-displayed content leaves a
+			// "ghost tail" at the bottom — the pre-refresh rows beyond the new
+			// snapshot's last row keep rendering and produce visible duplicates.
+			this.emit('sessionRestore', session, `\x1b[2J\x1b[H${snapshot}`);
 		}
 	}
 

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -320,6 +320,21 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			return '';
 		}
 
+		// While the session is busy, cursor-addressed status-box redraws can push
+		// stale frames into scrollback (e.g. Claude's spinner + token stats line).
+		// Those ghost rows render as duplicated status bars when replayed, so
+		// restore only the viewport during busy state.
+		const isBusy = session.stateMutex.getSnapshot().state === 'busy';
+		if (isBusy) {
+			const snapshot = session.serializer.serialize({
+				scrollback: 0,
+				excludeAltBuffer: true,
+			});
+			const cursorRow = normalBuffer.cursorY + 1;
+			const cursorCol = normalBuffer.cursorX + 1;
+			return `${snapshot}\x1b[${cursorRow};${cursorCol}H`;
+		}
+
 		const scrollbackStart = Math.max(
 			0,
 			normalBuffer.baseY - TERMINAL_RESTORE_SCROLLBACK_LINES,


### PR DESCRIPTION
## Summary

Follow-up to #271 / #274 / #276 / #282 targeting two remaining restore-rendering regressions observed against Claude Code sessions.

### 1. Ghost status-box rows when restoring during busy animations

`getRestoreSnapshot` previously replayed up to 200 lines of normal-buffer scrollback. Claude Code's busy-state status box is redrawn in place each animation frame, and new messages scrolling underneath push the **old** status-box rows into scrollback without erasing them. The serialized replay then faithfully rendered the stale copies, surfacing as duplicated status bars above the current viewport.

**Fix** (250cb4e): while the session state is \`busy\`, fall back to a viewport-only snapshot (\`scrollback: 0\`, \`excludeAltBuffer: true\`) so the ghost rows never reach the real terminal. Idle-state restores still include bounded scrollback as before.

### 2. Partial viewport after restore (empty middle / missing prompt box)

Ink can split a single UI redraw across multiple PTY writes with short time gaps. A synchronous \`setSessionActive(true)\` sometimes captures the headless xterm between chunks, emitting a snapshot with the top/bottom chrome drawn and the middle rows blank. Returning to the menu and re-entering let the late chunks land before the next snapshot, which is why a second entry appeared to "fix" the display.

**Fix** (328ca19): after the initial emit, schedule a debounced follow-up \`sessionRestore\`. Every incoming PTY chunk resets a 120 ms quiet timer, capped at 400 ms overall, after which a fresh viewport-only snapshot is re-emitted. The initial emit keeps the fast-path UX; the refresh picks up any late chunks.

Two follow-ups on the refresh path:

- 0cac83a: prefix the refresh payload with \`\x1b[2J\` so a shorter refresh snapshot doesn't leave a "ghost tail" of pre-refresh rows at the bottom of the viewport (the regression in the screenshot from 2026-04-21).
- c733b97: wrap the refresh payload with \`\x1b[?7h\` / \`\x1b[?7l\`. Session.tsx disables DECAWM after the initial restore for live-TUI stability, but SerializeAddon relies on DECAWM to advance wrapped rows, so the refresh had to re-enable it transiently to avoid re-introducing the #276 overlap.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test\` passes — new cases in \`src/services/sessionManager.test.ts\`:
  - viewport-only snapshot while busy
  - refresh fires after the PTY quiet period
  - refresh fires at max-wait deadline under continuous streaming
  - refresh cancelled when the session is deactivated
- [ ] Manual: enter a long Claude session during a busy turn → ghost status-bar rows no longer restored
- [ ] Manual: return to menu mid-animation and re-enter → middle of the viewport renders on the first entry, no lingering rows below the refreshed snapshot
- [ ] Manual: long wrapped line in the viewport when leaving menu → no wrap overlap after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)