### PR TITLE
fix: guard SelectInput callbacks against undefined and replace unsafe as-casts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,11 +37,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "4.1.13",
-        "@kodaikabasawa/ccmanager-darwin-x64": "4.1.13",
-        "@kodaikabasawa/ccmanager-linux-arm64": "4.1.13",
-        "@kodaikabasawa/ccmanager-linux-x64": "4.1.13",
-        "@kodaikabasawa/ccmanager-win32-x64": "4.1.13",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "4.1.14",
+        "@kodaikabasawa/ccmanager-darwin-x64": "4.1.14",
+        "@kodaikabasawa/ccmanager-linux-arm64": "4.1.14",
+        "@kodaikabasawa/ccmanager-linux-x64": "4.1.14",
+        "@kodaikabasawa/ccmanager-win32-x64": "4.1.14",
       },
     },
   },
@@ -128,15 +128,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@4.1.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Oyh0Dq1fhHNh9xVHE23LF4Sy10mdzcb3Yud5cKV2P6mlMjIF452fcgmK73yA7iDwTeJG2AmnUSaAljfo7cr7nA=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@4.1.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vNN/Yljqr8FgcSanuiqV6KtkFiVigrSkDmreHzpX8odZqWV8LdpLEL8Gd+KFCow+HyrXjEl7M0ZknLlwWZdgpA=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@4.1.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-kCq5K7FWArjaHGAiXeBg8Sk4WkiY2qPEBtjQci8K/4fmHyLLxGEYbXF2H0150Isz7J+0bGva5zLg34Ia8yOWLA=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@4.1.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-upWyjtoHxEX2UC2J2j2zMPQulPYqIaybVRFRctzqMsMqIk0QDkX4hiqYjf5GAJc+IV6OzoGBZLpptvI0kb78Jg=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@4.1.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-ouIF5IAN73WgZiLRMjuEE4g5QY8i/AV159CObvBO6wk2dx1lu3BugS4lFY+c1oLsGTh882+Ya5bYd45HY42Nnw=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@4.1.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-vN0Y5s59I0ulmEDiNyPLe8Uij8cOzyT4CfZNX/K9r6oPrMjzwjG9ujwQP2fnydCdYes1UK3BLFJ3K9F0n6hXhA=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@4.1.13", "", { "os": "linux", "cpu": "x64" }, "sha512-EJL3l4kxtHPYy6w3Qrmp/iw4TOjdqKU15OVKGnslQzTDMklJkEarnn2Ks80IJZW9P4SLmt77WKgTNfjPUGjkNQ=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@4.1.14", "", { "os": "linux", "cpu": "x64" }, "sha512-hSnOCShZpFOI8AlGuqHZO1Bk6k0EytIx2gNNg4wrvv0ZjGP1pwCYdNrO+NU5hkhNIC9AFW/1AeEfA3GrGAiYEg=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@4.1.13", "", { "os": "win32", "cpu": "x64" }, "sha512-ppwq0wdaunUuUU6LBtveVDb9mfz4CNCNHIkKXq3vDkztssNS+vJT4PKT8osgFbS7V9OarvI3j7Q7C4oGGQLvDw=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@4.1.14", "", { "os": "win32", "cpu": "x64" }, "sha512-H2SI5amPHtWjuka7Hp4BF9UT9l3ygfO62LRQjhzEbsXohxoEsq6s1F2874VArnTGfHK8liushnPWs1PvfSC+uA=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/src/components/ConfigureCommand.tsx
+++ b/src/components/ConfigureCommand.tsx
@@ -284,12 +284,15 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 		}
 	};
 
-	const handleStrategySelect = (item: {label: string; value: string}) => {
+	const handleStrategySelect = (item: {
+		label: string;
+		value: StateDetectionStrategy;
+	}) => {
 		const preset = presets.find(p => p.id === selectedPresetId);
 		if (!preset) return;
 
 		const updatedPreset = {...preset};
-		updatedPreset.detectionStrategy = item.value as StateDetectionStrategy;
+		updatedPreset.detectionStrategy = item.value;
 
 		const updatedPresets = presets.map(p =>
 			p.id === preset.id ? updatedPreset : p,
@@ -300,8 +303,11 @@ const ConfigureCommand: React.FC<ConfigureCommandProps> = ({onComplete}) => {
 		setIsSelectingStrategy(false);
 	};
 
-	const handleAddStrategySelect = (item: {label: string; value: string}) => {
-		const strategy = item.value as StateDetectionStrategy;
+	const handleAddStrategySelect = (item: {
+		label: string;
+		value: StateDetectionStrategy;
+	}) => {
+		const strategy = item.value;
 		const defaultCommand = DEFAULT_COMMANDS[strategy];
 
 		setNewPreset({

--- a/src/components/ConfigureMerge.tsx
+++ b/src/components/ConfigureMerge.tsx
@@ -11,6 +11,7 @@ interface ConfigureMergeProps {
 }
 
 type EditField = 'mergeArgs' | 'rebaseArgs';
+type MenuItemValue = EditField | 'separator' | 'back';
 
 const DEFAULT_MERGE_ARGS = ['--no-ff'];
 const DEFAULT_REBASE_ARGS: string[] = [];
@@ -33,7 +34,7 @@ const ConfigureMerge: React.FC<ConfigureMergeProps> = ({onComplete}) => {
 	const formatArgs = (args: string[]) =>
 		args.length > 0 ? args.join(' ') : '(none)';
 
-	const menuItems = [
+	const menuItems: Array<{label: string; value: MenuItemValue}> = [
 		{
 			label: `Merge Arguments: ${formatArgs(getMergeArgs())}`,
 			value: 'mergeArgs',
@@ -46,16 +47,15 @@ const ConfigureMerge: React.FC<ConfigureMergeProps> = ({onComplete}) => {
 		{label: '<- Back', value: 'back'},
 	];
 
-	const handleSelect = (item: {label: string; value: string}) => {
+	const handleSelect = (item: {label: string; value: MenuItemValue}) => {
 		if (item.value === 'separator') return;
 		if (item.value === 'back') {
 			onComplete();
 			return;
 		}
 
-		const field = item.value as EditField;
-		setEditField(field);
-		switch (field) {
+		setEditField(item.value);
+		switch (item.value) {
 			case 'mergeArgs':
 				setInputValue(getMergeArgs().join(' '));
 				break;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -654,7 +654,11 @@ const Dashboard: React.FC<DashboardProps> = ({
 				>
 					<SelectInput
 						items={items}
-						onSelect={item => handleSelect(item as DashboardItem)}
+						onSelect={raw => {
+							const item = items.find(i => i.value === raw?.value);
+							if (!item) return;
+							handleSelect(item);
+						}}
 						isFocused={!displayError}
 						limit={limit}
 						initialIndex={selectedIndex}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -580,17 +580,17 @@ const Menu: React.FC<MenuProps> = ({
 			>
 				<SelectInput
 					items={items}
-					onSelect={item => handleSelect(item as MenuItem)}
-					onHighlight={item => {
-						// ink-select-input may call onHighlight with undefined when items are empty
-						// (e.g., during menu re-mount after returning from a session), so guard it.
-						if (!item) {
-							return;
-						}
-						const menuItem = item as MenuItem;
-						if (menuItem.type === 'worktree') {
-							setHighlightedWorktreePath(menuItem.worktree.path);
-							setHighlightedSession(menuItem.session);
+					onSelect={raw => {
+						const item = items.find(i => i.value === raw?.value);
+						if (!item) return;
+						handleSelect(item);
+					}}
+					onHighlight={raw => {
+						const item = items.find(i => i.value === raw?.value);
+						if (!item) return;
+						if (item.type === 'worktree') {
+							setHighlightedWorktreePath(item.worktree.path);
+							setHighlightedSession(item.session);
 						}
 					}}
 					isFocused={!error}

--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -128,7 +128,7 @@ function handleStatusExit(
 	} else if (Exit.isFailure(statusExit)) {
 		const failure = Cause.failureOption(statusExit.cause);
 		if (Option.isSome(failure)) {
-			const gitError = failure.value as GitError;
+			const gitError = failure.value;
 			update.gitStatus = undefined;
 			update.gitStatusError = formatGitError(gitError);
 			hasUpdate = true;

--- a/src/services/autoApprovalVerifier.ts
+++ b/src/services/autoApprovalVerifier.ts
@@ -688,7 +688,8 @@ export class AutoApprovalVerifier {
 
 				return JSON.parse(responseText) as AutoApprovalResponse;
 			},
-			catch: (error: unknown) => error as Error,
+			catch: (error: unknown) =>
+				error instanceof Error ? error : new Error(String(error)),
 		});
 
 		return Effect.catchAll(attemptVerification, (error: Error) => {

--- a/src/services/projectManager.ts
+++ b/src/services/projectManager.ts
@@ -254,7 +254,14 @@ export class ProjectManager implements IProjectManager {
 				);
 			} catch (error) {
 				// Silently skip directories we can't read
-				if ((error as NodeJS.ErrnoException).code !== 'EACCES') {
+				if (
+					!(
+						typeof error === 'object' &&
+						error !== null &&
+						'code' in error &&
+						error.code === 'EACCES'
+					)
+				) {
 					console.error(`Error scanning directory ${dir}:`, error);
 				}
 			}
@@ -351,7 +358,7 @@ export class ProjectManager implements IProjectManager {
 				return null;
 			}
 		} catch (error) {
-			result.error = `Failed to process: ${(error as Error).message}`;
+			result.error = `Failed to process: ${error instanceof Error ? error.message : String(error)}`;
 		}
 
 		return result;
@@ -470,11 +477,14 @@ export class ProjectManager implements IProjectManager {
 					return error;
 				}
 
-				const nodeError = error as NodeJS.ErrnoException;
-				const cause =
-					nodeError.code === 'ENOENT'
-						? `Projects directory does not exist: ${projectsDir}`
-						: String(error);
+				const isEnoent =
+					typeof error === 'object' &&
+					error !== null &&
+					'code' in error &&
+					error.code === 'ENOENT';
+				const cause = isEnoent
+					? `Projects directory does not exist: ${projectsDir}`
+					: String(error);
 
 				return new FileSystemError({
 					operation: 'read',

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -214,7 +214,7 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			.catch(async (error: unknown) => {
 				if (abortController.signal.aborted) {
 					logger.debug(
-						`[${session.id}] Auto-approval verification aborted (${(error as Error)?.message ?? 'aborted'})`,
+						`[${session.id}] Auto-approval verification aborted (${error instanceof Error ? error.message : 'aborted'})`,
 					);
 					return;
 				}
@@ -230,8 +230,9 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					await this.updateSessionState(session, 'waiting_input', {
 						autoApprovalFailed: true,
 						autoApprovalReason:
-							(error as Error | undefined)?.message ??
-							'Auto-approval verification failed',
+							error instanceof Error
+								? error.message
+								: 'Auto-approval verification failed',
 					});
 				}
 			})


### PR DESCRIPTION
## Problem

Returning from a session to the Menu and immediately pressing ↑/↓ or
Enter crashes with:

```
TypeError: undefined is not an object (evaluating 'item.value')
```

`ink-select-input` can call `onSelect`/`onHighlight` with `undefined`
while the items list is transitioning (e.g. during menu re-mount after
session exit). The original handler cast `item as MenuItem` which hid
this at compile time but crashed at runtime.

## Changes

**Crash fix — Menu & Dashboard**

Replace `item as MenuItem` / `item as DashboardItem` casts with an
`items.find()` lookup. Both `onSelect` and `onHighlight` return early
when the raw argument is falsy or when no matching item is found.

**Broader as-cast audit**

While fixing the above, audited all `as`-casts in `src/` and replaced
each unsafe one:

| File | Before | After |
|---|---|---|
| `ConfigureCommand.tsx` | `item.value as StateDetectionStrategy` | handler signature narrowed to `StateDetectionStrategy` |
| `ConfigureMerge.tsx` | `item.value as EditField` | `MenuItemValue` union + TypeScript narrowing after guards |
| `useGitStatus.ts` | `failure.value as GitError` | removed (redundant — `Cause.failureOption` already returns `Option<GitError>`) |
| `autoApprovalVerifier.ts` | `error as Error` | `instanceof` guard with `new Error(String(error))` fallback |
| `projectManager.ts` ×3 | `as NodeJS.ErrnoException` / `as Error` | `typeof object && 'code' in error` narrowing |
| `sessionManager.ts` ×2 | `(error as Error)?.message` | `instanceof` guard |

## Test plan

- [ ] `npm run typecheck` and `npm run lint` pass
- [ ] Return from a session to the menu and immediately press ↑/↓ or Enter — no crash
- [ ] Menu item selection (worktree, new/merge/delete/config/exit) all work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)