### PR TITLE
fix: tighten xterm session restore against busy ghosts, resize duplicates, and partial-frame snapshots

### DIFF
--- a/src/components/Session.test.tsx
+++ b/src/components/Session.test.tsx
@@ -119,7 +119,10 @@ describe('Session', () => {
 		expect(terminalResize.mock.invocationCallOrder[0] ?? 0).toBeLessThan(
 			setSessionActive.mock.invocationCallOrder[0] ?? 0,
 		);
-		expect(testState.stdout?.write).toHaveBeenNthCalledWith(2, '\nrestored');
+		expect(testState.stdout?.write).toHaveBeenNthCalledWith(
+			2,
+			'\x1b[?7h\nrestored\x1b[?7l',
+		);
 		expect(testState.stdout?.write).toHaveBeenNthCalledWith(3, '\x1b[?7l');
 	});
 });

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -90,17 +90,20 @@ const Session: React.FC<SessionProps> = ({
 		stdout.write('\x1B[2J\x1B[H');
 
 		// Restore the current terminal state from the headless xterm snapshot.
-		// The xterm serialize addon relies on auto-wrap (DECAWM) being enabled to
-		// render wrapped lines. It omits row separators for wrapped rows and expects
-		// characters to naturally overflow to the next line, so auto-wrap must stay
-		// enabled while writing the snapshot and only be disabled afterward.
+		// The xterm serialize addon relies on auto-wrap (DECAWM) being enabled
+		// to render wrapped lines. It omits row separators for wrapped rows
+		// and expects characters to naturally overflow to the next line, so
+		// re-enable DECAWM around the snapshot write and restore the live-TUI
+		// default afterward. This matters for both the synchronous initial
+		// restore and the deferred restore that may fire after Session.tsx
+		// has already disabled DECAWM for live TUI redraws.
 		const handleSessionRestore = (
 			restoredSession: ISession,
 			restoreSnapshot: string,
 		) => {
 			if (restoredSession.id === session.id) {
 				if (restoreSnapshot.length > 0) {
-					stdout.write(restoreSnapshot);
+					stdout.write(`\x1b[?7h${restoreSnapshot}\x1b[?7l`);
 				}
 			}
 		};

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -108,6 +108,21 @@ const Session: React.FC<SessionProps> = ({
 		// Listen for restore event first
 		sessionManager.on('sessionRestore', handleSessionRestore);
 
+		// Repaint the user's terminal viewport from the post-resize headless
+		// snapshot. Without this, Ink-based TUIs (e.g. Claude Code) re-emit
+		// their full static history on SIGWINCH, which the user's terminal
+		// appends below the (already-clipped) viewport, producing duplicated
+		// rows equal to the resize delta.
+		const handleSessionResize = (
+			resizedSession: ISession,
+			redrawPayload: string,
+		) => {
+			if (resizedSession.id === session.id && redrawPayload.length > 0) {
+				stdout.write(redrawPayload);
+			}
+		};
+		sessionManager.on('sessionResize', handleSessionResize);
+
 		// Listen for session data events
 		const handleSessionData = (activeSession: ISession, data: string) => {
 			// Only handle data for our session
@@ -157,11 +172,7 @@ const Session: React.FC<SessionProps> = ({
 		const handleResize = () => {
 			const cols = process.stdout.columns || 80;
 			const rows = process.stdout.rows || 24;
-			session.process.resize(cols, rows);
-			// Also resize the virtual terminal
-			if (session.terminal) {
-				session.terminal.resize(cols, rows);
-			}
+			sessionManager.performResize(session.id, cols, rows);
 		};
 
 		stdout.on('resize', handleResize);
@@ -180,6 +191,7 @@ const Session: React.FC<SessionProps> = ({
 
 			// Remove event listeners
 			sessionManager.off('sessionRestore', handleSessionRestore);
+			sessionManager.off('sessionResize', handleSessionResize);
 			sessionManager.off('sessionData', handleSessionData);
 			sessionManager.off('sessionExit', handleSessionExit);
 			stdout.off('resize', handleResize);

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1303,51 +1303,137 @@ describe('SessionManager', () => {
 			expect(eventOrder).toEqual(['restore', 'data']);
 		});
 
-		it('should fall back to viewport-only restore when the detector reports a transient footer', async () => {
-			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
-				id: '1',
-				name: 'Main',
-				command: 'claude',
-			});
-			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+		it('should defer the viewport-only restore until PTY output is quiet when a transient footer is visible', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+					id: '1',
+					name: 'Main',
+					command: 'claude',
+				});
+				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
 
-			const session = await Effect.runPromise(
-				sessionManager.createSessionWithPresetEffect('/test/worktree'),
-			);
-			const normalBuffer = session.terminal.buffer.normal as unknown as {
-				baseY: number;
-				length: number;
-				cursorY: number;
-				cursorX: number;
-			};
-			normalBuffer.baseY = 260;
-			normalBuffer.length = 300;
-			normalBuffer.cursorY = 7;
-			normalBuffer.cursorX = 11;
-			session.restoreScrollbackBaseLine = 120;
-			vi.spyOn(
-				session.stateDetector,
-				'hasTransientRenderFooter',
-			).mockReturnValue(true);
-			const serializeMock = vi
-				.spyOn(session.serializer, 'serialize')
-				.mockReturnValue('[31mviewport[0m');
-			const restoreHandler = vi.fn();
-			sessionManager.on('sessionRestore', restoreHandler);
+				const session = await Effect.runPromise(
+					sessionManager.createSessionWithPresetEffect('/test/worktree'),
+				);
+				const normalBuffer = session.terminal.buffer.normal as unknown as {
+					baseY: number;
+					length: number;
+					cursorY: number;
+					cursorX: number;
+				};
+				normalBuffer.baseY = 260;
+				normalBuffer.length = 300;
+				normalBuffer.cursorY = 7;
+				normalBuffer.cursorX = 11;
+				session.restoreScrollbackBaseLine = 120;
+				vi.spyOn(
+					session.stateDetector,
+					'hasTransientRenderFooter',
+				).mockReturnValue(true);
+				const serializeMock = vi
+					.spyOn(session.serializer, 'serialize')
+					.mockReturnValue('[31mviewport[0m');
+				const restoreHandler = vi.fn();
+				sessionManager.on('sessionRestore', restoreHandler);
 
-			sessionManager.setSessionActive(session.id, true);
+				sessionManager.setSessionActive(session.id, true);
 
-			expect(serializeMock).toHaveBeenCalledWith({
-				scrollback: 0,
-				excludeAltBuffer: true,
-			});
-			expect(serializeMock).not.toHaveBeenCalledWith(
-				expect.objectContaining({range: expect.anything()}),
-			);
-			expect(restoreHandler).toHaveBeenCalledWith(
-				session,
-				'[31mviewport[0m[8;12H',
-			);
+				expect(restoreHandler).not.toHaveBeenCalled();
+				expect(serializeMock).not.toHaveBeenCalled();
+
+				vi.advanceTimersByTime(80);
+
+				expect(serializeMock).toHaveBeenCalledWith({
+					scrollback: 0,
+					excludeAltBuffer: true,
+				});
+				expect(serializeMock).not.toHaveBeenCalledWith(
+					expect.objectContaining({range: expect.anything()}),
+				);
+				expect(restoreHandler).toHaveBeenCalledWith(
+					session,
+					'[31mviewport[0m[8;12H',
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should extend the restore quiet timer while PTY output keeps streaming, capped by the deadline', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+					id: '1',
+					name: 'Main',
+					command: 'claude',
+				});
+				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+				const session = await Effect.runPromise(
+					sessionManager.createSessionWithPresetEffect('/test/worktree'),
+				);
+				(session.terminal.buffer.normal as unknown as {length: number}).length =
+					1;
+				vi.spyOn(
+					session.stateDetector,
+					'hasTransientRenderFooter',
+				).mockReturnValue(true);
+				vi.spyOn(session.serializer, 'serialize').mockReturnValue('snap');
+				const restoreHandler = vi.fn();
+				sessionManager.on('sessionRestore', restoreHandler);
+
+				sessionManager.setSessionActive(session.id, true);
+				expect(restoreHandler).not.toHaveBeenCalled();
+
+				// Each chunk arrives within the quiet window and resets the timer
+				// without firing the snapshot. Three 50 ms ticks keep the cap
+				// (250 ms) safely ahead.
+				for (let i = 0; i < 3; i++) {
+					vi.advanceTimersByTime(50);
+					mockPty.emit('data', 'tick');
+				}
+				expect(restoreHandler).not.toHaveBeenCalled();
+
+				// Advance past the cap so the snapshot fires even though chunks
+				// kept arriving inside the quiet window.
+				vi.advanceTimersByTime(150);
+				expect(restoreHandler).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should cancel a pending deferred restore when the session is deactivated', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+					id: '1',
+					name: 'Main',
+					command: 'claude',
+				});
+				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+				const session = await Effect.runPromise(
+					sessionManager.createSessionWithPresetEffect('/test/worktree'),
+				);
+				vi.spyOn(
+					session.stateDetector,
+					'hasTransientRenderFooter',
+				).mockReturnValue(true);
+				vi.spyOn(session.serializer, 'serialize').mockReturnValue('snap');
+				const restoreHandler = vi.fn();
+				sessionManager.on('sessionRestore', restoreHandler);
+
+				sessionManager.setSessionActive(session.id, true);
+				sessionManager.setSessionActive(session.id, false);
+
+				vi.advanceTimersByTime(500);
+
+				expect(restoreHandler).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('should advance the restore baseline when transitioning out of busy', async () => {

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -3,7 +3,7 @@ import {Effect, Either} from 'effect';
 import {ValidationError} from '../types/errors.js';
 import {spawn, type IPty} from './bunTerminal.js';
 import {EventEmitter} from 'events';
-import {Session, DevcontainerConfig} from '../types/index.js';
+import {Session, DevcontainerConfig, SessionState} from '../types/index.js';
 import {spawn as childSpawn} from 'child_process';
 
 // Helper to create a mock child process for child_process.spawn
@@ -1301,6 +1301,103 @@ describe('SessionManager', () => {
 			sessionManager.setSessionActive(session.id, true);
 
 			expect(eventOrder).toEqual(['restore', 'data']);
+		});
+
+		it('should fall back to viewport-only restore when the detector reports a transient footer', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			const normalBuffer = session.terminal.buffer.normal as unknown as {
+				baseY: number;
+				length: number;
+				cursorY: number;
+				cursorX: number;
+			};
+			normalBuffer.baseY = 260;
+			normalBuffer.length = 300;
+			normalBuffer.cursorY = 7;
+			normalBuffer.cursorX = 11;
+			session.restoreScrollbackBaseLine = 120;
+			vi.spyOn(
+				session.stateDetector,
+				'hasTransientRenderFooter',
+			).mockReturnValue(true);
+			const serializeMock = vi
+				.spyOn(session.serializer, 'serialize')
+				.mockReturnValue('[31mviewport[0m');
+			const restoreHandler = vi.fn();
+			sessionManager.on('sessionRestore', restoreHandler);
+
+			sessionManager.setSessionActive(session.id, true);
+
+			expect(serializeMock).toHaveBeenCalledWith({
+				scrollback: 0,
+				excludeAltBuffer: true,
+			});
+			expect(serializeMock).not.toHaveBeenCalledWith(
+				expect.objectContaining({range: expect.anything()}),
+			);
+			expect(restoreHandler).toHaveBeenCalledWith(
+				session,
+				'[31mviewport[0m[8;12H',
+			);
+		});
+
+		it('should advance the restore baseline when transitioning out of busy', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			(session.terminal.buffer.normal as unknown as {baseY: number}).baseY = 42;
+			session.restoreScrollbackBaseLine = 5;
+			await session.stateMutex.update(data => ({...data, state: 'busy'}));
+
+			const updateState = (
+				sessionManager as unknown as {
+					updateSessionState: (s: Session, next: SessionState) => Promise<void>;
+				}
+			).updateSessionState.bind(sessionManager);
+			await updateState(session, 'idle');
+
+			expect(session.restoreScrollbackBaseLine).toBe(42);
+		});
+
+		it('should not advance the restore baseline on transitions that do not leave busy', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			(session.terminal.buffer.normal as unknown as {baseY: number}).baseY = 42;
+			session.restoreScrollbackBaseLine = 5;
+			await session.stateMutex.update(data => ({...data, state: 'idle'}));
+
+			const updateState = (
+				sessionManager as unknown as {
+					updateSessionState: (s: Session, next: SessionState) => Promise<void>;
+				}
+			).updateSessionState.bind(sessionManager);
+			await updateState(session, 'busy');
+
+			expect(session.restoreScrollbackBaseLine).toBe(5);
 		});
 	});
 

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1401,6 +1401,130 @@ describe('SessionManager', () => {
 		});
 	});
 
+	describe('performResize', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('emits a wrapped viewport snapshot to repaint after resize', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			session.isActive = true;
+			const normalBuffer = session.terminal.buffer.normal as unknown as {
+				cursorY: number;
+				cursorX: number;
+			};
+			normalBuffer.cursorY = 3;
+			normalBuffer.cursorX = 4;
+			const serializeMock = vi
+				.spyOn(session.serializer, 'serialize')
+				.mockReturnValue('VIEWPORT');
+			const resizeHandler = vi.fn();
+			sessionManager.on('sessionResize', resizeHandler);
+
+			sessionManager.performResize(session.id, 100, 24);
+
+			expect(session.process.resize).toHaveBeenCalledWith(100, 24);
+			expect(session.terminal.resize).toHaveBeenCalledWith(100, 24);
+			expect(serializeMock).toHaveBeenCalledWith({scrollback: 0});
+			expect(resizeHandler).toHaveBeenCalledWith(
+				session,
+				'[?7h[2J[HVIEWPORT[4;5H[?7l',
+			);
+		});
+
+		it('suppresses live PTY → stdout forwarding for the post-resize quiet window', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			session.isActive = true;
+			vi.spyOn(session.serializer, 'serialize').mockReturnValue('VIEWPORT');
+			const dataHandler = vi.fn();
+			sessionManager.on('sessionData', dataHandler);
+
+			sessionManager.performResize(session.id, 100, 24);
+
+			mockPty.emit('data', 'static-replay');
+			expect(dataHandler).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(260);
+			mockPty.emit('data', 'live-after-window');
+
+			expect(dataHandler).toHaveBeenCalledTimes(1);
+			expect(dataHandler).toHaveBeenCalledWith(session, 'live-after-window');
+		});
+
+		it('skips emitting a resize repaint for inactive sessions', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			session.isActive = false;
+			vi.spyOn(session.serializer, 'serialize').mockReturnValue('VIEWPORT');
+			const resizeHandler = vi.fn();
+			sessionManager.on('sessionResize', resizeHandler);
+
+			sessionManager.performResize(session.id, 100, 24);
+
+			expect(resizeHandler).not.toHaveBeenCalled();
+			expect(session.process.resize).toHaveBeenCalledWith(100, 24);
+		});
+
+		it('clears the resize suppression when the session is deactivated', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			session.isActive = true;
+			vi.spyOn(session.serializer, 'serialize').mockReturnValue('VIEWPORT');
+			const dataHandler = vi.fn();
+			sessionManager.on('sessionData', dataHandler);
+
+			sessionManager.performResize(session.id, 100, 24);
+			sessionManager.setSessionActive(session.id, false);
+			session.isActive = true;
+
+			mockPty.emit('data', 'live-after-deactivate');
+
+			expect(dataHandler).toHaveBeenCalledTimes(1);
+			expect(dataHandler).toHaveBeenCalledWith(
+				session,
+				'live-after-deactivate',
+			);
+		});
+	});
+
 	describe('static methods', () => {
 		describe('getSessionCounts', () => {
 			// Helper to create mock session with stateMutex

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -278,6 +278,15 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		}));
 
 		if (oldState !== newState) {
+			// While busy, cursor-addressed footer redraws (spinner, token stats,
+			// "accept edits on …" line) can push ghost frames into scrollback as
+			// chat content scrolls. Once the busy turn ends, advance the restore
+			// baseline so the next session restore replays only post-busy
+			// scrollback and skips the ghost-bearing range.
+			if (oldState === 'busy' && newState !== 'busy') {
+				session.restoreScrollbackBaseLine =
+					session.terminal.buffer.normal.baseY;
+			}
 			void Effect.runPromise(executeStatusHook(oldState, newState, session));
 			this.emit('sessionStateChanged', session);
 		}
@@ -320,6 +329,23 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			return '';
 		}
 
+		const cursorRow = normalBuffer.cursorY + 1;
+		const cursorCol = normalBuffer.cursorX + 1;
+
+		// When the live viewport shows a transient footer (spinner activity,
+		// token stats, persistent shift+tab footer, etc.), the renderer keeps
+		// redrawing it in place and earlier copies have likely been pushed into
+		// scrollback by chat output scrolling beneath it. Replaying that
+		// scrollback would paint duplicated footer rows, so emit only the
+		// viewport in this case.
+		if (session.stateDetector.hasTransientRenderFooter(session.terminal)) {
+			const viewportSnapshot = session.serializer.serialize({
+				scrollback: 0,
+				excludeAltBuffer: true,
+			});
+			return `${viewportSnapshot}\x1b[${cursorRow};${cursorCol}H`;
+		}
+
 		const scrollbackStart = Math.max(
 			0,
 			normalBuffer.baseY - TERMINAL_RESTORE_SCROLLBACK_LINES,
@@ -337,8 +363,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			},
 			excludeAltBuffer: true,
 		});
-		const cursorRow = normalBuffer.cursorY + 1;
-		const cursorCol = normalBuffer.cursorX + 1;
 
 		return `${snapshot}\x1b[${cursorRow};${cursorCol}H`;
 	}

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -37,6 +37,14 @@ const TERMINAL_RESTORE_SCROLLBACK_LINES = 200;
 // child process's SIGWINCH-triggered re-emission of static content does not
 // duplicate already-displayed rows in the user's terminal.
 const RESIZE_SUPPRESS_MS = 250;
+// While a busy TUI is mid-frame across multiple PTY chunks, a synchronous
+// viewport-only restore can capture an incomplete frame and paint a half-
+// drawn screen. Defer the restore emit until PTY output has been quiet for
+// this long (extended on each chunk) so the snapshot captures a coherent
+// post-frame state. Capped by RESTORE_DEFER_MAX_MS so a continuously
+// streaming session still restores within a small bounded delay.
+const RESTORE_DEFER_QUIET_MS = 80;
+const RESTORE_DEFER_MAX_MS = 250;
 
 export interface SessionCounts {
 	idle: number;
@@ -57,6 +65,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	private bufferedRestoreData: Map<string, string[]> = new Map();
 	private resizingSessions: Set<string> = new Set();
 	private resizeSuppressTimers: Map<string, NodeJS.Timeout> = new Map();
+	private restoreDeferTimers: Map<string, NodeJS.Timeout> = new Map();
+	private restoreDeferDeadlines: Map<string, number> = new Map();
 
 	private async spawn(
 		command: string,
@@ -591,6 +601,15 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 
 			session.lastActivity = new Date();
 
+			// Deferred restore is waiting for the TUI to finish a frame. Reset
+			// the quiet timer with each chunk; the snapshot fired at the end of
+			// the quiet window will already include this data through the
+			// headless write above, so do not buffer or forward.
+			if (this.restoreDeferDeadlines.has(session.id)) {
+				this.armRestoreDeferTimer(session);
+				return;
+			}
+
 			// Only emit data events when session is active
 			if (session.isActive) {
 				if (this.restoringSessions.has(session.id)) {
@@ -792,21 +811,21 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			if (active) {
 				session.lastAccessedAt = Date.now();
 				this.restoringSessions.add(session.id);
-				try {
-					const restoreSnapshot = this.getRestoreSnapshot(session);
-					if (restoreSnapshot.length > 0) {
-						this.emit('sessionRestore', session, restoreSnapshot);
-					}
-				} finally {
-					this.restoringSessions.delete(session.id);
-					const bufferedData = this.bufferedRestoreData.get(session.id);
-					if (bufferedData && bufferedData.length > 0) {
-						this.bufferedRestoreData.delete(session.id);
-						for (const chunk of bufferedData) {
-							this.emit('sessionData', session, chunk);
-						}
-					}
+
+				// While the TUI shows a busy footer it may be mid-frame across
+				// multiple PTY chunks; capturing the snapshot synchronously can
+				// surface a half-drawn viewport. Defer until PTY output is
+				// quiet so the snapshot reflects a coherent post-frame state.
+				if (session.stateDetector.hasTransientRenderFooter(session.terminal)) {
+					this.restoreDeferDeadlines.set(
+						session.id,
+						Date.now() + RESTORE_DEFER_MAX_MS,
+					);
+					this.armRestoreDeferTimer(session);
+					return;
 				}
+
+				this.emitRestoreSnapshot(session);
 			} else {
 				this.restoringSessions.delete(session.id);
 				this.bufferedRestoreData.delete(session.id);
@@ -816,8 +835,65 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					clearTimeout(resizeTimer);
 					this.resizeSuppressTimers.delete(session.id);
 				}
+				this.cancelRestoreDefer(session.id);
 			}
 		}
+	}
+
+	private emitRestoreSnapshot(session: Session): void {
+		try {
+			const restoreSnapshot = this.getRestoreSnapshot(session);
+			if (restoreSnapshot.length > 0) {
+				this.emit('sessionRestore', session, restoreSnapshot);
+			}
+		} finally {
+			this.restoringSessions.delete(session.id);
+			const bufferedData = this.bufferedRestoreData.get(session.id);
+			if (bufferedData && bufferedData.length > 0) {
+				this.bufferedRestoreData.delete(session.id);
+				for (const chunk of bufferedData) {
+					this.emit('sessionData', session, chunk);
+				}
+			}
+		}
+	}
+
+	private armRestoreDeferTimer(session: Session): void {
+		const deadline = this.restoreDeferDeadlines.get(session.id);
+		if (deadline === undefined) {
+			return;
+		}
+		const existing = this.restoreDeferTimers.get(session.id);
+		if (existing !== undefined) {
+			clearTimeout(existing);
+		}
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			this.fireRestoreDefer(session);
+			return;
+		}
+		const delay = Math.min(RESTORE_DEFER_QUIET_MS, remaining);
+		const timer = setTimeout(() => this.fireRestoreDefer(session), delay);
+		this.restoreDeferTimers.set(session.id, timer);
+	}
+
+	private fireRestoreDefer(session: Session): void {
+		this.restoreDeferTimers.delete(session.id);
+		this.restoreDeferDeadlines.delete(session.id);
+		if (!session.isActive) {
+			this.restoringSessions.delete(session.id);
+			return;
+		}
+		this.emitRestoreSnapshot(session);
+	}
+
+	private cancelRestoreDefer(sessionId: string): void {
+		const timer = this.restoreDeferTimers.get(sessionId);
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			this.restoreDeferTimers.delete(sessionId);
+		}
+		this.restoreDeferDeadlines.delete(sessionId);
 	}
 
 	cancelAutoApproval(sessionId: string, reason = 'User input received'): void {
@@ -906,6 +982,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				clearTimeout(resizeTimer);
 				this.resizeSuppressTimers.delete(sessionId);
 			}
+			this.cancelRestoreDefer(sessionId);
 			this.emit('sessionDestroyed', session);
 		}
 	}
@@ -972,6 +1049,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					clearTimeout(resizeTimer);
 					this.resizeSuppressTimers.delete(sessionId);
 				}
+				this.cancelRestoreDefer(sessionId);
 				this.emit('sessionDestroyed', session);
 			},
 			catch: (error: unknown) => {

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -33,6 +33,10 @@ const {Terminal} = pkg;
 const TERMINAL_CONTENT_MAX_LINES = 300;
 const TERMINAL_SCROLLBACK_LINES = 5000;
 const TERMINAL_RESTORE_SCROLLBACK_LINES = 200;
+// How long to suppress PTY → stdout forwarding after a viewport resize so the
+// child process's SIGWINCH-triggered re-emission of static content does not
+// duplicate already-displayed rows in the user's terminal.
+const RESIZE_SUPPRESS_MS = 250;
 
 export interface SessionCounts {
 	idle: number;
@@ -51,6 +55,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	private autoApprovalDisabledWorktrees: Set<string> = new Set();
 	private restoringSessions: Set<string> = new Set();
 	private bufferedRestoreData: Map<string, string[]> = new Map();
+	private resizingSessions: Set<string> = new Set();
+	private resizeSuppressTimers: Map<string, NodeJS.Timeout> = new Map();
 
 	private async spawn(
 		command: string,
@@ -367,6 +373,83 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		return `${snapshot}\x1b[${cursorRow};${cursorCol}H`;
 	}
 
+	private getViewportRedrawSnapshot(session: Session): string {
+		const snapshot = session.serializer.serialize({scrollback: 0});
+		if (snapshot.length === 0) {
+			return '';
+		}
+		const activeBuffer = session.terminal.buffer.active;
+		if (activeBuffer.type !== 'normal') {
+			// Serialized alternate-buffer output already carries its own cursor
+			// positioning, so do not append a cursor home sequence here.
+			return snapshot;
+		}
+		const normalBuffer = session.terminal.buffer.normal;
+		const cursorRow = normalBuffer.cursorY + 1;
+		const cursorCol = normalBuffer.cursorX + 1;
+		return `${snapshot}\x1b[${cursorRow};${cursorCol}H`;
+	}
+
+	/**
+	 * Resize a session's PTY and headless terminal, then repaint the user's
+	 * terminal viewport from the post-resize headless state. Live PTY → stdout
+	 * forwarding is suppressed for a short window so the child's SIGWINCH
+	 * redraw (which on Ink-based TUIs re-emits the full static history) cannot
+	 * append duplicates below the repainted viewport.
+	 */
+	performResize(sessionId: string, cols: number, rows: number): void {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			return;
+		}
+
+		try {
+			session.process.resize(cols, rows);
+		} catch {
+			/* empty */
+		}
+		try {
+			session.terminal.resize(cols, rows);
+		} catch {
+			/* empty */
+		}
+
+		this.resizingSessions.add(sessionId);
+		const existing = this.resizeSuppressTimers.get(sessionId);
+		if (existing !== undefined) {
+			clearTimeout(existing);
+		}
+		const timer = setTimeout(() => {
+			this.resizeSuppressTimers.delete(sessionId);
+			this.resizingSessions.delete(sessionId);
+		}, RESIZE_SUPPRESS_MS);
+		this.resizeSuppressTimers.set(sessionId, timer);
+
+		if (!session.isActive) {
+			return;
+		}
+
+		const snapshot = this.getViewportRedrawSnapshot(session);
+		if (snapshot.length === 0) {
+			return;
+		}
+
+		// \x1b[?7h ... \x1b[?7l: SerializeAddon's wrapped-row encoding relies
+		//   on auto-wrap (DECAWM) being enabled to advance the cursor across
+		//   row boundaries (see PR #276). Session.tsx keeps DECAWM disabled
+		//   for live TUI redraws, so re-enable it just for the snapshot write
+		//   and restore the live default afterward.
+		// \x1b[2J\x1b[H: clear the post-resize viewport so the snapshot paints
+		//   onto a known canvas; rows that the child won't cover (e.g. trailing
+		//   blanks after a height shrink) stay clean rather than retaining
+		//   pre-resize content.
+		this.emit(
+			'sessionResize',
+			session,
+			`\x1b[?7h\x1b[2J\x1b[H${snapshot}\x1b[?7l`,
+		);
+	}
+
 	private async createSessionInternal(
 		worktreePath: string,
 		ptyProcess: IPty,
@@ -514,6 +597,16 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					const bufferedData = this.bufferedRestoreData.get(session.id) ?? [];
 					bufferedData.push(data);
 					this.bufferedRestoreData.set(session.id, bufferedData);
+					return;
+				}
+
+				// During a viewport resize, the child process re-emits its full
+				// static content to adapt to new line-wrapping. The headless
+				// terminal already absorbed the data above, so the post-resize
+				// snapshot we wrote on resize is in sync. Drop the live forward
+				// here to keep the user's terminal from acquiring duplicated
+				// rows below the snapshot.
+				if (this.resizingSessions.has(session.id)) {
 					return;
 				}
 
@@ -717,6 +810,12 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			} else {
 				this.restoringSessions.delete(session.id);
 				this.bufferedRestoreData.delete(session.id);
+				this.resizingSessions.delete(session.id);
+				const resizeTimer = this.resizeSuppressTimers.get(session.id);
+				if (resizeTimer !== undefined) {
+					clearTimeout(resizeTimer);
+					this.resizeSuppressTimers.delete(session.id);
+				}
 			}
 		}
 	}
@@ -801,6 +900,12 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			this.waitingWithBottomBorder.delete(sessionId);
 			this.restoringSessions.delete(sessionId);
 			this.bufferedRestoreData.delete(sessionId);
+			this.resizingSessions.delete(sessionId);
+			const resizeTimer = this.resizeSuppressTimers.get(sessionId);
+			if (resizeTimer !== undefined) {
+				clearTimeout(resizeTimer);
+				this.resizeSuppressTimers.delete(sessionId);
+			}
 			this.emit('sessionDestroyed', session);
 		}
 	}
@@ -861,6 +966,12 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 
 				this.sessions.delete(sessionId);
 				this.waitingWithBottomBorder.delete(sessionId);
+				this.resizingSessions.delete(sessionId);
+				const resizeTimer = this.resizeSuppressTimers.get(sessionId);
+				if (resizeTimer !== undefined) {
+					clearTimeout(resizeTimer);
+					this.resizeSuppressTimers.delete(sessionId);
+				}
 				this.emit('sessionDestroyed', session);
 			},
 			catch: (error: unknown) => {

--- a/src/services/stateDetector/base.ts
+++ b/src/services/stateDetector/base.ts
@@ -20,4 +20,8 @@ export abstract class BaseStateDetector implements StateDetector {
 	abstract detectBackgroundTask(terminal: Terminal): number;
 
 	abstract detectTeamMembers(terminal: Terminal): number;
+
+	hasTransientRenderFooter(_terminal: Terminal): boolean {
+		return false;
+	}
 }

--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -994,15 +994,18 @@ describe('ClaudeStateDetector', () => {
 			expect(detector.hasTransientRenderFooter(terminal)).toBe(true);
 		});
 
-		it('returns true when viewport contains the persistent shift+tab footer', () => {
+		it('returns false for a steady idle viewport that only shows the persistent shift+tab footer', () => {
+			// The "(shift+tab to cycle)" line is rendered even when nothing
+			// is scrolling, so on its own it does not imply scrollback ghosts.
 			terminal = createMockTerminal([
+				'Some idle conversation',
 				'──────────────────────────────',
 				'❯',
 				'──────────────────────────────',
 				'⏵⏵ accept edits on (shift+tab to cycle)',
 			]);
 
-			expect(detector.hasTransientRenderFooter(terminal)).toBe(true);
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(false);
 		});
 
 		it('returns true when viewport contains "esc to interrupt"', () => {

--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -971,6 +971,73 @@ describe('ClaudeStateDetector', () => {
 		});
 	});
 
+	describe('hasTransientRenderFooter', () => {
+		it('returns true when viewport contains spinner activity label', () => {
+			terminal = createMockTerminal([
+				'✶ Befuddling… (1m 1s · ↓ 283 tokens)',
+				'──────────────────────────────',
+				'❯',
+				'──────────────────────────────',
+			]);
+
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(true);
+		});
+
+		it('returns true when viewport contains a token stats line', () => {
+			terminal = createMockTerminal([
+				'(9m 21s · ↓ 13.7k tokens)',
+				'──────────────────────────────',
+				'❯',
+				'──────────────────────────────',
+			]);
+
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(true);
+		});
+
+		it('returns true when viewport contains the persistent shift+tab footer', () => {
+			terminal = createMockTerminal([
+				'──────────────────────────────',
+				'❯',
+				'──────────────────────────────',
+				'⏵⏵ accept edits on (shift+tab to cycle)',
+			]);
+
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(true);
+		});
+
+		it('returns true when viewport contains "esc to interrupt"', () => {
+			terminal = createMockTerminal([
+				'Working...',
+				'Press esc to interrupt',
+				'❯',
+			]);
+
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(true);
+		});
+
+		it('returns true when viewport contains "ctrl+c to interrupt"', () => {
+			terminal = createMockTerminal(['Searching… (ctrl+c to interrupt)', '❯']);
+
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(true);
+		});
+
+		it('returns false on a quiet idle viewport without footer markers', () => {
+			terminal = createMockTerminal([
+				'Some output',
+				'Command completed successfully',
+				'> ',
+			]);
+
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(false);
+		});
+
+		it('returns false for an empty terminal', () => {
+			terminal = createMockTerminal([]);
+
+			expect(detector.hasTransientRenderFooter(terminal)).toBe(false);
+		});
+	});
+
 	describe('detectTeamMembers', () => {
 		it('should return 2 when two @name members are present with shift+↑ to expand', () => {
 			terminal = createMockTerminal([

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -14,6 +14,11 @@ const SPINNER_ACTIVITY_PATTERN = new RegExp(
 // Session stats above the prompt, e.g. "(9m 21s · ↓ 13.7k tokens)" — requires parens, a digit, and "tokens"
 const TOKEN_STATS_LINE_PATTERN = /\([^)]*\d[^)]*tokens\s*\)/i;
 
+// Persistent footer hint Claude renders below the prompt box, e.g.
+// "⏵⏵ accept edits on (shift+tab to cycle)". The redraw of this footer is
+// what produces the most visible scrollback ghosts when chat content scrolls.
+const PERSISTENT_FOOTER_PATTERN = /\(shift\+tab\s+to\s+cycle\)/i;
+
 // Workaround: Claude Code sometimes appears idle in terminal output while
 // still actively processing (busy). To mitigate false idle transitions,
 // require terminal output to remain unchanged for this duration before
@@ -195,6 +200,30 @@ export class ClaudeStateDetector extends BaseStateDetector {
 
 		// No background task detected
 		return 0;
+	}
+
+	override hasTransientRenderFooter(terminal: Terminal): boolean {
+		const viewport = this.getTerminalContent(terminal, terminal.rows);
+		if (viewport.length === 0) {
+			return false;
+		}
+		if (SPINNER_ACTIVITY_PATTERN.test(viewport)) {
+			return true;
+		}
+		if (TOKEN_STATS_LINE_PATTERN.test(viewport)) {
+			return true;
+		}
+		if (PERSISTENT_FOOTER_PATTERN.test(viewport)) {
+			return true;
+		}
+		const lower = viewport.toLowerCase();
+		if (
+			lower.includes('esc to interrupt') ||
+			lower.includes('ctrl+c to interrupt')
+		) {
+			return true;
+		}
+		return false;
 	}
 
 	detectTeamMembers(terminal: Terminal): number {

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -14,11 +14,6 @@ const SPINNER_ACTIVITY_PATTERN = new RegExp(
 // Session stats above the prompt, e.g. "(9m 21s · ↓ 13.7k tokens)" — requires parens, a digit, and "tokens"
 const TOKEN_STATS_LINE_PATTERN = /\([^)]*\d[^)]*tokens\s*\)/i;
 
-// Persistent footer hint Claude renders below the prompt box, e.g.
-// "⏵⏵ accept edits on (shift+tab to cycle)". The redraw of this footer is
-// what produces the most visible scrollback ghosts when chat content scrolls.
-const PERSISTENT_FOOTER_PATTERN = /\(shift\+tab\s+to\s+cycle\)/i;
-
 // Workaround: Claude Code sometimes appears idle in terminal output while
 // still actively processing (busy). To mitigate false idle transitions,
 // require terminal output to remain unchanged for this duration before
@@ -203,6 +198,13 @@ export class ClaudeStateDetector extends BaseStateDetector {
 	}
 
 	override hasTransientRenderFooter(terminal: Terminal): boolean {
+		// Only flag busy-turn footer markers. The persistent "(shift+tab to
+		// cycle)" footer is always visible during an active Claude session
+		// even when idle, but it does not by itself indicate that recent
+		// scrolling pushed ghost frames into scrollback — only an in-flight
+		// busy turn does. busy → non-busy transitions advance the restore
+		// baseline separately so already-scrolled ghosts from a just-ended
+		// turn are not replayed either.
 		const viewport = this.getTerminalContent(terminal, terminal.rows);
 		if (viewport.length === 0) {
 			return false;
@@ -211,9 +213,6 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			return true;
 		}
 		if (TOKEN_STATS_LINE_PATTERN.test(viewport)) {
-			return true;
-		}
-		if (PERSISTENT_FOOTER_PATTERN.test(viewport)) {
 			return true;
 		}
 		const lower = viewport.toLowerCase();

--- a/src/services/stateDetector/types.ts
+++ b/src/services/stateDetector/types.ts
@@ -4,4 +4,10 @@ export interface StateDetector {
 	detectState(terminal: Terminal, currentState: SessionState): SessionState;
 	detectBackgroundTask(terminal: Terminal): number;
 	detectTeamMembers(terminal: Terminal): number;
+	// True when the live viewport shows a footer (spinner/token-stats/persistent
+	// status bar etc.) that the renderer keeps redrawing in place. Earlier
+	// frames of that footer can be pushed into normal-buffer scrollback as the
+	// chat scrolls, so callers (session restore) should avoid replaying that
+	// scrollback to prevent duplicated footer rows.
+	hasTransientRenderFooter(terminal: Terminal): boolean;
 }


### PR DESCRIPTION
## Summary

A small stack of follow-up fixes to the xterm session restore work from #282. Each commit targets a distinct rendering glitch that was reproducible in real Claude Code sessions, with no new dependencies and the `restoringSessions` / serialize-addon model intact.

- **Drop scrollback ghosts from Claude session restore** (`31eb96e`) — Ink redraws push earlier copies of the bottom footer (spinner, token stats, `accept edits on …`) into normal-buffer scrollback as chat content scrolls. PR #282's bounded-scrollback restore replayed those copies and stacked duplicate footer rows on re-entry. Add `StateDetector.hasTransientRenderFooter(terminal)` (Claude detector inspects the live viewport for spinner activity, token stats, or `esc/ctrl+c to interrupt`) and fall back to a viewport-only snapshot when it's true. On `busy → non-busy` transitions advance `restoreScrollbackBaseLine` to the current `baseY` so the next restore skips the scrollback range that captured ghost frames during the just-ended turn.
- **Scope transient-footer detection to busy markers only** (`bf4dcea`) — The persistent `(shift+tab to cycle)` footer is rendered during every active Claude session, including idle, so detecting it forced restore into the viewport-only path on virtually every Claude re-entry and threw away the bounded 200-line scrollback recall. Limit detection to busy markers (the busy → non-busy baseline bump still excludes ghost-bearing scrollback from a just-ended turn).
- **Drop duplicate viewport rows after a terminal height shrink** (`635c7f8`) — On SIGWINCH Ink-based TUIs re-emit their full static history to adapt to new line wrapping. Forwarding that re-emission appends duplicates equal to the resize delta below the (already-clipped) viewport. Add `SessionManager.performResize` which resizes PTY + headless terminal, marks the session ‘resizing’ for 250 ms (suppressing PTY → stdout while still feeding the headless terminal), and emits a `sessionResize` event carrying a viewport-only repaint payload wrapped in `\x1b[?7h\x1b[2J\x1b[H<snap>\x1b[?7l`. Session.tsx wires the existing `stdout.on('resize', …)` listener through the new method and writes the payload.
- **Defer busy session restore until PTY output is quiet** (`a7d4627`) — Ink emits a single visual frame across multiple PTY chunks. Capturing the viewport-only snapshot synchronously can land between chunks and freeze a half-drawn frame; on re-entry the user sees a mostly empty viewport with a garbled tail that survives until the next menu round-trip. Defer the snapshot when the live viewport shows a transient footer: the deferred timer waits for `RESTORE_DEFER_QUIET_MS` (80 ms) of PTY silence, resetting on every chunk, capped at `RESTORE_DEFER_MAX_MS` (250 ms). PTY data still flows into the headless terminal during the wait so the eventual snapshot is in sync, but it is not forwarded or buffered for the user terminal (the snapshot will reproduce it). `Session.tsx` wraps the restore payload in `\x1b[?7h…\x1b[?7l` so the deferred emit, which fires after Session.tsx already disabled DECAWM for live TUI redraws, still has DECAWM on while the SerializeAddon's wrapped-row encoding is replayed. Idle restores keep the synchronous path.

### Why not just re-apply #293

PR #293 also targeted the busy/refresh problem with two snapshot writes per re-entry (initial sync emit + a `\x1b[?7h\x1b[2J\x1b[H<viewport>\x1b[?7l` deferred refresh). That refresh interleaved with live data between the two writes and produced the garbled ‘bottom-duplicate’ artifact reverted in #297. The fixes here keep at most **one** snapshot write per session re-entry / per resize, so that interaction surface is gone by construction.

## Test plan
- [x] `npm run test` (851 passed / 5 skipped — new tests cover the busy-marker detector, scrollback baseline bump, deferred restore timing & deadline cap, deferred-restore cancellation on deactivate, resize repaint payload, resize suppression window, inactive-session resize skip, and resize cleanup on deactivate)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual: open a busy Claude session, switch to menu and back several times — restored viewport is coherent (no half-drawn frame, no stacked footer rows).
- [ ] Manual: shrink terminal height while a Claude session is active — no duplicate of the bottom rows below the viewport.
- [ ] Manual: idle session re-entry still feels instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)