### PR TITLE
fix: detach session before returning to menu

### DIFF
--- a/src/components/Session.test.tsx
+++ b/src/components/Session.test.tsx
@@ -125,4 +125,70 @@ describe('Session', () => {
 		);
 		expect(testState.stdout?.write).toHaveBeenNthCalledWith(3, '\x1b[?7l');
 	});
+
+	it('detaches synchronously when returning to menu so late session output cannot repaint', async () => {
+		const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+		const session = {
+			id: 'session-1',
+			process: {
+				write: vi.fn(),
+				resize: vi.fn(),
+			},
+			terminal: {
+				resize: vi.fn(),
+			},
+			stateMutex: {
+				getSnapshot: () => ({state: 'busy'}),
+			},
+		} as unknown as SessionType;
+		const onReturnToMenu = vi.fn();
+		const setSessionActive = vi.fn();
+		const sessionManager = {
+			on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+				const handlers = listeners.get(event) ?? new Set();
+				handlers.add(handler);
+				listeners.set(event, handlers);
+				return sessionManager;
+			}),
+			off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+				listeners.get(event)?.delete(handler);
+				return sessionManager;
+			}),
+			setSessionActive,
+			cancelAutoApproval: vi.fn(),
+			performResize: vi.fn(),
+		};
+
+		const {unmount} = render(
+			<Session
+				session={session}
+				sessionManager={sessionManager as never}
+				onReturnToMenu={onReturnToMenu}
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 0));
+		testState.stdout?.write.mockClear();
+
+		process.stdin.emit('data', '\u0005');
+		for (const handler of listeners.get('sessionData') ?? []) {
+			handler(session, 'late-data');
+		}
+		for (const handler of listeners.get('sessionRestore') ?? []) {
+			handler(session, 'late-restore');
+		}
+		for (const handler of listeners.get('sessionResize') ?? []) {
+			handler(session, 'late-resize');
+		}
+
+		expect(setSessionActive).toHaveBeenCalledWith(session.id, false);
+		expect(onReturnToMenu).toHaveBeenCalledTimes(1);
+		expect(testState.stdout?.write).not.toHaveBeenCalledWith('late-data');
+		expect(testState.stdout?.write).not.toHaveBeenCalledWith(
+			'\x1b[?7hlate-restore\x1b[?7l',
+		);
+		expect(testState.stdout?.write).not.toHaveBeenCalledWith('late-resize');
+
+		unmount();
+	});
 });

--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -63,6 +63,8 @@ const Session: React.FC<SessionProps> = ({
 
 			// Check for return to menu shortcut
 			if (shortcutManager.matchesRawInput('returnToMenu', data)) {
+				isExitingRef.current = true;
+				sessionManager.setSessionActive(session.id, false);
 				// Disable any extended input modes that might have been enabled by the PTY
 				if (stdout) {
 					resetTerminalInputModes();
@@ -101,7 +103,7 @@ const Session: React.FC<SessionProps> = ({
 			restoredSession: ISession,
 			restoreSnapshot: string,
 		) => {
-			if (restoredSession.id === session.id) {
+			if (restoredSession.id === session.id && !isExitingRef.current) {
 				if (restoreSnapshot.length > 0) {
 					stdout.write(`\x1b[?7h${restoreSnapshot}\x1b[?7l`);
 				}
@@ -120,7 +122,11 @@ const Session: React.FC<SessionProps> = ({
 			resizedSession: ISession,
 			redrawPayload: string,
 		) => {
-			if (resizedSession.id === session.id && redrawPayload.length > 0) {
+			if (
+				resizedSession.id === session.id &&
+				redrawPayload.length > 0 &&
+				!isExitingRef.current
+			) {
 				stdout.write(redrawPayload);
 			}
 		};

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1304,6 +1304,94 @@ describe('SessionManager', () => {
 			expect(session.restoreScrollbackBaseLine).toBe(17);
 		});
 
+		it('should keep full scrollback for normal output that scrolls', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			const normalBuffer = session.terminal.buffer.normal as unknown as {
+				baseY: number;
+			};
+			normalBuffer.baseY = 10;
+			vi.mocked(session.terminal.write).mockImplementation(() => {
+				normalBuffer.baseY = 12;
+			});
+
+			mockPty.emit('data', 'ordinary output\n');
+
+			expect(session.restoreScrollbackBaseLine).toBe(0);
+		});
+
+		it('should skip scrollback that grows during cursor-addressed redraws', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			const normalBuffer = session.terminal.buffer.normal as unknown as {
+				baseY: number;
+			};
+			normalBuffer.baseY = 10;
+			vi.mocked(session.terminal.write).mockImplementation(() => {
+				normalBuffer.baseY = 12;
+			});
+
+			mockPty.emit('data', '\x1b[Hredrawn status\n');
+
+			expect(session.restoreScrollbackBaseLine).toBe(12);
+		});
+
+		it('should keep cursor-addressed redraw tracking active for a short quiet window', async () => {
+			vi.useFakeTimers();
+			try {
+				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+					id: '1',
+					name: 'Main',
+					command: 'claude',
+				});
+				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+				const session = await Effect.runPromise(
+					sessionManager.createSessionWithPresetEffect('/test/worktree'),
+				);
+				const normalBuffer = session.terminal.buffer.normal as unknown as {
+					baseY: number;
+				};
+				normalBuffer.baseY = 10;
+				vi.mocked(session.terminal.write).mockImplementation(() => {
+					if (normalBuffer.baseY === 10) {
+						return;
+					}
+					normalBuffer.baseY++;
+				});
+
+				mockPty.emit('data', '\x1b[Hredraw frame');
+				normalBuffer.baseY = 11;
+				mockPty.emit('data', 'plain continuation that scrolls');
+
+				expect(session.restoreScrollbackBaseLine).toBe(12);
+
+				vi.advanceTimersByTime(501);
+				normalBuffer.baseY = 20;
+				mockPty.emit('data', 'ordinary output after quiet window');
+
+				expect(session.restoreScrollbackBaseLine).toBe(12);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it('should flush live session data after the restore snapshot completes', async () => {
 			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
 				id: '1',

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1151,7 +1151,7 @@ describe('SessionManager', () => {
 	});
 
 	describe('session restore snapshots', () => {
-		it('should emit a bounded normal-buffer restore snapshot and restore the cursor position', async () => {
+		it('should emit a normal-buffer restore snapshot from the restore baseline and restore the cursor position', async () => {
 			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
 				id: '1',
 				name: 'Main',
@@ -1192,6 +1192,43 @@ describe('SessionManager', () => {
 				session,
 				'\u001b[31mrestored\u001b[0m\u001b[8;12H',
 			);
+		});
+
+		it('should restore all retained normal-buffer scrollback when no baseline excludes it', async () => {
+			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
+				id: '1',
+				name: 'Main',
+				command: 'claude',
+			});
+			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
+
+			const session = await Effect.runPromise(
+				sessionManager.createSessionWithPresetEffect('/test/worktree'),
+			);
+			const normalBuffer = session.terminal.buffer.normal as unknown as {
+				baseY: number;
+				length: number;
+				cursorY: number;
+				cursorX: number;
+			};
+			normalBuffer.baseY = 260;
+			normalBuffer.length = 300;
+			normalBuffer.cursorY = 7;
+			normalBuffer.cursorX = 11;
+			session.restoreScrollbackBaseLine = 0;
+			const serializeMock = vi
+				.spyOn(session.serializer, 'serialize')
+				.mockReturnValue('\u001b[31mrestored\u001b[0m');
+
+			sessionManager.setSessionActive(session.id, true);
+
+			expect(serializeMock).toHaveBeenCalledWith({
+				range: {
+					start: 0,
+					end: 299,
+				},
+				excludeAltBuffer: true,
+			});
 		});
 
 		it('should keep viewport-only restore behavior for alternate screen sessions', async () => {
@@ -1303,7 +1340,7 @@ describe('SessionManager', () => {
 			expect(eventOrder).toEqual(['restore', 'data']);
 		});
 
-		it('should defer the viewport-only restore until PTY output is quiet when a transient footer is visible', async () => {
+		it('should defer the scrollback restore until PTY output is quiet when a transient footer is visible', async () => {
 			vi.useFakeTimers();
 			try {
 				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
@@ -1345,11 +1382,14 @@ describe('SessionManager', () => {
 				vi.advanceTimersByTime(80);
 
 				expect(serializeMock).toHaveBeenCalledWith({
-					scrollback: 0,
+					range: {
+						start: 120,
+						end: 299,
+					},
 					excludeAltBuffer: true,
 				});
 				expect(serializeMock).not.toHaveBeenCalledWith(
-					expect.objectContaining({range: expect.anything()}),
+					expect.objectContaining({scrollback: 0}),
 				);
 				expect(restoreHandler).toHaveBeenCalledWith(
 					session,

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -45,6 +45,11 @@ const RESIZE_SUPPRESS_MS = 250;
 // streaming session still restores within a small bounded delay.
 const RESTORE_DEFER_QUIET_MS = 80;
 const RESTORE_DEFER_MAX_MS = 250;
+// Cursor-addressed redraws (progress bars, spinners, TUIs) can leave transient
+// rows in scrollback if the viewport scrolls before those rows are overwritten.
+// Keep a short generic redraw window so restore can skip that ghost-bearing
+// range without depending on any specific CLI output text.
+const REDRAW_SCROLLBACK_QUIET_MS = 500;
 
 export interface SessionCounts {
 	idle: number;
@@ -67,6 +72,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	private resizeSuppressTimers: Map<string, NodeJS.Timeout> = new Map();
 	private restoreDeferTimers: Map<string, NodeJS.Timeout> = new Map();
 	private restoreDeferDeadlines: Map<string, number> = new Map();
+	private cursorRedrawSessions: Set<string> = new Set();
+	private cursorRedrawTimers: Map<string, NodeJS.Timeout> = new Map();
 
 	private async spawn(
 		command: string,
@@ -331,6 +338,50 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		);
 	}
 
+	private hasCursorAddressedRedraw(data: string): boolean {
+		return (
+			// CSI cursor movement/positioning, erase, and scroll controls.
+			/\x1b\[[0-?]*[ -/]*[ABCDEFGHJKSTX`abcdefg]/.test(data) ||
+			// DEC save/restore cursor.
+			/\x1b[78]/.test(data) ||
+			// Synchronized output mode usually brackets full-frame redraws.
+			/\x1b\[\?2026[hl]/.test(data)
+		);
+	}
+
+	private markCursorRedrawActive(session: Session): void {
+		this.cursorRedrawSessions.add(session.id);
+
+		const existing = this.cursorRedrawTimers.get(session.id);
+		if (existing !== undefined) {
+			clearTimeout(existing);
+		}
+
+		const timer = setTimeout(() => {
+			this.cursorRedrawTimers.delete(session.id);
+			this.cursorRedrawSessions.delete(session.id);
+		}, REDRAW_SCROLLBACK_QUIET_MS);
+		this.cursorRedrawTimers.set(session.id, timer);
+	}
+
+	private handleScrollbackGrowthDuringRedraw(
+		session: Session,
+		beforeBaseY: number,
+	): void {
+		const afterBaseY = session.terminal.buffer.normal.baseY;
+		if (
+			afterBaseY <= beforeBaseY ||
+			!this.cursorRedrawSessions.has(session.id)
+		) {
+			return;
+		}
+
+		session.restoreScrollbackBaseLine = Math.max(
+			session.restoreScrollbackBaseLine,
+			afterBaseY,
+		);
+	}
+
 	private getRestoreSnapshot(session: Session): string {
 		const activeBuffer = session.terminal.buffer.active;
 		if (activeBuffer.type !== 'normal') {
@@ -577,8 +628,14 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	private setupDataHandler(session: Session): void {
 		// This handler always runs for all data
 		session.process.onData((data: string) => {
+			const beforeBaseY = session.terminal.buffer.normal.baseY;
+			if (this.hasCursorAddressedRedraw(data)) {
+				this.markCursorRedrawActive(session);
+			}
+
 			// Write data to virtual terminal
 			session.terminal.write(data);
+			this.handleScrollbackGrowthDuringRedraw(session, beforeBaseY);
 
 			if (this.shouldResetRestoreScrollback(data)) {
 				session.restoreScrollbackBaseLine =
@@ -882,6 +939,15 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		this.restoreDeferDeadlines.delete(sessionId);
 	}
 
+	private clearCursorRedrawTracking(sessionId: string): void {
+		this.cursorRedrawSessions.delete(sessionId);
+		const timer = this.cursorRedrawTimers.get(sessionId);
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			this.cursorRedrawTimers.delete(sessionId);
+		}
+	}
+
 	cancelAutoApproval(sessionId: string, reason = 'User input received'): void {
 		const session = this.sessions.get(sessionId);
 		if (!session) {
@@ -968,6 +1034,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				clearTimeout(resizeTimer);
 				this.resizeSuppressTimers.delete(sessionId);
 			}
+			this.clearCursorRedrawTracking(sessionId);
 			this.cancelRestoreDefer(sessionId);
 			this.emit('sessionDestroyed', session);
 		}
@@ -1035,6 +1102,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					clearTimeout(resizeTimer);
 					this.resizeSuppressTimers.delete(sessionId);
 				}
+				this.clearCursorRedrawTracking(sessionId);
 				this.cancelRestoreDefer(sessionId);
 				this.emit('sessionDestroyed', session);
 			},

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -32,7 +32,7 @@ import {preparePresetLaunch} from '../utils/presetPrompt.js';
 const {Terminal} = pkg;
 const TERMINAL_CONTENT_MAX_LINES = 300;
 const TERMINAL_SCROLLBACK_LINES = 5000;
-const TERMINAL_RESTORE_SCROLLBACK_LINES = 200;
+const TERMINAL_RESTORE_SCROLLBACK_LINES = TERMINAL_SCROLLBACK_LINES;
 // How long to suppress PTY → stdout forwarding after a viewport resize so the
 // child process's SIGWINCH-triggered re-emission of static content does not
 // duplicate already-displayed rows in the user's terminal.
@@ -347,20 +347,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 
 		const cursorRow = normalBuffer.cursorY + 1;
 		const cursorCol = normalBuffer.cursorX + 1;
-
-		// When the live viewport shows a transient footer (spinner activity,
-		// token stats, persistent shift+tab footer, etc.), the renderer keeps
-		// redrawing it in place and earlier copies have likely been pushed into
-		// scrollback by chat output scrolling beneath it. Replaying that
-		// scrollback would paint duplicated footer rows, so emit only the
-		// viewport in this case.
-		if (session.stateDetector.hasTransientRenderFooter(session.terminal)) {
-			const viewportSnapshot = session.serializer.serialize({
-				scrollback: 0,
-				excludeAltBuffer: true,
-			});
-			return `${viewportSnapshot}\x1b[${cursorRow};${cursorCol}H`;
-		}
 
 		const scrollbackStart = Math.max(
 			0,


### PR DESCRIPTION
## Summary
- detach active sessions synchronously when the return-to-menu shortcut is pressed
- block late session restore/resize repaints after the session view starts exiting
- add a regression test for late output after returning to menu

## Cause
When returning from a busy Claude session to the menu, App cleared the terminal immediately, but Session listeners could remain attached until React unmount cleanup. Late PTY output or deferred restore/resize repaint could then write over the newly cleared menu, producing duplicated or overlapping rows.

## Verification
- npm run test -- src/components/Session.test.tsx
- npm run typecheck
- npm run lint