### PR TITLE
fix: prevent double session creation when using number keys in PresetSelector

### DIFF
--- a/src/components/PresetSelector.test.tsx
+++ b/src/components/PresetSelector.test.tsx
@@ -122,29 +122,15 @@ describe('PresetSelector component', () => {
 		expect(output).toContain('← Cancel');
 	});
 
-	it('pressing 1 calls onSelect with first preset id immediately', () => {
+	// Number key selection is handled by ink-select-input v6+ natively.
+	// PresetSelector's useInput only handles ESC to avoid double-firing onSelect
+	// (which would create two sessions for one worktree).
+	it('pressing number keys via useInput does NOT trigger onSelect', () => {
 		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
 		expect(capturedHandlers.inputHandler).not.toBeNull();
 		capturedHandlers.inputHandler!('1', makeKey());
-		expect(onSelect).toHaveBeenCalledWith('preset-1');
-		expect(onCancel).not.toHaveBeenCalled();
-	});
-
-	it('pressing 2 calls onSelect with second preset id immediately', () => {
-		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
 		capturedHandlers.inputHandler!('2', makeKey());
-		expect(onSelect).toHaveBeenCalledWith('preset-2');
-	});
-
-	it('pressing 3 calls onSelect with third preset id immediately', () => {
-		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
 		capturedHandlers.inputHandler!('3', makeKey());
-		expect(onSelect).toHaveBeenCalledWith('preset-3');
-	});
-
-	it('pressing a number beyond preset count does nothing', () => {
-		render(<PresetSelector onSelect={onSelect} onCancel={onCancel} />);
-		capturedHandlers.inputHandler!('9', makeKey());
 		expect(onSelect).not.toHaveBeenCalled();
 		expect(onCancel).not.toHaveBeenCalled();
 	});

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -48,19 +48,11 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
 		item => item.value === defaultPresetId,
 	);
 
-	useInput((input, key) => {
+	// ink-select-input v6+ handles number keys 1-9 natively, so only handle ESC here
+	// to avoid double-firing onSelect (which would create two sessions for one worktree).
+	useInput((_input, key) => {
 		if (key.escape) {
 			onCancel();
-			return;
-		}
-
-		// Number keys 1-9: immediate launch
-		if (/^[1-9]$/.test(input)) {
-			const idx = parseInt(input) - 1;
-			if (idx < presets.length && presets[idx]) {
-				onSelect(presets[idx]!.id);
-			}
-			return;
 		}
 	});
 


### PR DESCRIPTION
## Summary

- `ink-select-input` v6+ natively handles number keys 1-9 by calling `onSelect` directly in its internal `useInput` handler
- `PresetSelector` also had its own `useInput` handler for the same keys (added in #238)
- When a number key was pressed in the preset selector, **both handlers fired simultaneously**, calling `handlePresetSelected` twice before React state updates could propagate
- This caused `createSessionWithPresetEffect` to be called twice for the same worktree path, creating two sessions

**Fix:** Remove the number-key block from `PresetSelector`'s `useInput`, keeping only ESC handling. `SelectInput` now owns number-key selection entirely, eliminating the double-fire.

## Reproduction

1. Configure multiple presets with `selectPresetOnStart: true`
2. Select a worktree from the menu
3. Press a number key (1-9) in the preset selector
4. Observe two sessions created for the same worktree

## Test plan

- [ ] Verify `PresetSelector` tests pass (`npm run test -- PresetSelector`)
- [ ] Manually confirm pressing number keys in preset selector creates exactly one session
- [ ] Verify ESC still cancels the preset selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)