### PR TITLE
fix: surface worktree hook failures

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -14,17 +14,20 @@ import type {Effect as EffectType} from 'effect';
 import type {
 	Session as SessionType,
 	Worktree,
+	CreateWorktreeResult,
 	GitProject,
 	DevcontainerConfig,
 	MenuAction,
 } from '../types/index.js';
 import {ENV_VARS} from '../constants/env.js';
+import {ProcessError} from '../types/errors.js';
 
 type AppComponent = typeof import('./App.js').default;
 
 type MenuMockProps = {
 	onMenuAction: (action: MenuAction) => void | Promise<void>;
 	onSelectRecentProject?: (project: GitProject) => void | Promise<void>;
+	error?: string | null;
 };
 
 type NewWorktreeMockProps = {
@@ -63,7 +66,7 @@ type CreateWorktreeEffect = (
 	baseBranch: string,
 	copySessionData: boolean,
 	copyClaudeDirectory: boolean,
-) => EffectType.Effect<Worktree, unknown, never>;
+) => EffectType.Effect<CreateWorktreeResult, unknown, never>;
 
 type DeleteWorktreeEffect = (
 	worktreePath: string,
@@ -256,11 +259,13 @@ beforeEach(() => {
 	deleteWorktreeEffectMock.mockReset();
 	createWorktreeEffectMock.mockImplementation((path, branch) =>
 		Effect.succeed({
-			path,
-			branch,
-			isMainWorktree: false,
-			hasSession: false,
-		} as Worktree),
+			worktree: {
+				path,
+				branch,
+				isMainWorktree: false,
+				hasSession: false,
+			} as Worktree,
+		}),
 	);
 	deleteWorktreeEffectMock.mockImplementation(() => Effect.succeed(undefined));
 	sessionManagers.length = 0;
@@ -312,14 +317,16 @@ describe('App component loading state machine', () => {
 		createWorktreeEffectMock.mockImplementation(() =>
 			Effect.tryPromise({
 				try: () =>
-					new Promise<Worktree>(resolve => {
+					new Promise<CreateWorktreeResult>(resolve => {
 						resolveWorktree = () =>
 							resolve({
-								path: '/tmp/test',
-								branch: 'feature',
-								isMainWorktree: false,
-								hasSession: false,
-							} as Worktree);
+								worktree: {
+									path: '/tmp/test',
+									branch: 'feature',
+									isMainWorktree: false,
+									hasSession: false,
+								} as Worktree,
+							});
 					}),
 				catch: (error: unknown) => error as never,
 			}),
@@ -405,14 +412,207 @@ describe('App component loading state machine', () => {
 		unmount();
 	});
 
+	it('shows a hook error screen before returning to menu when post-creation hook fails after manual worktree creation', async () => {
+		createWorktreeEffectMock.mockImplementation((path, branch) =>
+			Effect.succeed({
+				worktree: {
+					path,
+					branch,
+					isMainWorktree: false,
+					hasSession: false,
+				} as Worktree,
+				postCreationHookError: new ProcessError({
+					command: 'exit 1',
+					exitCode: 1,
+					message: 'Hook exited with code 1',
+				}),
+			}),
+		);
+
+		const {lastFrame, stdin, unmount} = render(<App version="test" />);
+		await waitForCondition(() => Boolean(menuProps));
+
+		await Promise.resolve(menuProps!.onMenuAction({type: 'newWorktree'}));
+		await waitForCondition(() => Boolean(newWorktreeProps));
+
+		await Promise.resolve(
+			newWorktreeProps!.onComplete({
+				creationMode: 'manual',
+				path: '/tmp/test',
+				branch: 'feature',
+				baseBranch: 'main',
+				copySessionData: false,
+				copyClaudeDirectory: false,
+			}),
+		);
+
+		await waitForCondition(
+			() => lastFrame()?.includes('Worktree hook error') ?? false,
+		);
+
+		expect(lastFrame()).toContain('Post-creation hook failed');
+		expect(lastFrame()).toContain('Hook exited with code 1');
+		expect(lastFrame()).toContain('Press any key to return to the menu');
+
+		await flush(120);
+		stdin.write('x');
+		await waitForCondition(() => lastFrame()?.includes('Menu View') ?? false);
+
+		unmount();
+	});
+
+	it('shows a hook error screen before returning to menu when pre-creation hook fails', async () => {
+		createWorktreeEffectMock.mockImplementation(() =>
+			Effect.fail(
+				new ProcessError({
+					command: 'exit 1',
+					exitCode: 1,
+					message: 'Hook exited with code 1',
+				}),
+			),
+		);
+
+		const {lastFrame, stdin, unmount} = render(<App version="test" />);
+		await waitForCondition(() => Boolean(menuProps));
+
+		await Promise.resolve(menuProps!.onMenuAction({type: 'newWorktree'}));
+		await waitForCondition(() => Boolean(newWorktreeProps));
+
+		await Promise.resolve(
+			newWorktreeProps!.onComplete({
+				creationMode: 'manual',
+				path: '/tmp/test',
+				branch: 'feature',
+				baseBranch: 'main',
+				copySessionData: false,
+				copyClaudeDirectory: false,
+			}),
+		);
+
+		await waitForCondition(
+			() => lastFrame()?.includes('Worktree hook error') ?? false,
+		);
+
+		expect(lastFrame()).toContain('Pre-creation hook failed');
+		expect(lastFrame()).toContain('Hook exited with code 1');
+		expect(lastFrame()).toContain('Press any key to return to the menu');
+
+		await flush(120);
+		stdin.write('x');
+		await waitForCondition(() => lastFrame()?.includes('Menu View') ?? false);
+
+		unmount();
+	});
+
+	it('ignores immediate input on the hook error screen so the error remains visible', async () => {
+		createWorktreeEffectMock.mockImplementation((path, branch) =>
+			Effect.succeed({
+				worktree: {
+					path,
+					branch,
+					isMainWorktree: false,
+					hasSession: false,
+				} as Worktree,
+				postCreationHookError: new ProcessError({
+					command: 'exit 1',
+					exitCode: 1,
+					message: 'Hook exited with code 1',
+				}),
+			}),
+		);
+
+		const {lastFrame, stdin, unmount} = render(<App version="test" />);
+		await waitForCondition(() => Boolean(menuProps));
+
+		await Promise.resolve(menuProps!.onMenuAction({type: 'newWorktree'}));
+		await waitForCondition(() => Boolean(newWorktreeProps));
+
+		await Promise.resolve(
+			newWorktreeProps!.onComplete({
+				creationMode: 'manual',
+				path: '/tmp/test',
+				branch: 'feature',
+				baseBranch: 'main',
+				copySessionData: false,
+				copyClaudeDirectory: false,
+			}),
+		);
+
+		await waitForCondition(
+			() => lastFrame()?.includes('Worktree hook error') ?? false,
+		);
+
+		stdin.write('x');
+		await flush(40);
+
+		expect(lastFrame()).toContain('Worktree hook error');
+		expect(lastFrame()).toContain('Hook exited with code 1');
+
+		await flush(120);
+		stdin.write('x');
+		await waitForCondition(() => lastFrame()?.includes('Menu View') ?? false);
+
+		unmount();
+	});
+
+	it('does not auto-start a prompt-first session when post-creation hook fails', async () => {
+		createWorktreeEffectMock.mockImplementation((path, branch) =>
+			Effect.succeed({
+				worktree: {
+					path,
+					branch,
+					isMainWorktree: false,
+					hasSession: false,
+				} as Worktree,
+				postCreationHookError: new ProcessError({
+					command: 'exit 1',
+					exitCode: 1,
+					message: 'Hook exited with code 1',
+				}),
+			}),
+		);
+
+		const {lastFrame, unmount} = render(<App version="test" />);
+		await waitForCondition(() => Boolean(menuProps));
+		const sessionManager = sessionManagers[0]!;
+
+		await Promise.resolve(menuProps!.onMenuAction({type: 'newWorktree'}));
+		await waitForCondition(() => Boolean(newWorktreeProps));
+
+		await Promise.resolve(
+			newWorktreeProps!.onComplete({
+				creationMode: 'prompt',
+				path: '/tmp/project',
+				projectPath: '/tmp/project',
+				autoDirectoryPattern: '../{branch}',
+				baseBranch: 'main',
+				presetId: 'claude',
+				initialPrompt: 'trim worktree name output',
+				copySessionData: false,
+				copyClaudeDirectory: false,
+			}),
+		);
+
+		await waitForCondition(
+			() => lastFrame()?.includes('Worktree hook error') ?? false,
+		);
+
+		expect(sessionManager.createSessionWithPresetEffect).not.toHaveBeenCalled();
+		expect(lastFrame()).toContain('Post-creation hook failed');
+
+		unmount();
+	});
+
 	it('uses the created worktree path when auto-starting a prompt-first session', async () => {
 		createWorktreeEffectMock.mockImplementation((_path, branch) =>
 			Effect.succeed({
-				path: '/tmp/resolved-worktree',
-				branch,
-				isMainWorktree: false,
-				hasSession: false,
-			} as Worktree),
+				worktree: {
+					path: '/tmp/resolved-worktree',
+					branch,
+					isMainWorktree: false,
+					hasSession: false,
+				} as Worktree,
+			}),
 		);
 
 		const {unmount} = render(<App version="test" />);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, useCallback} from 'react';
-import {useApp, Box, Text} from 'ink';
+import {useApp, useInput, Box, Text} from 'ink';
 import {Effect} from 'effect';
 import Menu from './Menu.js';
 import Dashboard from './Dashboard.js';
@@ -31,7 +31,7 @@ import {
 	AmbiguousBranchError,
 	RemoteBranchMatch,
 } from '../types/index.js';
-import {type AppError} from '../types/errors.js';
+import {type AppError, type ProcessError} from '../types/errors.js';
 import {configReader} from '../services/config/configReader.js';
 import {ConfigScope} from '../types/index.js';
 import {ENV_VARS} from '../constants/env.js';
@@ -45,6 +45,7 @@ type View =
 	| 'session'
 	| 'new-worktree'
 	| 'creating-worktree'
+	| 'worktree-hook-error'
 	| 'creating-session'
 	| 'creating-session-preset'
 	| 'delete-worktree'
@@ -80,6 +81,9 @@ const App: React.FC<AppProps> = ({
 	);
 	const [activeSession, setActiveSession] = useState<ISession | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [worktreeHookError, setWorktreeHookError] = useState<string | null>(
+		null,
+	);
 	const [menuKey, setMenuKey] = useState(0); // Force menu refresh
 
 	const [selectedWorktree, setSelectedWorktree] = useState<Worktree | null>(
@@ -125,6 +129,31 @@ const App: React.FC<AppProps> = ({
 
 	// State for streaming devcontainer up logs
 	const [devcontainerLogs, setDevcontainerLogs] = useState<string[]>([]);
+	const [canReturnFromHookError, setCanReturnFromHookError] = useState(false);
+
+	useEffect(() => {
+		if (view !== 'worktree-hook-error') {
+			setCanReturnFromHookError(false);
+			return;
+		}
+
+		const timeout = setTimeout(() => {
+			setCanReturnFromHookError(true);
+		}, 100);
+
+		return () => {
+			clearTimeout(timeout);
+		};
+	}, [view]);
+
+	useInput(() => {
+		if (view !== 'worktree-hook-error' || !canReturnFromHookError) {
+			return;
+		}
+
+		setWorktreeHookError(null);
+		handleReturnToMenu();
+	});
 
 	// Helper function to format error messages based on error type using _tag discrimination
 	const formatErrorMessage = (error: AppError): string => {
@@ -141,6 +170,14 @@ const App: React.FC<AppProps> = ({
 				return `Validation failed for ${error.field}: ${error.constraint}`;
 		}
 	};
+
+	const formatPostCreationHookWarning = (error: ProcessError): string =>
+		`Post-creation hook failed: ${error.message}`;
+
+	const formatPreCreationHookError = (error: AppError): string =>
+		error._tag === 'ProcessError'
+			? `Pre-creation hook failed: ${error.message}`
+			: formatErrorMessage(error);
 
 	// Helper function to create session with Effect-based error handling
 	const createSessionWithEffect = useCallback(
@@ -373,7 +410,7 @@ const App: React.FC<AppProps> = ({
 
 	// Helper function to handle worktree creation results
 	const handleWorktreeCreationResult = (
-		result: {success: boolean; error?: string},
+		result: {success: boolean; error?: string; warning?: string},
 		creationData: {
 			path: string;
 			branch: string;
@@ -385,6 +422,13 @@ const App: React.FC<AppProps> = ({
 		},
 	) => {
 		if (result.success) {
+			if (result.warning) {
+				setError(null);
+				setWorktreeHookError(result.warning);
+				setView('worktree-hook-error');
+				return;
+			}
+
 			if (creationData.presetId && creationData.initialPrompt) {
 				setPendingMenuSessionLaunch({
 					worktree: {
@@ -599,7 +643,14 @@ const App: React.FC<AppProps> = ({
 		// Transform Effect result to legacy format for handleWorktreeCreationResult
 		if (result._tag === 'Left') {
 			// Handle error using pattern matching on _tag
-			const errorMessage = formatErrorMessage(result.left);
+			const errorMessage = formatPreCreationHookError(result.left);
+			if (result.left._tag === 'ProcessError') {
+				setError(null);
+				setWorktreeHookError(errorMessage);
+				setView('worktree-hook-error');
+				return;
+			}
+
 			handleWorktreeCreationResult(
 				{success: false, error: errorMessage},
 				{
@@ -618,9 +669,14 @@ const App: React.FC<AppProps> = ({
 			);
 		} else {
 			// Success case
-			const createdWorktree = result.right;
+			const {worktree: createdWorktree, postCreationHookError} = result.right;
 			handleWorktreeCreationResult(
-				{success: true},
+				{
+					success: true,
+					warning: postCreationHookError
+						? formatPostCreationHookWarning(postCreationHookError)
+						: undefined,
+				},
 				{
 					path: createdWorktree.path,
 					branch: createdWorktree.branch || branch,
@@ -675,15 +731,28 @@ const App: React.FC<AppProps> = ({
 
 		if (result._tag === 'Left') {
 			// Handle error using pattern matching on _tag
-			const errorMessage = formatErrorMessage(result.left);
+			const errorMessage = formatPreCreationHookError(result.left);
+			if (result.left._tag === 'ProcessError') {
+				setError(null);
+				setWorktreeHookError(errorMessage);
+				setView('worktree-hook-error');
+				return;
+			}
+
 			setError(errorMessage);
 			setView('new-worktree');
 		} else {
+			const {worktree: createdWorktree, postCreationHookError} = result.right;
 			handleWorktreeCreationResult(
-				{success: true},
 				{
-					path: creationData.path,
-					branch: creationData.branch,
+					success: true,
+					warning: postCreationHookError
+						? formatPostCreationHookWarning(postCreationHookError)
+						: undefined,
+				},
+				{
+					path: createdWorktree.path,
+					branch: createdWorktree.branch || creationData.branch,
 					baseBranch: selectedRemoteRef,
 					copySessionData: creationData.copySessionData,
 					copyClaudeDirectory: creationData.copyClaudeDirectory,
@@ -880,6 +949,20 @@ const App: React.FC<AppProps> = ({
 		return (
 			<Box flexDirection="column">
 				<LoadingSpinner message={message} color="cyan" />
+			</Box>
+		);
+	}
+
+	if (view === 'worktree-hook-error') {
+		return (
+			<Box flexDirection="column">
+				<Box marginBottom={1}>
+					<Text color="red">Worktree hook error</Text>
+				</Box>
+				<Box marginBottom={1}>
+					<Text color="red">{worktreeHookError}</Text>
+				</Box>
+				<Text dimColor>Press any key to return to the menu</Text>
 			</Box>
 		);
 	}

--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -4,7 +4,7 @@ import {execSync} from 'child_process';
 import {existsSync, statSync, Stats} from 'fs';
 import {configReader} from './config/configReader.js';
 import {Effect} from 'effect';
-import {GitError} from '../types/errors.js';
+import {GitError, ProcessError} from '../types/errors.js';
 
 // Mock child_process module
 vi.mock('child_process');
@@ -30,6 +30,7 @@ vi.mock('./config/configReader.js', () => ({
 
 // Mock HookExecutor
 vi.mock('../utils/hookExecutor.js', () => ({
+	executeWorktreePreCreationHook: vi.fn(),
 	executeWorktreePostCreationHook: vi.fn(),
 }));
 
@@ -809,7 +810,7 @@ branch refs/heads/feature
 			);
 			const result = await Effect.runPromise(effect);
 
-			expect(result).toMatchObject({
+			expect(result.worktree).toMatchObject({
 				path: '/path/to/worktree',
 				branch: 'new-feature',
 				isMainWorktree: false,
@@ -851,6 +852,107 @@ branch refs/heads/feature
 			} else {
 				expect.fail('Should have returned Left with GitError');
 			}
+		});
+
+		it('should fail with ProcessError and skip git worktree add when pre-creation hook fails', async () => {
+			const {executeWorktreePreCreationHook} =
+				await import('../utils/hookExecutor.js');
+			const mockedPreHook = vi.mocked(executeWorktreePreCreationHook);
+			mockedGetWorktreeHooks.mockReturnValue({
+				pre_creation: {
+					command: 'exit 1',
+					enabled: true,
+				},
+			});
+			mockedPreHook.mockReturnValue(
+				Effect.fail(
+					new ProcessError({
+						command: 'exit 1',
+						exitCode: 1,
+						message: 'Hook exited with code 1',
+					}),
+				),
+			);
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd.includes('rev-parse --verify')) {
+						throw new Error('Branch not found');
+					}
+					if (cmd.includes('git worktree add')) {
+						throw new Error('git worktree add should not be called');
+					}
+				}
+				return '';
+			});
+
+			const result = await Effect.runPromise(
+				Effect.either(
+					service.createWorktreeEffect(
+						'/path/to/worktree',
+						'new-feature',
+						'main',
+					),
+				),
+			);
+
+			expect(result._tag).toBe('Left');
+			if (result._tag === 'Left') {
+				expect(result.left).toBeInstanceOf(ProcessError);
+			}
+			expect(mockedExecSync).not.toHaveBeenCalledWith(
+				expect.stringContaining('git worktree add'),
+				expect.anything(),
+			);
+		});
+
+		it('should return Worktree with postCreationHookError when post-creation hook fails', async () => {
+			const {executeWorktreePostCreationHook} =
+				await import('../utils/hookExecutor.js');
+			const mockedPostHook = vi.mocked(executeWorktreePostCreationHook);
+			const hookError = new ProcessError({
+				command: 'exit 1',
+				exitCode: 1,
+				message: 'Hook exited with code 1',
+			});
+
+			mockedGetWorktreeHooks.mockReturnValue({
+				post_creation: {
+					command: 'exit 1',
+					enabled: true,
+				},
+			});
+			mockedPostHook.mockReturnValue(Effect.fail(hookError));
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd.includes('rev-parse --verify')) {
+						throw new Error('Branch not found');
+					}
+					if (cmd.includes('git worktree add')) {
+						return '';
+					}
+				}
+				return '';
+			});
+
+			const result = await Effect.runPromise(
+				service.createWorktreeEffect(
+					'/path/to/worktree',
+					'new-feature',
+					'main',
+				),
+			);
+
+			expect(result.worktree).toMatchObject({
+				path: '/path/to/worktree',
+				branch: 'new-feature',
+			});
+			expect(result.postCreationHookError).toBe(hookError);
 		});
 	});
 

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import {Effect, Either} from 'effect';
 import {
 	Worktree,
+	CreateWorktreeResult,
 	AmbiguousBranchError,
 	RemoteBranchMatch,
 	MergeConfig,
@@ -19,6 +20,7 @@ import {
 	executeWorktreePreCreationHook,
 } from '../utils/hookExecutor.js';
 import {configReader} from './config/configReader.js';
+import {logger} from '../utils/logger.js';
 
 const CLAUDE_DIR = '.claude';
 
@@ -891,7 +893,11 @@ export class WorktreeService {
 		baseBranch: string,
 		copySessionData = false,
 		copyClaudeDirectory = false,
-	): Effect.Effect<Worktree, GitError | FileSystemError | ProcessError, never> {
+	): Effect.Effect<
+		CreateWorktreeResult,
+		GitError | FileSystemError | ProcessError,
+		never
+	> {
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const self = this;
 
@@ -912,6 +918,17 @@ export class WorktreeService {
 				? worktreePath
 				: path.join(absoluteGitRoot, worktreePath);
 
+			logger.info('Worktree creation requested', {
+				inputPath: worktreePath,
+				resolvedPath,
+				branch,
+				baseBranch,
+				rootPath: self.rootPath,
+				absoluteGitRoot,
+				copySessionData,
+				copyClaudeDirectory,
+			});
+
 			// Check if branch exists
 			const branchExists = yield* Effect.catchAll(
 				Effect.try({
@@ -929,6 +946,14 @@ export class WorktreeService {
 
 			// Execute pre-creation hook if configured (BEFORE git worktree add)
 			const worktreeHooksConfig = configReader.getWorktreeHooks();
+			logger.info('Worktree hook config before creation', {
+				preCreationEnabled: Boolean(worktreeHooksConfig.pre_creation?.enabled),
+				preCreationCommand: worktreeHooksConfig.pre_creation?.command,
+				postCreationEnabled: Boolean(
+					worktreeHooksConfig.post_creation?.enabled,
+				),
+				postCreationCommand: worktreeHooksConfig.post_creation?.command,
+			});
 			if (
 				worktreeHooksConfig.pre_creation?.enabled &&
 				worktreeHooksConfig.pre_creation?.command
@@ -955,9 +980,17 @@ export class WorktreeService {
 			// Execute the worktree creation command
 			yield* Effect.try({
 				try: () => {
+					logger.info('Executing git worktree add command', {
+						command,
+						cwd: absoluteGitRoot,
+					});
 					execSync(command, {
 						cwd: absoluteGitRoot,
 						encoding: 'utf8',
+					});
+					logger.info('Git worktree add command succeeded', {
+						command,
+						cwd: absoluteGitRoot,
 					});
 				},
 				catch: (error: unknown) => {
@@ -1017,30 +1050,43 @@ export class WorktreeService {
 
 			// Execute post-creation hook if configured
 			const worktreeHooks = configReader.getWorktreeHooks();
-			if (
-				worktreeHooks.post_creation?.enabled &&
-				worktreeHooks.post_creation?.command
-			) {
-				const newWorktree: Worktree = {
-					path: resolvedPath,
-					branch: branch,
-					isMainWorktree: false,
-					hasSession: false,
-				};
-
-				yield* executeWorktreePostCreationHook(
-					worktreeHooks.post_creation.command,
-					newWorktree,
-					absoluteGitRoot,
-					baseBranch,
-				);
-			}
-
-			return {
+			logger.info('Worktree hook config after creation', {
+				postCreationEnabled: Boolean(worktreeHooks.post_creation?.enabled),
+				postCreationCommand: worktreeHooks.post_creation?.command,
+				resolvedPath,
+				branch,
+			});
+			let postCreationHookError: ProcessError | undefined;
+			const createdWorktree: Worktree = {
 				path: resolvedPath,
 				branch,
 				isMainWorktree: false,
 				hasSession: false,
+			};
+
+			if (
+				worktreeHooks.post_creation?.enabled &&
+				worktreeHooks.post_creation?.command
+			) {
+				const postCreationHookResult = yield* Effect.either(
+					executeWorktreePostCreationHook(
+						worktreeHooks.post_creation.command,
+						createdWorktree,
+						absoluteGitRoot,
+						baseBranch,
+					),
+				);
+				if (postCreationHookResult._tag === 'Left') {
+					postCreationHookError = postCreationHookResult.left;
+					logger.error(
+						`Failed to execute post-creation hook: ${postCreationHookError.message}`,
+					);
+				}
+			}
+
+			return {
+				worktree: createdWorktree,
+				postCreationHookError,
 			};
 		});
 	}

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -41,6 +41,8 @@ export class ProcessError extends Data.TaggedError('ProcessError')<{
 	readonly signal?: string;
 	readonly exitCode?: number;
 	readonly message: string;
+	readonly stdout?: string;
+	readonly stderr?: string;
 }> {}
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ import type {SerializeAddon} from '@xterm/addon-serialize';
 import {GitStatus} from '../utils/gitStatus.js';
 import {Mutex, SessionStateData} from '../utils/mutex.js';
 import type {StateDetector} from '../services/stateDetector/types.js';
+import type {ProcessError} from './errors.js';
 
 export type Terminal = InstanceType<typeof pkg.Terminal>;
 
@@ -31,6 +32,11 @@ export interface Worktree {
 	gitStatus?: GitStatus;
 	gitStatusError?: string;
 	lastCommitDate?: Date;
+}
+
+export interface CreateWorktreeResult {
+	worktree: Worktree;
+	postCreationHookError?: ProcessError;
 }
 
 export interface Session {
@@ -344,7 +350,7 @@ export interface IWorktreeService {
 		copySessionData?: boolean,
 		copyClaudeDirectory?: boolean,
 	): import('effect').Effect.Effect<
-		Worktree,
+		CreateWorktreeResult,
 		| import('../types/errors.js').GitError
 		| import('../types/errors.js').FileSystemError
 		| import('../types/errors.js').ProcessError,

--- a/src/utils/hookExecutor.test.ts
+++ b/src/utils/hookExecutor.test.ts
@@ -205,7 +205,7 @@ describe('hookExecutor Integration Tests', () => {
 	});
 
 	describe('executeWorktreePostCreationHook (real execution)', () => {
-		it('should not throw even when command fails', async () => {
+		it('should fail with ProcessError when command fails', async () => {
 			// Arrange
 			const tmpDir = await mkdtemp(join(tmpdir(), 'hook-test-'));
 			const worktree = {
@@ -216,12 +216,18 @@ describe('hookExecutor Integration Tests', () => {
 			};
 
 			try {
-				// Act & Assert - should not throw even with failing command
-				await expect(
-					Effect.runPromise(
+				// Act & Assert - post-creation hook failures are surfaced to callers
+				const result = await Effect.runPromise(
+					Effect.either(
 						executeWorktreePostCreationHook('exit 1', worktree, tmpDir, 'main'),
 					),
-				).resolves.toBeUndefined();
+				);
+
+				expect(result._tag).toBe('Left');
+				if (result._tag === 'Left') {
+					expect(result.left._tag).toBe('ProcessError');
+					expect(result.left.exitCode).toBe(1);
+				}
 			} finally {
 				// Cleanup
 				await rm(tmpDir, {recursive: true});

--- a/src/utils/hookExecutor.ts
+++ b/src/utils/hookExecutor.ts
@@ -5,6 +5,7 @@ import {ProcessError} from '../types/errors.js';
 import {Worktree, Session, SessionState} from '../types/index.js';
 import {WorktreeService} from '../services/worktreeService.js';
 import {configReader} from '../services/config/configReader.js';
+import {logger} from './logger.js';
 
 export interface HookEnvironment {
 	CCMANAGER_WORKTREE_PATH: string;
@@ -54,6 +55,12 @@ export function executeHook(
 	environment: HookEnvironment,
 ): Effect.Effect<void, ProcessError> {
 	return Effect.async<void, ProcessError>(resume => {
+		logger.info('Hook execution starting', {
+			command,
+			cwd,
+			environment,
+		});
+
 		// Use spawn with shell to execute the command and wait for all child processes
 		const child = spawn(command, [], {
 			cwd,
@@ -65,7 +72,12 @@ export function executeHook(
 			stdio: ['ignore', 'pipe', 'pipe'],
 		});
 
+		let stdout = '';
 		let stderr = '';
+
+		child.stdout?.on('data', data => {
+			stdout += data.toString();
+		});
 
 		// Collect stderr for logging
 		child.stderr?.on('data', data => {
@@ -74,10 +86,25 @@ export function executeHook(
 
 		// Wait for the process and all its children to exit
 		child.on('exit', (code, signal) => {
+			logger.info('Hook execution finished', {
+				command,
+				cwd,
+				exitCode: code,
+				signal,
+				stdout,
+				stderr,
+			});
+
 			if (code !== 0 || signal) {
 				const errorMessage = signal
 					? `Hook terminated by signal ${signal}`
 					: `Hook exited with code ${code}`;
+				const outputDetails = [
+					stderr ? `Stderr: ${stderr}` : undefined,
+					stdout ? `Stdout: ${stdout}` : undefined,
+				]
+					.filter(Boolean)
+					.join('\n');
 
 				resume(
 					Effect.fail(
@@ -85,9 +112,11 @@ export function executeHook(
 							command,
 							exitCode: code ?? undefined,
 							signal: signal ?? undefined,
-							message: stderr
-								? `${errorMessage}\nStderr: ${stderr}`
+							message: outputDetails
+								? `${errorMessage}\n${outputDetails}`
 								: errorMessage,
+							stdout,
+							stderr,
 						}),
 					),
 				);
@@ -99,6 +128,11 @@ export function executeHook(
 
 		// Handle errors in spawning the process
 		child.on('error', error => {
+			logger.error('Hook spawn failed', {
+				command,
+				cwd,
+				error: error.message,
+			});
 			resume(
 				Effect.fail(
 					new ProcessError({
@@ -139,6 +173,14 @@ export function executeWorktreePreCreationHook(
 		environment.CCMANAGER_BASE_BRANCH = baseBranch;
 	}
 
+	logger.info('Worktree pre-creation hook configured', {
+		command,
+		worktreePath,
+		branch,
+		gitRoot,
+		baseBranch,
+	});
+
 	// Execute in git root (worktree doesn't exist yet)
 	// NO Effect.catchAll - errors must propagate to abort creation
 	return executeHook(command, gitRoot, environment);
@@ -153,7 +195,7 @@ export function executeWorktreePostCreationHook(
 	worktree: Worktree,
 	gitRoot: string,
 	baseBranch?: string,
-): Effect.Effect<void, never> {
+): Effect.Effect<void, ProcessError> {
 	const environment: HookEnvironment = {
 		CCMANAGER_WORKTREE_PATH: worktree.path,
 		CCMANAGER_WORKTREE_BRANCH: worktree.branch || 'unknown',
@@ -164,14 +206,15 @@ export function executeWorktreePostCreationHook(
 		environment.CCMANAGER_BASE_BRANCH = baseBranch;
 	}
 
-	return Effect.catchAll(
-		executeHook(command, worktree.path, environment),
-		error => {
-			// Log error but don't throw - hooks should not break the main flow
-			console.error(`Failed to execute post-creation hook: ${error.message}`);
-			return Effect.void;
-		},
-	);
+	logger.info('Worktree post-creation hook configured', {
+		command,
+		worktreePath: worktree.path,
+		branch: worktree.branch || 'unknown',
+		gitRoot,
+		baseBranch,
+	});
+
+	return executeHook(command, worktree.path, environment);
 }
 
 /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import {format} from 'util';
-import os from 'os';
+import * as os from 'os';
 
 /**
  * Logger configuration with size management and log rotation


### PR DESCRIPTION
## Summary
- surface pre-creation and post-creation hook failures in a dedicated TUI error screen
- preserve hook stdout/stderr in ProcessError and logs
- keep post-creation worktree creation successful while blocking auto session start until the error is acknowledged

## Verification
- bun run typecheck
- bun run lint
- bun run build
- bun run vitest --run src/components/App.test.tsx src/utils/hookExecutor.test.ts src/services/worktreeService.test.ts

Note: full `bun run test` was attempted, but an existing dist submodule test failed while running `git config --global protocol.file.allow always` because `/Users/kbwo/.gitconfig` was locked. The targeted tests for this change pass.