### PR TITLE
fix: restore Ctrl+C / Ctrl+L in PTY sessions by scoping worktree-hook-error useInput

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -146,14 +146,17 @@ const App: React.FC<AppProps> = ({
 		};
 	}, [view]);
 
-	useInput(() => {
-		if (view !== 'worktree-hook-error' || !canReturnFromHookError) {
-			return;
-		}
+	useInput(
+		() => {
+			if (!canReturnFromHookError) {
+				return;
+			}
 
-		setWorktreeHookError(null);
-		handleReturnToMenu();
-	});
+			setWorktreeHookError(null);
+			handleReturnToMenu();
+		},
+		{isActive: view === 'worktree-hook-error'},
+	);
 
 	// Helper function to format error messages based on error type using _tag discrimination
 	const formatErrorMessage = (error: AppError): string => {


### PR DESCRIPTION
## Summary

- Fix Ctrl+C killing ccmanager instead of clearing Claude Code's input
- Fix Ctrl+L doing nothing in Claude Code's input field
- Both regressions were introduced by #295 (eab4957)

## Root cause

#295 added `useInput` in `App.tsx` without an `isActive` guard, making it permanently active across all views — including active PTY sessions.

Ink's internal implementation attaches a `'readable'` listener to `process.stdin` whenever any `useInput` hook is active. Node.js streams do **not** switch to flowing mode when `readableListening` is `true`: even after `Session.tsx` calls `stdin.resume()`, `state.flowing` stays `false` (`= !readableListening`). As a result Ink's `'readable'` handler keeps consuming raw stdin bytes alongside `Session.tsx`'s `'data'` listener:

- **Ctrl+C (`\x03`)** — Ink's `handleInput` detects it and calls `handleExit()`, which switches the terminal back to cooked mode and fires `onExit()`. All subsequent input becomes unresponsive; a second Ctrl+C sends SIGINT and exits ccmanager.
- **Ctrl+L (`\x0C`)** — Ink reads the byte, emits it to `useInput` handlers, but `App.tsx`'s handler returns early on the view check, so the byte is silently dropped and Claude Code never sees it.

## Fix

Add `{ isActive: view === 'worktree-hook-error' }` to the `useInput` call in `App.tsx`.  When the view is anything other than `worktree-hook-error`, `isActive: false` prevents Ink from registering a `'readable'` listener, leaving `Session.tsx` in exclusive control of stdin during PTY sessions.

## Test plan

- [ ] Enter a Claude Code session with text in the input field; press Ctrl+C — input should be cleared, ccmanager should remain alive
- [ ] Enter a Claude Code session; press Ctrl+L — screen/input should clear as expected
- [ ] Trigger a worktree post-creation hook failure; verify the error screen is shown and any key dismisses it back to the menu
- [ ] `npm run typecheck` passes
- [ ] `npm run test` passes (851 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)