### PR TITLE
fix: avoid detached HEAD when creating worktree from remote branch

### DIFF
--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -793,8 +793,14 @@ branch refs/heads/feature
 					if (cmd === 'git rev-parse --git-common-dir') {
 						return '/fake/path/.git\n';
 					}
-					if (cmd.includes('rev-parse --verify')) {
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
 						throw new Error('Branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						throw new Error('Remote branch not found');
 					}
 					if (cmd.includes('git worktree add')) {
 						return '';
@@ -817,14 +823,73 @@ branch refs/heads/feature
 			});
 		});
 
+		it('should create local branch from remote ref when only remote branch exists', async () => {
+			const executedCommands: string[] = [];
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					executedCommands.push(cmd);
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					// No local branch
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
+						throw new Error('Branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\n';
+					}
+					// Remote branch exists
+					if (
+						cmd ===
+						'git show-ref --verify --quiet refs/remotes/origin/feature/remote-only'
+					) {
+						return '';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						throw new Error('Remote branch not found');
+					}
+					if (cmd.includes('git worktree add')) {
+						return '';
+					}
+				}
+				return '';
+			});
+
+			const effect = service.createWorktreeEffect(
+				'/path/to/worktree',
+				'feature/remote-only',
+				'main',
+			);
+			const result = await Effect.runPromise(effect);
+
+			expect(result.worktree).toMatchObject({
+				path: '/path/to/worktree',
+				branch: 'feature/remote-only',
+				isMainWorktree: false,
+			});
+
+			// Should use -b with the remote ref as start point, not baseBranch
+			const worktreeAddCmd = executedCommands.find(c =>
+				c.includes('git worktree add'),
+			);
+			expect(worktreeAddCmd).toContain('-b "feature/remote-only"');
+			expect(worktreeAddCmd).toContain('"origin/feature/remote-only"');
+		});
+
 		it('should return Effect that fails with GitError on git command failure', async () => {
 			mockedExecSync.mockImplementation((cmd, _options) => {
 				if (typeof cmd === 'string') {
 					if (cmd === 'git rev-parse --git-common-dir') {
 						return '/fake/path/.git\n';
 					}
-					if (cmd.includes('rev-parse --verify')) {
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
 						throw new Error('Branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						throw new Error('Remote branch not found');
 					}
 					if (cmd.includes('git worktree add')) {
 						const error: MockGitError = new Error(
@@ -878,8 +943,14 @@ branch refs/heads/feature
 					if (cmd === 'git rev-parse --git-common-dir') {
 						return '/fake/path/.git\n';
 					}
-					if (cmd.includes('rev-parse --verify')) {
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
 						throw new Error('Branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						throw new Error('Remote branch not found');
 					}
 					if (cmd.includes('git worktree add')) {
 						throw new Error('git worktree add should not be called');
@@ -930,8 +1001,14 @@ branch refs/heads/feature
 					if (cmd === 'git rev-parse --git-common-dir') {
 						return '/fake/path/.git\n';
 					}
-					if (cmd.includes('rev-parse --verify')) {
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
 						throw new Error('Branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						throw new Error('Remote branch not found');
 					}
 					if (cmd.includes('git worktree add')) {
 						return '';

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -929,11 +929,15 @@ export class WorktreeService {
 				copyClaudeDirectory,
 			});
 
-			// Check if branch exists
-			const branchExists = yield* Effect.catchAll(
+			// Check if a LOCAL branch exists (refs/heads/ only).
+			// Using `git rev-parse --verify` without qualifying the ref would also
+			// match remote-tracking refs (e.g. refs/remotes/origin/<branch>), which
+			// causes `git worktree add` to create the worktree in detached-HEAD
+			// state instead of on a proper local branch.
+			const localBranchExists = yield* Effect.catchAll(
 				Effect.try({
 					try: () => {
-						execSync(`git rev-parse --verify ${branch}`, {
+						execSync(`git show-ref --verify --quiet refs/heads/${branch}`, {
 							cwd: self.rootPath,
 							encoding: 'utf8',
 						});
@@ -967,14 +971,22 @@ export class WorktreeService {
 				);
 			}
 
-			// Create the worktree command
+			// Create the worktree command.
+			// Three cases:
+			// 1. Local branch exists → attach worktree directly
+			// 2. No local branch, but remote-tracking branch exists → create
+			//    local branch from the remote ref (avoids detached HEAD)
+			// 3. Branch is brand-new → create from baseBranch
 			let command: string;
-			if (branchExists) {
+			if (localBranchExists) {
 				command = `git worktree add "${resolvedPath}" "${branch}"`;
 			} else {
-				// Resolve the base branch to its proper git reference
-				const resolvedBaseBranch = self.resolveBranchReference(baseBranch);
-				command = `git worktree add -b "${branch}" "${resolvedPath}" "${resolvedBaseBranch}"`;
+				const resolvedRef = self.resolveBranchReference(branch);
+				const isRemoteBranch = resolvedRef !== branch;
+				const startPoint = isRemoteBranch
+					? resolvedRef
+					: self.resolveBranchReference(baseBranch);
+				command = `git worktree add -b "${branch}" "${resolvedPath}" "${startPoint}"`;
 			}
 
 			// Execute the worktree creation command


### PR DESCRIPTION
## Summary

When creating a worktree for a branch that only exists on a remote (e.g. `origin/feature/foo`), ccmanager creates the worktree in **detached HEAD** state instead of on a proper local tracking branch.

**Root cause:** `createWorktreeEffect` uses `git rev-parse --verify <branch>` to check if a branch exists. This command resolves *any* git ref, including remote-tracking refs like `refs/remotes/origin/foo`. When it matches a remote ref, the code takes the "branch exists" path and runs `git worktree add <path> <branch>`, which git interprets as a detached checkout of the remote ref.

**Fix:** Use `git show-ref --verify --quiet refs/heads/<branch>` (which only matches local branches) instead of `git rev-parse --verify`. This is consistent with what `resolveBranchReference()` already does internally. When no local branch exists but a remote-tracking branch does, the code now correctly falls through to `git worktree add -b <branch> <path> <remote/branch>`, creating a local branch from the remote ref.

### Before (broken)
```
$ git worktree list
/repo/origin-pvp-add_mint_evals_to_nightly  0d9ef0a (detached HEAD)
```

### After (fixed)
```
$ git worktree list
/repo/origin-pvp-add_mint_evals_to_nightly  0d9ef0a [pvp/add_mint_evals_to_nightly]
```

## Changes

- **`src/services/worktreeService.ts`**: Replace `git rev-parse --verify` with `git show-ref --verify --quiet refs/heads/` for local branch detection. When the branch exists only on a remote, resolve it via `resolveBranchReference(branch)` to get the remote ref as the start point.
- **`src/services/worktreeService.test.ts`**: Update mocks to match the new git command, add test case for the remote-only branch scenario.

## Test plan

- [x] All 849 existing tests pass
- [x] New test verifies that remote-only branches use `-b` with the remote ref as start point
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)