### PR TITLE
fix: propagate AmbiguousBranchError as a typed Effect error

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -29,7 +29,6 @@ import {
 	GitProject,
 	MenuAction,
 	AmbiguousBranchError,
-	RemoteBranchMatch,
 } from '../types/index.js';
 import {type AppError, type ProcessError} from '../types/errors.js';
 import {configReader} from '../services/config/configReader.js';
@@ -380,37 +379,6 @@ const App: React.FC<AppProps> = ({
 		};
 	}, [view, pendingMenuSessionLaunch, startSessionForWorktree]);
 
-	// Helper function to parse ambiguous branch error and create AmbiguousBranchError
-	const parseAmbiguousBranchError = (
-		errorMessage: string,
-	): AmbiguousBranchError | null => {
-		const pattern =
-			/Ambiguous branch '(.+?)' found in multiple remotes: (.+?)\. Please specify which remote to use\./;
-		const match = errorMessage.match(pattern);
-
-		if (!match) {
-			return null;
-		}
-
-		const branchName = match[1]!;
-		const remoteRefsText = match[2]!;
-		const remoteRefs = remoteRefsText.split(', ');
-
-		// Parse remote refs into RemoteBranchMatch objects
-		const matches: RemoteBranchMatch[] = remoteRefs.map(fullRef => {
-			const parts = fullRef.split('/');
-			const remote = parts[0]!;
-			const branch = parts.slice(1).join('/');
-			return {
-				remote,
-				branch,
-				fullRef,
-			};
-		});
-
-		return new AmbiguousBranchError(branchName, matches);
-	};
-
 	// Helper function to handle worktree creation results
 	const handleWorktreeCreationResult = (
 		result: {success: boolean; error?: string; warning?: string},
@@ -451,21 +419,8 @@ const App: React.FC<AppProps> = ({
 			return;
 		}
 
-		const errorMessage = result.error || 'Failed to create worktree';
-		const ambiguousError = parseAmbiguousBranchError(errorMessage);
-
-		if (ambiguousError) {
-			// Handle ambiguous branch error
-			setPendingWorktreeCreation({
-				...creationData,
-				ambiguousError,
-			});
-			navigateWithClear('remote-branch-selector');
-		} else {
-			// Handle regular error
-			setError(errorMessage);
-			setView('new-worktree');
-		}
+		setError(result.error || 'Failed to create worktree');
+		setView('new-worktree');
 	};
 
 	const handleMenuAction = async (action: MenuAction) => {
@@ -643,9 +598,26 @@ const App: React.FC<AppProps> = ({
 			),
 		);
 
-		// Transform Effect result to legacy format for handleWorktreeCreationResult
 		if (result._tag === 'Left') {
-			// Handle error using pattern matching on _tag
+			if (result.left._tag === 'AmbiguousBranchError') {
+				setPendingWorktreeCreation({
+					path: targetPath,
+					branch,
+					baseBranch: request.baseBranch,
+					copySessionData: request.copySessionData,
+					copyClaudeDirectory: request.copyClaudeDirectory,
+					presetId:
+						request.creationMode === 'prompt' ? request.presetId : undefined,
+					initialPrompt:
+						request.creationMode === 'prompt'
+							? request.initialPrompt
+							: undefined,
+					ambiguousError: result.left,
+				});
+				navigateWithClear('remote-branch-selector');
+				return;
+			}
+
 			const errorMessage = formatPreCreationHookError(result.left);
 			if (result.left._tag === 'ProcessError') {
 				setError(null);
@@ -733,7 +705,12 @@ const App: React.FC<AppProps> = ({
 		);
 
 		if (result._tag === 'Left') {
-			// Handle error using pattern matching on _tag
+			if (result.left._tag === 'AmbiguousBranchError') {
+				setError(result.left.message);
+				setView('new-worktree');
+				return;
+			}
+
 			const errorMessage = formatPreCreationHookError(result.left);
 			if (result.left._tag === 'ProcessError') {
 				setError(null);

--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -5,6 +5,7 @@ import {existsSync, statSync, Stats} from 'fs';
 import {configReader} from './config/configReader.js';
 import {Effect} from 'effect';
 import {GitError, ProcessError} from '../types/errors.js';
+import {AmbiguousBranchError} from '../types/index.js';
 
 // Mock child_process module
 vi.mock('child_process');
@@ -477,6 +478,93 @@ origin/feature/test
 		});
 	});
 
+	describe('resolveBranchReferenceEffect', () => {
+		it('should succeed with remote ref when single remote has the branch', async () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (
+						cmd.includes('show-ref --verify --quiet refs/heads/foo/bar-xyz')
+					) {
+						throw new Error('Local branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\nupstream\n';
+					}
+					if (
+						cmd.includes(
+							'show-ref --verify --quiet refs/remotes/origin/foo/bar-xyz',
+						)
+					) {
+						return '';
+					}
+					if (
+						cmd.includes(
+							'show-ref --verify --quiet refs/remotes/upstream/foo/bar-xyz',
+						)
+					) {
+						throw new Error('Remote branch not found in upstream');
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const effect = (service as any).resolveBranchReferenceEffect(
+				'foo/bar-xyz',
+			);
+			const result = await Effect.runPromise(Effect.either(effect));
+
+			expect(result._tag).toBe('Right');
+			if (result._tag === 'Right') {
+				expect(result.right).toBe('origin/foo/bar-xyz');
+			}
+		});
+
+		it('should fail with AmbiguousBranchError (not Die) when multiple remotes have the branch', async () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (
+						cmd.includes('show-ref --verify --quiet refs/heads/foo/bar-xyz')
+					) {
+						throw new Error('Local branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\nupstream\n';
+					}
+					if (
+						cmd.includes(
+							'show-ref --verify --quiet refs/remotes/origin/foo/bar-xyz',
+						) ||
+						cmd.includes(
+							'show-ref --verify --quiet refs/remotes/upstream/foo/bar-xyz',
+						)
+					) {
+						return '';
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const effect = (service as any).resolveBranchReferenceEffect(
+				'foo/bar-xyz',
+			);
+			const result = await Effect.runPromise(Effect.either(effect));
+
+			expect(result._tag).toBe('Left');
+			if (result._tag === 'Left') {
+				expect(result.left).toBeInstanceOf(AmbiguousBranchError);
+				expect((result.left as AmbiguousBranchError)._tag).toBe(
+					'AmbiguousBranchError',
+				);
+				expect((result.left as AmbiguousBranchError).branchName).toBe(
+					'foo/bar-xyz',
+				);
+				expect((result.left as AmbiguousBranchError).matches).toHaveLength(2);
+			}
+		});
+	});
+
 	describe('hasClaudeDirectoryInBranchEffect', () => {
 		it('should return Effect with true when .claude directory exists in branch worktree', async () => {
 			mockedExecSync.mockImplementation((cmd, _options) => {
@@ -874,6 +962,48 @@ branch refs/heads/feature
 			);
 			expect(worktreeAddCmd).toContain('-b "feature/remote-only"');
 			expect(worktreeAddCmd).toContain('"origin/feature/remote-only"');
+		});
+
+		it('should return Effect Left with AmbiguousBranchError when branch exists in multiple remotes', async () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
+						throw new Error('Branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\nkbwo-fork\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						return ''; // Both remotes have the branch
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			const effect = service.createWorktreeEffect(
+				'/path/to/worktree',
+				'feature/feed-mention',
+				'main',
+			);
+			const result = await Effect.runPromise(Effect.either(effect));
+
+			expect(result._tag).toBe('Left');
+			if (result._tag === 'Left') {
+				expect(result.left).toBeInstanceOf(AmbiguousBranchError);
+				expect((result.left as AmbiguousBranchError)._tag).toBe(
+					'AmbiguousBranchError',
+				);
+				expect((result.left as AmbiguousBranchError).branchName).toBe(
+					'feature/feed-mention',
+				);
+				expect((result.left as AmbiguousBranchError).matches).toHaveLength(2);
+				expect(
+					(result.left as AmbiguousBranchError).matches.map(m => m.remote),
+				).toEqual(['origin', 'kbwo-fork']);
+			}
 		});
 
 		it('should return Effect that fails with GitError on git command failure', async () => {

--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -1006,6 +1006,50 @@ branch refs/heads/feature
 			}
 		});
 
+		it('should succeed when baseBranch is already a resolved remote ref for branch (retry after disambiguation)', async () => {
+			const executedCommands: string[] = [];
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					executedCommands.push(cmd);
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					// No local branch
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
+						throw new Error('Branch not found');
+					}
+					if (cmd.includes('git worktree add')) {
+						return '';
+					}
+				}
+				return '';
+			});
+
+			// Simulate the retry call: user selected "origin/feature/feed-mention",
+			// which is passed as baseBranch.
+			const effect = service.createWorktreeEffect(
+				'/path/to/worktree',
+				'feature/feed-mention',
+				'origin/feature/feed-mention',
+			);
+			const result = await Effect.runPromise(Effect.either(effect));
+
+			expect(result._tag).toBe('Right');
+
+			// Should use baseBranch directly as startPoint without calling show-ref
+			const worktreeAddCmd = executedCommands.find(c =>
+				c.includes('git worktree add'),
+			);
+			expect(worktreeAddCmd).toContain('-b "feature/feed-mention"');
+			expect(worktreeAddCmd).toContain('"origin/feature/feed-mention"');
+			// show-ref for remotes must NOT be called (no re-resolution)
+			expect(
+				executedCommands.some(
+					c => c.includes('show-ref') && c.includes('refs/remotes/'),
+				),
+			).toBe(false);
+		});
+
 		it('should return Effect that fails with GitError on git command failure', async () => {
 			mockedExecSync.mockImplementation((cmd, _options) => {
 				if (typeof cmd === 'string') {

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -190,7 +190,12 @@ export class WorktreeService {
 	): Effect.Effect<string, AmbiguousBranchError> {
 		return Effect.try({
 			try: () => this.resolveBranchReference(branchName),
-			catch: error => error as AmbiguousBranchError,
+			catch: error => {
+				if (error instanceof AmbiguousBranchError) return error;
+				// resolveBranchReference only re-throws AmbiguousBranchError; all
+				// other errors are swallowed internally. This path is unreachable.
+				throw error;
+			},
 		});
 	}
 
@@ -989,6 +994,11 @@ export class WorktreeService {
 			let command: string;
 			if (localBranchExists) {
 				command = `git worktree add "${resolvedPath}" "${branch}"`;
+			} else if (baseBranch.endsWith(`/${branch}`)) {
+				// baseBranch is already a remote-tracking ref for branch
+				// (e.g. "origin/feature/x" after the user resolved an ambiguity).
+				// Use it directly to avoid re-triggering AmbiguousBranchError.
+				command = `git worktree add -b "${branch}" "${resolvedPath}" "${baseBranch}"`;
 			} else {
 				const resolvedRef = yield* self.resolveBranchReferenceEffect(branch);
 				const isRemoteBranch = resolvedRef !== branch;

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -185,6 +185,15 @@ export class WorktreeService {
 		}
 	}
 
+	private resolveBranchReferenceEffect(
+		branchName: string,
+	): Effect.Effect<string, AmbiguousBranchError> {
+		return Effect.try({
+			try: () => this.resolveBranchReference(branchName),
+			catch: error => error as AmbiguousBranchError,
+		});
+	}
+
 	/**
 	 * SYNCHRONOUS HELPER: Gets all git remotes for this repository.
 	 *
@@ -895,7 +904,7 @@ export class WorktreeService {
 		copyClaudeDirectory = false,
 	): Effect.Effect<
 		CreateWorktreeResult,
-		GitError | FileSystemError | ProcessError,
+		GitError | FileSystemError | ProcessError | AmbiguousBranchError,
 		never
 	> {
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -981,11 +990,11 @@ export class WorktreeService {
 			if (localBranchExists) {
 				command = `git worktree add "${resolvedPath}" "${branch}"`;
 			} else {
-				const resolvedRef = self.resolveBranchReference(branch);
+				const resolvedRef = yield* self.resolveBranchReferenceEffect(branch);
 				const isRemoteBranch = resolvedRef !== branch;
 				const startPoint = isRemoteBranch
 					? resolvedRef
-					: self.resolveBranchReference(baseBranch);
+					: yield* self.resolveBranchReferenceEffect(baseBranch);
 				command = `git worktree add -b "${branch}" "${resolvedPath}" "${startPoint}"`;
 			}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,8 @@ import type {SerializeAddon} from '@xterm/addon-serialize';
 import {GitStatus} from '../utils/gitStatus.js';
 import {Mutex, SessionStateData} from '../utils/mutex.js';
 import type {StateDetector} from '../services/stateDetector/types.js';
-import type {ProcessError} from './errors.js';
+import type {Effect} from 'effect';
+import type {GitError, FileSystemError, ProcessError} from './errors.js';
 
 export type Terminal = InstanceType<typeof pkg.Terminal>;
 
@@ -321,6 +322,7 @@ export interface RemoteBranchMatch {
 }
 
 export class AmbiguousBranchError extends Error {
+	readonly _tag = 'AmbiguousBranchError' as const;
 	branchName: string;
 	matches: RemoteBranchMatch[];
 
@@ -337,11 +339,7 @@ export class AmbiguousBranchError extends Error {
 }
 
 export interface IWorktreeService {
-	getWorktreesEffect(): import('effect').Effect.Effect<
-		Worktree[],
-		import('../types/errors.js').GitError,
-		never
-	>;
+	getWorktreesEffect(): Effect.Effect<Worktree[], GitError, never>;
 	getGitRootPath(): string;
 	createWorktreeEffect(
 		worktreePath: string,
@@ -349,29 +347,19 @@ export interface IWorktreeService {
 		baseBranch: string,
 		copySessionData?: boolean,
 		copyClaudeDirectory?: boolean,
-	): import('effect').Effect.Effect<
+	): Effect.Effect<
 		CreateWorktreeResult,
-		| import('../types/errors.js').GitError
-		| import('../types/errors.js').FileSystemError
-		| import('../types/errors.js').ProcessError,
+		GitError | FileSystemError | ProcessError | AmbiguousBranchError,
 		never
 	>;
 	deleteWorktreeEffect(
 		worktreePath: string,
 		options?: {deleteBranch?: boolean},
-	): import('effect').Effect.Effect<
-		void,
-		import('../types/errors.js').GitError,
-		never
-	>;
+	): Effect.Effect<void, GitError, never>;
 	mergeWorktreeEffect(
 		sourceBranch: string,
 		targetBranch: string,
 		operation?: 'merge' | 'rebase',
 		mergeConfig?: MergeConfig,
-	): import('effect').Effect.Effect<
-		void,
-		import('../types/errors.js').GitError,
-		never
-	>;
+	): Effect.Effect<void, GitError, never>;
 }


### PR DESCRIPTION
## Summary

- `resolveBranchReference()` was called directly inside `Effect.gen`, so when `AmbiguousBranchError` was thrown (e.g. branch exists in both `origin` and a fork remote), it escaped the Effect runtime as an unhandled `Die` (FiberFailure) and crashed the TUI instead of being handled gracefully.
- Added `resolveBranchReferenceEffect()` wrapping the sync helper in `Effect.try`, so `AmbiguousBranchError` propagates as a typed Effect error.
- Added `readonly _tag = 'AmbiguousBranchError' as const` to enable discriminated union pattern matching.
- Updated `IWorktreeService` and `createWorktreeEffect` signatures to include `AmbiguousBranchError` in the error union.
- Replaced string-parsing fallback (`parseAmbiguousBranchError`) in `App.tsx` with direct `_tag` checks; the remote branch selector UI is now reached via the typed error path.
- Cleaned up inline dynamic imports in `IWorktreeService` with top-level imports.
