### PR TITLE
feat: match menu search against displayed name (session name and (main))

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -386,6 +386,7 @@ const Dashboard: React.FC<DashboardProps> = ({
 					worktree: wt,
 					session: entry.session,
 					baseLabel,
+					searchableName: `${entry.projectName} :: ${fullBranchName}${isMain}`,
 					fileChanges,
 					aheadBehind,
 					parentBranch,

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -21,7 +21,7 @@ import {projectManager} from '../services/projectManager.js';
 import {RecentProject} from '../types/index.js';
 import {useSearchMode} from '../hooks/useSearchMode.js';
 import {useDynamicLimit} from '../hooks/useDynamicLimit.js';
-import {filterWorktreesByQuery} from '../utils/filterByQuery.js';
+import {filterSessionItemsByQuery} from '../utils/filterByQuery.js';
 import SearchableList from './SearchableList.js';
 import {globalSessionOrchestrator} from '../services/globalSessionOrchestrator.js';
 import {configReader} from '../services/config/configReader.js';
@@ -212,15 +212,9 @@ const Menu: React.FC<MenuProps> = ({
 		});
 		const columnPositions = calculateColumnPositions(items);
 
-		// Filter worktrees based on search query
-		const filteredWorktrees = filterWorktreesByQuery(
-			items.map(item => item.worktree),
-			searchQuery,
-		);
-		const filteredWorktreeSet = new Set(filteredWorktrees);
-		const filteredItems = items.filter(item =>
-			filteredWorktreeSet.has(item.worktree),
-		);
+		// Filter session items based on search query, matching the name shown in
+		// the menu (branch name, " (main)", and session name) plus the path.
+		const filteredItems = filterSessionItemsByQuery(items, searchQuery);
 
 		// Build menu items with proper alignment
 		const menuItems: MenuItem[] = filteredItems.map(

--- a/src/utils/filterByQuery.test.ts
+++ b/src/utils/filterByQuery.test.ts
@@ -1,0 +1,97 @@
+import {describe, it, expect} from 'vitest';
+import {
+	filterWorktreesByQuery,
+	filterSessionItemsByQuery,
+} from './filterByQuery.js';
+import {Worktree} from '../types/index.js';
+import {SessionItem} from './worktreeUtils.js';
+
+const makeItem = (searchableName: string, path: string): SessionItem => ({
+	worktree: {
+		path,
+		isMainWorktree: false,
+		hasSession: false,
+	} as Worktree,
+	baseLabel: searchableName,
+	searchableName,
+	fileChanges: '',
+	aheadBehind: '',
+	parentBranch: '',
+	lastCommitDate: '',
+	lengths: {
+		base: 0,
+		fileChanges: 0,
+		aheadBehind: 0,
+		parentBranch: 0,
+		lastCommitDate: 0,
+	},
+});
+
+describe('filterWorktreesByQuery', () => {
+	const worktrees: Worktree[] = [
+		{
+			path: '/repo/feature-a',
+			branch: 'feature/a',
+			isMainWorktree: false,
+			hasSession: false,
+		},
+		{
+			path: '/repo/main',
+			branch: 'main',
+			isMainWorktree: true,
+			hasSession: false,
+		},
+	];
+
+	it('returns all worktrees when query is empty', () => {
+		expect(filterWorktreesByQuery(worktrees, '')).toEqual(worktrees);
+	});
+
+	it('matches branch name case-insensitively', () => {
+		const result = filterWorktreesByQuery(worktrees, 'FEATURE');
+		expect(result).toHaveLength(1);
+		expect(result[0]?.branch).toBe('feature/a');
+	});
+
+	it('matches path', () => {
+		const result = filterWorktreesByQuery(worktrees, '/repo/main');
+		expect(result).toHaveLength(1);
+		expect(result[0]?.path).toBe('/repo/main');
+	});
+});
+
+describe('filterSessionItemsByQuery', () => {
+	const items: SessionItem[] = [
+		makeItem('feature/a', '/repo/feature-a'),
+		makeItem('main (main)', '/repo/main'),
+		makeItem('feature/b: my-session', '/repo/feature-b'),
+		makeItem('feature/b: other', '/repo/feature-b'),
+	];
+
+	it('returns all items when query is empty', () => {
+		expect(filterSessionItemsByQuery(items, '')).toEqual(items);
+	});
+
+	it('matches the session name within a worktree', () => {
+		const result = filterSessionItemsByQuery(items, 'my-session');
+		expect(result).toHaveLength(1);
+		expect(result[0]?.searchableName).toBe('feature/b: my-session');
+	});
+
+	it('matches the (main) indicator', () => {
+		const result = filterSessionItemsByQuery(items, '(main)');
+		expect(result).toHaveLength(1);
+		expect(result[0]?.searchableName).toBe('main (main)');
+	});
+
+	it('matches branch name case-insensitively', () => {
+		const result = filterSessionItemsByQuery(items, 'FEATURE/A');
+		expect(result).toHaveLength(1);
+		expect(result[0]?.searchableName).toBe('feature/a');
+	});
+
+	it('matches path', () => {
+		const result = filterSessionItemsByQuery(items, '/repo/feature-b');
+		expect(result).toHaveLength(2);
+	});
+});

--- a/src/utils/filterByQuery.ts
+++ b/src/utils/filterByQuery.ts
@@ -1,4 +1,5 @@
 import {Worktree} from '../types/index.js';
+import {SessionItem} from './worktreeUtils.js';
 
 /**
  * Filter worktrees by matching search query against branch name and path.
@@ -16,4 +17,26 @@ export function filterWorktreesByQuery(
 			worktree.path.toLowerCase().includes(searchLower)
 		);
 	});
+}
+
+/**
+ * Filter session items by matching the search query against the name shown in
+ * the menu (branch name, " (main)" indicator, and session name) and the
+ * worktree path. Status icons and git status columns are not matched.
+ *
+ * Filtering happens per session item (not per worktree) so that a query can
+ * match an individual session name within a worktree that has multiple
+ * sessions.
+ */
+export function filterSessionItemsByQuery(
+	items: SessionItem[],
+	query: string,
+): SessionItem[] {
+	if (!query) return items;
+	const searchLower = query.toLowerCase();
+	return items.filter(
+		item =>
+			item.searchableName.toLowerCase().includes(searchLower) ||
+			item.worktree.path.toLowerCase().includes(searchLower),
+	);
 }

--- a/src/utils/worktreeUtils.test.ts
+++ b/src/utils/worktreeUtils.test.ts
@@ -290,6 +290,7 @@ describe('column alignment', () => {
 		{
 			worktree: {} as Worktree,
 			baseLabel: 'feature/test-branch',
+			searchableName: 'feature/test-branch',
 			fileChanges: '\x1b[32m+10\x1b[0m \x1b[31m-5\x1b[0m',
 			aheadBehind: '\x1b[33m↑2 ↓3\x1b[0m',
 			parentBranch: '',
@@ -305,6 +306,7 @@ describe('column alignment', () => {
 		{
 			worktree: {} as Worktree,
 			baseLabel: 'main',
+			searchableName: 'main',
 			fileChanges: '\x1b[32m+2\x1b[0m \x1b[31m-1\x1b[0m',
 			aheadBehind: '\x1b[33m↑1\x1b[0m',
 			parentBranch: '',

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -20,6 +20,9 @@ export interface SessionItem {
 	worktree: Worktree;
 	session?: Session;
 	baseLabel: string;
+	// Name portion shown in the menu (branch + " (main)" + session name),
+	// without status icons or git status columns. Used for search matching.
+	searchableName: string;
 	fileChanges: string;
 	aheadBehind: string;
 	parentBranch: string;
@@ -234,6 +237,9 @@ function buildSessionItem(
 	const branchName = truncateString(fullBranchName, MAX_BRANCH_NAME_LENGTH);
 	const isMain = wt.isMainWorktree ? ' (main)' : '';
 	const baseLabel = `${branchName}${isMain}${sessionSuffix}${status}`;
+	// Use the full (untruncated) branch name so search still matches the tail
+	// of long branch names; status icons are excluded so they don't match.
+	const searchableName = `${fullBranchName}${isMain}${sessionSuffix}`;
 	const {fileChanges, aheadBehind, parentBranch, error} = gitStatusColumns(
 		wt,
 		fullBranchName,
@@ -246,6 +252,7 @@ function buildSessionItem(
 		worktree: wt,
 		session,
 		baseLabel,
+		searchableName,
 		fileChanges,
 		aheadBehind,
 		parentBranch,


### PR DESCRIPTION
## What

Make the menu's `/` search match against the name shown in each row — branch name, the `(main)` indicator, and the session name — in addition to the path. Previously only the branch name and path were matched, so a query could not select a row by its session name or by `(main)`.

## Why

The search filter (`filterWorktreesByQuery`) matched only `worktree.branch` and `worktree.path`, and it operated per worktree. Because session names are per session row (a worktree can hold multiple sessions), per-worktree filtering could not distinguish individual session names within the same worktree. Matching against what the user actually sees in the menu makes the filter behave as expected.

## How

- `SessionItem` gains a `searchableName` field, built from the same pieces as the displayed label (branch + `(main)` + session name) but without status icons or git status columns. It uses the untruncated branch name so long branch names still match by their tail (no regression vs. the previous full-branch matching).
- New `filterSessionItemsByQuery` filters per session row against `searchableName` and the path. `Menu.tsx` switches from per-worktree to per-row filtering. The existing `filterWorktreesByQuery` is kept for `DeleteWorktree.tsx`.

Status icons (`[Busy]` etc.) and git status columns (changed files, ahead/behind, parent branch, commit date) are intentionally excluded from matching.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run test` pass (the one failing suite, `gitUtils.submodule.test.ts`, fails due to a local `~/.gitconfig` lock unrelated to this change).
- Added `src/utils/filterByQuery.test.ts` covering session-name, `(main)`, branch, and path matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
