### PR TITLE
feat: detect MCP tool permission prompts as waiting_input in Codex detector

### DIFF
--- a/src/services/stateDetector/codex.test.ts
+++ b/src/services/stateDetector/codex.test.ts
@@ -220,7 +220,7 @@ describe('CodexStateDetector', () => {
 		expect(state).toBe('waiting_input');
 	});
 
-	it('should detect waiting_input for MCP tool permission prompt with "esc to cancel"', () => {
+	it('should detect waiting_input for MCP tool permission prompt with "enter to submit"', () => {
 		// Arrange
 		terminal = createMockTerminal([
 			'Field 1/1',

--- a/src/services/stateDetector/codex.test.ts
+++ b/src/services/stateDetector/codex.test.ts
@@ -219,4 +219,27 @@ describe('CodexStateDetector', () => {
 		// Assert
 		expect(state).toBe('waiting_input');
 	});
+
+	it('should detect waiting_input for MCP tool permission prompt with "esc to cancel"', () => {
+		// Arrange
+		terminal = createMockTerminal([
+			'Field 1/1',
+			'Allow the chrome-devtools MCP server to run tool "new_page"?',
+			'',
+			'timeout: 10000',
+			'url: http://localhost:4000/scenarios',
+			'',
+			'› 1. Allow                   Run the tool and continue.',
+			'2. Allow for this session  Run the tool and remember this choice for this session.',
+			'3. Always allow            Run the tool and remember this choice for future tool calls.',
+			'4. Cancel                  Cancel this tool call',
+			'enter to submit | esc to cancel',
+		]);
+
+		// Act
+		const state = detector.detectState(terminal, 'idle');
+
+		// Assert
+		expect(state).toBe('waiting_input');
+	});
 });

--- a/src/services/stateDetector/codex.ts
+++ b/src/services/stateDetector/codex.ts
@@ -23,7 +23,8 @@ export class CodexStateDetector extends BaseStateDetector {
 		if (
 			lowerContent.includes('allow command?') ||
 			lowerContent.includes('[y/n]') ||
-			lowerContent.includes('yes (y)')
+			lowerContent.includes('yes (y)') ||
+			lowerContent.includes('esc to cancel')
 		) {
 			return 'waiting_input';
 		}

--- a/src/services/stateDetector/codex.ts
+++ b/src/services/stateDetector/codex.ts
@@ -24,7 +24,7 @@ export class CodexStateDetector extends BaseStateDetector {
 			lowerContent.includes('allow command?') ||
 			lowerContent.includes('[y/n]') ||
 			lowerContent.includes('yes (y)') ||
-			lowerContent.includes('esc to cancel')
+			lowerContent.includes('enter to submit')
 		) {
 			return 'waiting_input';
 		}


### PR DESCRIPTION
## Summary

- Add `enter to submit` pattern to `CodexStateDetector` to detect MCP tool permission prompts (e.g. "Allow the chrome-devtools MCP server to run tool X?") as `waiting_input`
- Add corresponding test case covering the full permission prompt layout

## Test plan

- [ ] Run `npm run test` and confirm the new test passes
- [ ] Manually verify that Codex sessions showing MCP permission prompts transition to `waiting_input` state in ccmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)