### PR TITLE
fix: pass projectPath to MergeWorktree for multi-project mode

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -923,6 +923,7 @@ const App: React.FC<AppProps> = ({
 					</Box>
 				)}
 				<MergeWorktree
+					projectPath={selectedProject?.path}
 					onComplete={handleReturnToMenu}
 					onCancel={handleReturnToMenu}
 				/>

--- a/src/components/MergeWorktree.test.tsx
+++ b/src/components/MergeWorktree.test.tsx
@@ -53,6 +53,79 @@ describe('MergeWorktree - Effect Integration', () => {
 		vi.clearAllMocks();
 	});
 
+	it('should pass projectPath to WorktreeService when provided', async () => {
+		const projectPath = '/test/project';
+		const mockWorktrees: Worktree[] = [
+			{
+				path: '/test/project/main',
+				branch: 'main',
+				isMainWorktree: true,
+				hasSession: false,
+			},
+			{
+				path: '/test/project/feature',
+				branch: 'feature-1',
+				isMainWorktree: false,
+				hasSession: false,
+			},
+		];
+
+		const mockEffect = Effect.succeed(mockWorktrees);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: vi.fn(() => mockEffect),
+			} as Partial<WorktreeService> as WorktreeService;
+		});
+
+		const onComplete = vi.fn();
+		const onCancel = vi.fn();
+
+		render(
+			<MergeWorktree
+				projectPath={projectPath}
+				onComplete={onComplete}
+				onCancel={onCancel}
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		expect(WorktreeService).toHaveBeenCalledWith(projectPath);
+	});
+
+	it('should use undefined when projectPath not provided', async () => {
+		const mockWorktrees: Worktree[] = [
+			{
+				path: '/test/main',
+				branch: 'main',
+				isMainWorktree: true,
+				hasSession: false,
+			},
+			{
+				path: '/test/feature',
+				branch: 'feature-1',
+				isMainWorktree: false,
+				hasSession: false,
+			},
+		];
+
+		const mockEffect = Effect.succeed(mockWorktrees);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: vi.fn(() => mockEffect),
+			} as Partial<WorktreeService> as WorktreeService;
+		});
+
+		const onComplete = vi.fn();
+		const onCancel = vi.fn();
+
+		render(<MergeWorktree onComplete={onComplete} onCancel={onCancel} />);
+
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		expect(WorktreeService).toHaveBeenCalledWith(undefined);
+	});
+
 	it('should load worktrees using Effect-based method', async () => {
 		// GIVEN: Mock worktrees returned by Effect
 		const mockWorktrees: Worktree[] = [

--- a/src/components/MergeWorktree.tsx
+++ b/src/components/MergeWorktree.tsx
@@ -158,14 +158,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 		};
 
 		performMerge();
-	}, [
-		step,
-		sourceBranch,
-		targetBranch,
-		operation,
-		mergeConfig,
-		projectPath,
-	]);
+	}, [step, sourceBranch, targetBranch, operation, mergeConfig, projectPath]);
 
 	// Check for uncommitted changes in source worktree when entering check-uncommitted step
 	useEffect(() => {

--- a/src/components/MergeWorktree.tsx
+++ b/src/components/MergeWorktree.tsx
@@ -11,6 +11,7 @@ import {MergeConfig} from '../types/index.js';
 import {hasUncommittedChanges} from '../utils/gitUtils.js';
 
 interface MergeWorktreeProps {
+	projectPath?: string;
 	onComplete: () => void;
 	onCancel: () => void;
 }
@@ -32,6 +33,7 @@ interface BranchItem {
 }
 
 const MergeWorktree: React.FC<MergeWorktreeProps> = ({
+	projectPath,
 	onComplete,
 	onCancel,
 }) => {
@@ -44,7 +46,6 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 	);
 	const [operation, setOperation] = useState<'merge' | 'rebase'>('merge');
 	const [mergeError, setMergeError] = useState<string | null>(null);
-	const [worktreeService] = useState(() => new WorktreeService());
 	const [mergeConfig] = useState<MergeConfig | undefined>(() =>
 		configReader.getMergeConfig(),
 	);
@@ -56,6 +57,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 
 		const loadWorktrees = async () => {
 			try {
+				const worktreeService = new WorktreeService(projectPath);
 				const loadedWorktrees = await Effect.runPromise(
 					worktreeService.getWorktreesEffect(),
 				);
@@ -93,7 +95,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 		return () => {
 			cancelled = true;
 		};
-	}, [worktreeService]);
+	}, [projectPath]);
 
 	useInput((input, key) => {
 		if (shortcutManager.matchesShortcut('cancel', input, key)) {
@@ -130,6 +132,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 
 		const performMerge = async () => {
 			try {
+				const worktreeService = new WorktreeService(projectPath);
 				await Effect.runPromise(
 					worktreeService.mergeWorktreeEffect(
 						sourceBranch,
@@ -161,7 +164,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 		targetBranch,
 		operation,
 		mergeConfig,
-		worktreeService,
+		projectPath,
 	]);
 
 	// Check for uncommitted changes in source worktree when entering check-uncommitted step
@@ -171,6 +174,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 		const checkUncommitted = async () => {
 			try {
 				// Find the worktree path for the source branch
+				const worktreeService = new WorktreeService(projectPath);
 				const worktrees = await Effect.runPromise(
 					worktreeService.getWorktreesEffect(),
 				);
@@ -191,7 +195,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 		};
 
 		checkUncommitted();
-	}, [step, sourceBranch, worktreeService]);
+	}, [step, sourceBranch, projectPath]);
 
 	if (isLoading) {
 		return (
@@ -458,6 +462,7 @@ const MergeWorktree: React.FC<MergeWorktreeProps> = ({
 				onConfirm={async () => {
 					try {
 						// Find the worktree path for the source branch
+						const worktreeService = new WorktreeService(projectPath);
 						const worktrees = await Effect.runPromise(
 							worktreeService.getWorktreesEffect(),
 						);


### PR DESCRIPTION
## Summary

Pass `projectPath` to `MergeWorktree` so it targets the selected project in multi-project mode — matching the pattern already used by `DeleteWorktree`.

`WorktreeService` is now created as a local variable with `projectPath` at each call site (load, merge, uncommitted-check, delete) instead of once at mount via `useState`.

## Test plan

- Two unit tests for `projectPath` forwarding (with and without prop)
- `npm run typecheck` and `npm run test` pass
