### PR TITLE
Dashboard session feature parity

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -858,6 +858,21 @@ const App: React.FC<AppProps> = ({
 		navigateWithClear('session');
 	};
 
+	const handleSessionActionFromDashboard = (
+		session: ISession,
+		project: GitProject,
+	) => {
+		const projectSessionManager =
+			globalSessionOrchestrator.getManagerForProject(project.path);
+		setSessionManager(projectSessionManager);
+		setWorktreeService(new WorktreeService(project.path));
+		setSessionActionsTarget({
+			session,
+			worktreePath: session.worktreePath,
+		});
+		navigateWithClear('session-actions');
+	};
+
 	const handleBackToProjectList = () => {
 		// Sessions persist in their project-specific managers
 		setSelectedProject(null);
@@ -885,6 +900,7 @@ const App: React.FC<AppProps> = ({
 				projectsDir={projectsDir}
 				onSelectSession={handleSelectSessionFromDashboard}
 				onSelectProject={handleSelectProject}
+				onSessionAction={handleSessionActionFromDashboard}
 				error={error}
 				onDismissError={() => setError(null)}
 				version={version}

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -654,6 +654,7 @@ describe('Dashboard', () => {
 
 		expect(lastFrame()).toContain('Controls:');
 		expect(lastFrame()).toContain('0-9 Quick Select');
+		expect(lastFrame()).toContain('Space-Session actions');
 		expect(lastFrame()).toContain('R-Refresh');
 		expect(lastFrame()).toContain('Q-Quit');
 	});

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -3,6 +3,33 @@ import {render} from 'ink-testing-library';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {GitProject} from '../types/index.js';
 
+const capturedHandlers: {
+	inputHandlers: Array<(input: string, key: Record<string, boolean>) => void>;
+	onHighlight: ((item: {value: string; label: string}) => void) | null;
+} = {inputHandlers: [], onHighlight: null};
+
+const makeKey = (
+	overrides: Record<string, boolean> = {},
+): Record<string, boolean> => ({
+	upArrow: false,
+	downArrow: false,
+	leftArrow: false,
+	rightArrow: false,
+	pageDown: false,
+	pageUp: false,
+	home: false,
+	end: false,
+	return: false,
+	escape: false,
+	ctrl: false,
+	shift: false,
+	tab: false,
+	backspace: false,
+	delete: false,
+	meta: false,
+	...overrides,
+});
+
 // Mock bunTerminal to avoid native module loading issues
 vi.mock('../services/bunTerminal.js', () => ({
 	spawn: vi.fn(function () {
@@ -10,22 +37,33 @@ vi.mock('../services/bunTerminal.js', () => ({
 	}),
 }));
 
-// Import the actual component code but skip the useInput hook
+// Import the actual component code but capture useInput handlers
 vi.mock('ink', async () => {
 	const actual = await vi.importActual<typeof import('ink')>('ink');
 	return {
 		...actual,
-		useInput: vi.fn(),
+		useInput: vi.fn(
+			(handler: (input: string, key: Record<string, boolean>) => void) => {
+				capturedHandlers.inputHandlers.push(handler);
+			},
+		),
 	};
 });
 
-// Mock SelectInput to render items as simple text
+// Mock SelectInput to render items as simple text and capture onHighlight
 vi.mock('ink-select-input', async () => {
 	const React = await vi.importActual<typeof import('react')>('react');
 	const {Text, Box} = await vi.importActual<typeof import('ink')>('ink');
 
 	return {
-		default: ({items}: {items: Array<{label: string; value: string}>}) => {
+		default: ({
+			items,
+			onHighlight,
+		}: {
+			items: Array<{label: string; value: string}>;
+			onHighlight?: (item: {value: string; label: string}) => void;
+		}) => {
+			if (onHighlight) capturedHandlers.onHighlight = onHighlight;
 			return React.createElement(
 				Box,
 				{flexDirection: 'column'},
@@ -143,6 +181,8 @@ describe('Dashboard', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		capturedHandlers.inputHandlers = [];
+		capturedHandlers.onHighlight = null;
 		vi.mocked(projectManager.instance.discoverProjectsEffect).mockReturnValue(
 			Effect.succeed(mockProjects),
 		);
@@ -704,5 +744,432 @@ describe('Dashboard', () => {
 		const frame = lastFrame()!;
 		// shared-lib should appear first (index 0) because it's recent
 		expect(frame).toContain('0 ❯ shared-lib');
+	});
+
+	it('should show session name suffix in label when session has a name', async () => {
+		const mockSession = {
+			id: 'session-named',
+			worktreePath: '/projects/my-app/worktrees/feature-auth',
+			sessionNumber: 1,
+			sessionName: 'my-feature',
+			lastActivity: new Date(),
+			isActive: true,
+			stateMutex: {
+				getSnapshot: () => ({
+					state: 'busy' as const,
+					backgroundTaskCount: 0,
+					teamMemberCount: 0,
+				}),
+			},
+		};
+
+		vi.mocked(globalSessionOrchestrator.getProjectPaths).mockReturnValue([
+			'/projects/my-app',
+		]);
+		vi.mocked(globalSessionOrchestrator.getProjectSessions).mockReturnValue([
+			mockSession as never,
+		]);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: () =>
+					Effect.succeed([
+						{
+							path: '/projects/my-app/worktrees/feature-auth',
+							branch: 'feature/auth',
+							isMainWorktree: false,
+							hasSession: true,
+						},
+					]),
+				getGitRootPath: () => '/projects/my-app',
+			};
+		} as never);
+
+		const {lastFrame, rerender} = render(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+		rerender(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await vi.waitFor(
+			() => {
+				return lastFrame()?.includes('Active Sessions') ?? false;
+			},
+			{timeout: 3000},
+		);
+
+		expect(lastFrame()).toContain('my-app :: feature/auth: my-feature');
+	});
+
+	it('should show session number suffix when multiple unnamed sessions on same worktree', async () => {
+		const mockSessions = [
+			{
+				id: 'session-1',
+				worktreePath: '/projects/my-app/worktrees/feature-auth',
+				sessionNumber: 1,
+				lastActivity: new Date(),
+				isActive: true,
+				stateMutex: {
+					getSnapshot: () => ({
+						state: 'busy' as const,
+						backgroundTaskCount: 0,
+						teamMemberCount: 0,
+					}),
+				},
+			},
+			{
+				id: 'session-2',
+				worktreePath: '/projects/my-app/worktrees/feature-auth',
+				sessionNumber: 2,
+				lastActivity: new Date(),
+				isActive: true,
+				stateMutex: {
+					getSnapshot: () => ({
+						state: 'idle' as const,
+						backgroundTaskCount: 0,
+						teamMemberCount: 0,
+					}),
+				},
+			},
+		];
+
+		vi.mocked(globalSessionOrchestrator.getProjectPaths).mockReturnValue([
+			'/projects/my-app',
+		]);
+		vi.mocked(globalSessionOrchestrator.getProjectSessions).mockReturnValue(
+			mockSessions as never,
+		);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: () =>
+					Effect.succeed([
+						{
+							path: '/projects/my-app/worktrees/feature-auth',
+							branch: 'feature/auth',
+							isMainWorktree: false,
+							hasSession: true,
+						},
+					]),
+				getGitRootPath: () => '/projects/my-app',
+			};
+		} as never);
+
+		const {lastFrame, rerender} = render(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+		rerender(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await vi.waitFor(
+			() => {
+				return lastFrame()?.includes('Active Sessions') ?? false;
+			},
+			{timeout: 3000},
+		);
+
+		const frame = lastFrame()!;
+		expect(frame).toContain('#1');
+		expect(frame).toContain('#2');
+	});
+
+	it('should show no session suffix for single unnamed session', async () => {
+		const mockSession = {
+			id: 'session-single',
+			worktreePath: '/projects/my-app/worktrees/feature-auth',
+			sessionNumber: 1,
+			lastActivity: new Date(),
+			isActive: true,
+			stateMutex: {
+				getSnapshot: () => ({
+					state: 'busy' as const,
+					backgroundTaskCount: 0,
+					teamMemberCount: 0,
+				}),
+			},
+		};
+
+		vi.mocked(globalSessionOrchestrator.getProjectPaths).mockReturnValue([
+			'/projects/my-app',
+		]);
+		vi.mocked(globalSessionOrchestrator.getProjectSessions).mockReturnValue([
+			mockSession as never,
+		]);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: () =>
+					Effect.succeed([
+						{
+							path: '/projects/my-app/worktrees/feature-auth',
+							branch: 'feature/auth',
+							isMainWorktree: false,
+							hasSession: true,
+						},
+					]),
+				getGitRootPath: () => '/projects/my-app',
+			};
+		} as never);
+
+		const {lastFrame, rerender} = render(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+		rerender(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await vi.waitFor(
+			() => {
+				return lastFrame()?.includes('Active Sessions') ?? false;
+			},
+			{timeout: 3000},
+		);
+
+		const frame = lastFrame()!;
+		expect(frame).toContain('my-app :: feature/auth');
+		expect(frame).not.toContain('feature/auth:');
+		expect(frame).not.toContain('feature/auth #');
+	});
+
+	it('should call onSessionAction when space is pressed on highlighted session', async () => {
+		const mockOnSessionAction = vi.fn();
+		const mockSession = {
+			id: 'session-action',
+			worktreePath: '/projects/my-app/worktrees/feature-auth',
+			sessionNumber: 1,
+			lastActivity: new Date(),
+			isActive: true,
+			stateMutex: {
+				getSnapshot: () => ({
+					state: 'busy' as const,
+					backgroundTaskCount: 0,
+					teamMemberCount: 0,
+				}),
+			},
+		};
+
+		vi.mocked(globalSessionOrchestrator.getProjectPaths).mockReturnValue([
+			'/projects/my-app',
+		]);
+		vi.mocked(globalSessionOrchestrator.getProjectSessions).mockReturnValue([
+			mockSession as never,
+		]);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: () =>
+					Effect.succeed([
+						{
+							path: '/projects/my-app/worktrees/feature-auth',
+							branch: 'feature/auth',
+							isMainWorktree: false,
+							hasSession: true,
+						},
+					]),
+				getGitRootPath: () => '/projects/my-app',
+			};
+		} as never);
+
+		const {lastFrame, rerender} = render(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				onSessionAction={mockOnSessionAction}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+		rerender(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				onSessionAction={mockOnSessionAction}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await vi.waitFor(
+			() => {
+				return lastFrame()?.includes('Active Sessions') ?? false;
+			},
+			{timeout: 3000},
+		);
+
+		// Enable the useInput handler (Dashboard guards on process.stdin.setRawMode)
+		const origSetRawMode = process.stdin.setRawMode;
+		process.stdin.setRawMode = vi.fn() as never;
+
+		// Simulate highlighting a session item
+		expect(capturedHandlers.onHighlight).not.toBeNull();
+		capturedHandlers.onHighlight!({
+			value: 'session-session-action',
+			label: 'my-app :: feature/auth',
+		});
+
+		// Force re-render to flush state update — new useInput handler captures updated closure
+		rerender(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				onSessionAction={mockOnSessionAction}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		// Use the latest Dashboard handler (last in array — has updated highlightedSession state)
+		const latestHandler =
+			capturedHandlers.inputHandlers[capturedHandlers.inputHandlers.length - 1];
+		expect(latestHandler).toBeDefined();
+		latestHandler!(' ', makeKey());
+
+		expect(mockOnSessionAction).toHaveBeenCalledWith(
+			expect.objectContaining({id: 'session-action'}),
+			expect.objectContaining({path: '/projects/my-app'}),
+		);
+
+		process.stdin.setRawMode = origSetRawMode;
+	});
+
+	it('should not call onSessionAction when space is pressed with no highlighted session', async () => {
+		const mockOnSessionAction = vi.fn();
+		const mockSession = {
+			id: 'session-noop',
+			worktreePath: '/projects/my-app/worktrees/feature-auth',
+			sessionNumber: 1,
+			lastActivity: new Date(),
+			isActive: true,
+			stateMutex: {
+				getSnapshot: () => ({
+					state: 'busy' as const,
+					backgroundTaskCount: 0,
+					teamMemberCount: 0,
+				}),
+			},
+		};
+
+		vi.mocked(globalSessionOrchestrator.getProjectPaths).mockReturnValue([
+			'/projects/my-app',
+		]);
+		vi.mocked(globalSessionOrchestrator.getProjectSessions).mockReturnValue([
+			mockSession as never,
+		]);
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getWorktreesEffect: () =>
+					Effect.succeed([
+						{
+							path: '/projects/my-app/worktrees/feature-auth',
+							branch: 'feature/auth',
+							isMainWorktree: false,
+							hasSession: true,
+						},
+					]),
+				getGitRootPath: () => '/projects/my-app',
+			};
+		} as never);
+
+		const {lastFrame, rerender} = render(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				onSessionAction={mockOnSessionAction}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+		rerender(
+			<Dashboard
+				projectsDir="/projects"
+				onSelectSession={mockOnSelectSession}
+				onSelectProject={mockOnSelectProject}
+				onSessionAction={mockOnSessionAction}
+				error={null}
+				onDismissError={mockOnDismissError}
+				version="3.8.1"
+			/>,
+		);
+
+		await vi.waitFor(
+			() => {
+				return lastFrame()?.includes('Active Sessions') ?? false;
+			},
+			{timeout: 3000},
+		);
+
+		// Enable the useInput handler (Dashboard guards on process.stdin.setRawMode)
+		const origSetRawMode = process.stdin.setRawMode;
+		process.stdin.setRawMode = vi.fn() as never;
+
+		// Do NOT call onHighlight — highlightedSession stays null
+		const dashboardHandler = capturedHandlers.inputHandlers.find(
+			handler => handler !== capturedHandlers.inputHandlers[0],
+		);
+		expect(dashboardHandler).toBeDefined();
+		dashboardHandler!(' ', makeKey());
+
+		expect(mockOnSessionAction).not.toHaveBeenCalled();
+
+		process.stdin.setRawMode = origSetRawMode;
 	});
 });

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -44,6 +44,7 @@ interface DashboardProps {
 	projectsDir: string;
 	onSelectSession: (session: ISession, project: GitProject) => void;
 	onSelectProject: (project: GitProject) => void;
+	onSessionAction?: (session: ISession, project: GitProject) => void;
 	error: string | null;
 	onDismissError: () => void;
 	version: string;
@@ -147,6 +148,7 @@ const Dashboard: React.FC<DashboardProps> = ({
 	projectsDir,
 	onSelectSession,
 	onSelectProject,
+	onSessionAction,
 	error,
 	onDismissError,
 	version,
@@ -163,6 +165,11 @@ const Dashboard: React.FC<DashboardProps> = ({
 		[],
 	);
 	const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
+	const [highlightedSession, setHighlightedSession] = useState<ISession | null>(
+		null,
+	);
+	const [highlightedProject, setHighlightedProject] =
+		useState<GitProject | null>(null);
 
 	const displayError = error || loadError;
 
@@ -364,9 +371,14 @@ const Dashboard: React.FC<DashboardProps> = ({
 				);
 				const isMain = wt.isMainWorktree ? ' (main)' : '';
 				const worktreeSessionCount = sessionEntries.filter(
-					e => e.worktree.path === entry.worktree.path && e.projectPath === entry.projectPath,
+					e =>
+						e.worktree.path === entry.worktree.path &&
+						e.projectPath === entry.projectPath,
 				).length;
-				const sessionSuffix = displaySuffix(entry.session, worktreeSessionCount > 1);
+				const sessionSuffix = displaySuffix(
+					entry.session,
+					worktreeSessionCount > 1,
+				);
 				const baseLabel = `${entry.projectName} :: ${branchName}${isMain}${sessionSuffix}${status}`;
 
 				let fileChanges = '';
@@ -596,6 +608,11 @@ const Dashboard: React.FC<DashboardProps> = ({
 		}
 
 		switch (keyPressed) {
+			case ' ':
+				if (highlightedSession && highlightedProject && onSessionAction) {
+					onSessionAction(highlightedSession, highlightedProject);
+				}
+				break;
 			case 'r':
 				refreshAll();
 				break;
@@ -663,6 +680,16 @@ const Dashboard: React.FC<DashboardProps> = ({
 							const item = items.find(i => i.value === raw?.value);
 							if (!item) return;
 							handleSelect(item);
+						}}
+						onHighlight={raw => {
+							const item = items.find(i => i.value === raw?.value);
+							if (item?.type === 'session') {
+								setHighlightedSession(item.session);
+								setHighlightedProject(item.project);
+							} else {
+								setHighlightedSession(null);
+								setHighlightedProject(null);
+							}
 						}}
 						isFocused={!displayError}
 						limit={limit}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -29,6 +29,7 @@ import {
 	calculateColumnPositions,
 	assembleSessionLabel,
 	formatRelativeDate,
+	displaySuffix,
 } from '../utils/worktreeUtils.js';
 import {
 	formatGitFileChanges,
@@ -362,7 +363,11 @@ const Dashboard: React.FC<DashboardProps> = ({
 					MAX_BRANCH_NAME_LENGTH,
 				);
 				const isMain = wt.isMainWorktree ? ' (main)' : '';
-				const baseLabel = `${entry.projectName} :: ${branchName}${isMain}${status}`;
+				const worktreeSessionCount = sessionEntries.filter(
+					e => e.worktree.path === entry.worktree.path && e.projectPath === entry.projectPath,
+				).length;
+				const sessionSuffix = displaySuffix(entry.session, worktreeSessionCount > 1);
+				const baseLabel = `${entry.projectName} :: ${branchName}${isMain}${sessionSuffix}${status}`;
 
 				let fileChanges = '';
 				let aheadBehind = '';

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -721,8 +721,8 @@ const Dashboard: React.FC<DashboardProps> = ({
 					{isSearchMode
 						? 'Search Mode: Type to filter, Enter to exit search, ESC to exit search'
 						: searchQuery
-							? `Filtered: "${searchQuery}" | ↑↓ Navigate Enter Select | /-Search ESC-Clear 0-9 Quick Select R-Refresh Q-Quit`
-							: 'Controls: ↑↓ Navigate Enter Select | Hotkeys: 0-9 Quick Select /-Search R-Refresh Q-Quit'}
+							? `Filtered: "${searchQuery}" | ↑↓ Navigate Enter Select | /-Search ESC-Clear 0-9 Quick Select Space-Session actions (session rows only) R-Refresh Q-Quit`
+							: 'Controls: ↑↓ Navigate Enter Select | Hotkeys: 0-9 Quick Select /-Search Space-Session actions (session rows only) R-Refresh Q-Quit'}
 				</Text>
 			</Box>
 		</Box>

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -171,7 +171,10 @@ function indexSessionsByWorktree(sessions: Session[]): {
 	return {byWorktreePath, maxAccessAt};
 }
 
-export function displaySuffix(session: Session, multipleForWorktree: boolean): string {
+export function displaySuffix(
+	session: Session,
+	multipleForWorktree: boolean,
+): string {
 	if (multipleForWorktree) {
 		return session.sessionName
 			? `: ${session.sessionName}`

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -171,7 +171,7 @@ function indexSessionsByWorktree(sessions: Session[]): {
 	return {byWorktreePath, maxAccessAt};
 }
 
-function displaySuffix(session: Session, multipleForWorktree: boolean): string {
+export function displaySuffix(session: Session, multipleForWorktree: boolean): string {
 	if (multipleForWorktree) {
 		return session.sessionName
 			? `: ${session.sessionName}`


### PR DESCRIPTION
## Dashboard session feature parity

### Problem

Multi-project Dashboard lacked session name labels and the space-key actions menu (rename/new/end) that the repo-level Menu already had.

### Session labels

Exported `displaySuffix`, added suffix: `: name` for named, ` #N` for multiple unnamed.

Before:
```
my-app :: main (main) [○ Idle]
my-app :: main (main) [○ Idle]
```

After:
```
my-app :: main (main): custom-name [○ Idle]
my-app :: main (main) #2 [○ Idle]
```

### Space key actions

Track highlighted item via `onHighlight`. Space triggers `onSessionAction`, reuses existing `session-actions` view.

### Tests

- Named session label contains `: name`
- Multiple unnamed show ` #1`, ` #2`; single unnamed has no suffix
- Space on session calls handler; space with nothing highlighted is a no-op
