### PR TITLE
feat: show worktree directory name when it adds information

### DIFF
--- a/src/utils/worktreeUtils.test.ts
+++ b/src/utils/worktreeUtils.test.ts
@@ -223,8 +223,10 @@ describe('truncateString', () => {
 });
 
 describe('prepareSessionItems', () => {
+	// The directory basename here matches the sanitized branch tail so the
+	// worktree-directory suffix is suppressed in the basic baseLabel tests.
 	const mockWorktree: Worktree = {
-		path: '/path/to/worktree',
+		path: '/path/to/test-branch',
 		branch: 'feature/test-branch',
 		isMainWorktree: false,
 		hasSession: false,
@@ -233,7 +235,7 @@ describe('prepareSessionItems', () => {
 	// Simplified mock
 	const mockSession: Session = {
 		id: 'test-session',
-		worktreePath: '/path/to/worktree',
+		worktreePath: '/path/to/test-branch',
 		sessionNumber: 1,
 		command: 'claude',
 		fallbackArgs: undefined,
@@ -282,6 +284,128 @@ describe('prepareSessionItems', () => {
 		};
 		const items = prepareSessionItems([longBranch], []);
 		expect(items[0]?.baseLabel.length).toBeLessThanOrEqual(80); // 70 + status + default
+	});
+
+	describe('worktree directory suffix', () => {
+		it('shows the directory name when it differs from the branch', () => {
+			const wt: Worktree = {
+				path: '/repos/myproj/worktrees/login-api',
+				branch: 'feature/login',
+				isMainWorktree: false,
+				hasSession: false,
+			};
+			const items = prepareSessionItems([wt], []);
+			expect(items[0]?.baseLabel).toBe('feature/login @ login-api');
+		});
+
+		it('hides the directory name when the directory equals the branch tail', () => {
+			const wt: Worktree = {
+				path: '/repos/myproj/worktrees/foo',
+				branch: 'feature/foo',
+				isMainWorktree: false,
+				hasSession: false,
+			};
+			const items = prepareSessionItems([wt], []);
+			expect(items[0]?.baseLabel).toBe('feature/foo');
+		});
+
+		it('hides the directory name when it matches the sanitized full branch', () => {
+			const wt: Worktree = {
+				path: '/repos/myproj/worktrees/feature-foo',
+				branch: 'feature/foo',
+				isMainWorktree: false,
+				hasSession: false,
+			};
+			const items = prepareSessionItems([wt], []);
+			expect(items[0]?.baseLabel).toBe('feature/foo');
+		});
+
+		it('hides the directory name for the main worktree', () => {
+			const wt: Worktree = {
+				path: '/repos/myproj',
+				branch: 'main',
+				isMainWorktree: true,
+				hasSession: false,
+			};
+			const items = prepareSessionItems([wt], []);
+			expect(items[0]?.baseLabel).toBe('main (main)');
+		});
+
+		it('truncates long directory names in the displayed label', () => {
+			const longDir =
+				'/repos/myproj/worktrees/this-is-a-very-long-directory-name-that-should-be-truncated';
+			const wt: Worktree = {
+				path: longDir,
+				branch: 'feature/short',
+				isMainWorktree: false,
+				hasSession: false,
+			};
+			const items = prepareSessionItems([wt], []);
+			// "feature/short @ " (16 chars) + up to MAX_WORKTREE_DIR_NAME_LENGTH (30)
+			const after = items[0]?.baseLabel.split(' @ ')[1] ?? '';
+			expect(after.length).toBeLessThanOrEqual(30);
+			expect(after.endsWith('...')).toBe(true);
+		});
+
+		it('keeps the untruncated directory basename in searchableName', () => {
+			const longDir =
+				'/repos/myproj/worktrees/this-is-a-very-long-directory-name-that-should-be-truncated';
+			const wt: Worktree = {
+				path: longDir,
+				branch: 'feature/short',
+				isMainWorktree: false,
+				hasSession: false,
+			};
+			const items = prepareSessionItems([wt], []);
+			expect(items[0]?.searchableName).toContain(
+				'this-is-a-very-long-directory-name-that-should-be-truncated',
+			);
+		});
+
+		it('places the directory suffix before session and status markers', () => {
+			const wt: Worktree = {
+				path: '/repos/myproj/worktrees/foo-api',
+				branch: 'feature/foo',
+				isMainWorktree: false,
+				hasSession: false,
+			};
+			const items = prepareSessionItems(
+				[wt],
+				[
+					{
+						...mockSession,
+						worktreePath: '/repos/myproj/worktrees/foo-api',
+						sessionName: 'lab',
+					},
+				],
+			);
+			// Order must be: branch, dir suffix, (no main), session suffix, status.
+			expect(items[0]?.baseLabel).toMatch(
+				/^feature\/foo @ foo-api: lab \[.*Idle.*\]$/,
+			);
+		});
+
+		it('does not break column alignment when a dir suffix is appended', () => {
+			const items = prepareSessionItems(
+				[
+					{
+						path: '/repos/myproj/worktrees/foo-api',
+						branch: 'feature/foo',
+						isMainWorktree: false,
+						hasSession: false,
+					},
+					{
+						path: '/repos/myproj',
+						branch: 'main',
+						isMainWorktree: true,
+						hasSession: false,
+					},
+				],
+				[],
+			);
+			expect(items[0]?.lengths.base).toBe(items[0]?.baseLabel.length);
+			expect(items[1]?.lengths.base).toBe(items[1]?.baseLabel.length);
+		});
 	});
 });
 

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -11,6 +11,7 @@ import {
 
 // Constants
 const MAX_BRANCH_NAME_LENGTH = 70; // Maximum characters for branch name display
+const MAX_WORKTREE_DIR_NAME_LENGTH = 30; // Maximum characters for the worktree directory name suffix
 const MIN_COLUMN_PADDING = 2; // Minimum spaces between columns
 
 /**
@@ -132,6 +133,55 @@ export function generateWorktreeDirectory(
 	return path.normalize(directory);
 }
 
+// Normalize a branch name or directory name for comparison.
+// Mirrors the sanitization rules used by generateWorktreeDirectory so a
+// worktree directory generated from a branch name is recognized as a match.
+function normalizeForComparison(value: string): string {
+	return value
+		.replace(/\//g, '-')
+		.replace(/[^a-zA-Z0-9-_.]+/g, '')
+		.replace(/^-+|-+$/g, '')
+		.toLowerCase();
+}
+
+/**
+ * Returns the worktree directory basename to show alongside the branch name,
+ * or an empty string when it would be redundant (main worktree, detached,
+ * or the directory name matches the branch).
+ *
+ * The visible suffix is truncated; the raw basename is also returned so
+ * callers that want to make it searchable can include it untruncated.
+ */
+export function formatWorktreeDirectorySuffix(
+	wt: Worktree,
+	fullBranchName: string,
+): {displaySuffix: string; rawName: string} {
+	if (wt.isMainWorktree) return {displaySuffix: '', rawName: ''};
+	if (!wt.branch) return {displaySuffix: '', rawName: ''};
+	if (!wt.path) return {displaySuffix: '', rawName: ''};
+
+	const dirName = path.basename(wt.path);
+	if (!dirName) return {displaySuffix: '', rawName: ''};
+
+	const normalizedDir = normalizeForComparison(dirName);
+	if (!normalizedDir) return {displaySuffix: '', rawName: ''};
+
+	const normalizedBranch = normalizeForComparison(fullBranchName);
+	if (normalizedDir === normalizedBranch) {
+		return {displaySuffix: '', rawName: ''};
+	}
+
+	// Also suppress when the directory matches just the tail segment of the
+	// branch (e.g. branch "feature/foo" vs directory "foo").
+	const tail = extractBranchParts(fullBranchName).name;
+	if (tail && normalizeForComparison(tail) === normalizedDir) {
+		return {displaySuffix: '', rawName: ''};
+	}
+
+	const visible = truncateString(dirName, MAX_WORKTREE_DIR_NAME_LENGTH);
+	return {displaySuffix: ` @ ${visible}`, rawName: dirName};
+}
+
 export function extractBranchParts(branchName: string): {
 	prefix?: string;
 	name: string;
@@ -239,10 +289,13 @@ function buildSessionItem(
 		: 'detached';
 	const branchName = truncateString(fullBranchName, MAX_BRANCH_NAME_LENGTH);
 	const isMain = wt.isMainWorktree ? ' (main)' : '';
-	const baseLabel = `${branchName}${isMain}${sessionSuffix}${status}`;
+	const {displaySuffix: dirSuffix, rawName: rawDirName} =
+		formatWorktreeDirectorySuffix(wt, fullBranchName);
+	const baseLabel = `${branchName}${dirSuffix}${isMain}${sessionSuffix}${status}`;
 	// Use the full (untruncated) branch name so search still matches the tail
 	// of long branch names; status icons are excluded so they don't match.
-	const searchableName = `${fullBranchName}${isMain}${sessionSuffix}`;
+	const rawDirForSearch = rawDirName ? ` @ ${rawDirName}` : '';
+	const searchableName = `${fullBranchName}${rawDirForSearch}${isMain}${sessionSuffix}`;
 	const {fileChanges, aheadBehind, parentBranch, error} = gitStatusColumns(
 		wt,
 		fullBranchName,


### PR DESCRIPTION
## Summary

Today the worktree menu row only displays the branch name (plus `(main)` / session suffix / status). When multiple worktrees share a branch (e.g. an `-agent` or `-review` checkout of the same branch) or when the branch name does not encode the directory, the rows become ambiguous and you have to leave the menu to figure out which worktree is which.

This PR appends ` @ <directory-basename>` to the base label **only when the directory adds information that the branch name does not already convey** — so the common case where the directory matches the branch is left untouched.

### Behavior

| Branch | Worktree directory | Rendered baseLabel |
|---|---|---|
| `feature/login` | `login-api` | `feature/login @ login-api` |
| `feature/foo` | `foo` (matches branch tail) | `feature/foo` (suppressed) |
| `feature/foo` | `feature-foo` (matches sanitized full branch) | `feature/foo` (suppressed) |
| `main` (main worktree) | `myrepo` | `main (main)` (suppressed) |
| `feature/x` | (detached, no branch) | `detached` (suppressed) |

Suppression rules:
- main worktree → no suffix
- no branch (detached) → no suffix
- directory basename matches the sanitized branch name → no suffix
- directory basename matches the sanitized branch tail segment → no suffix

The sanitization mirrors `generateWorktreeDirectory` (slash → dash, special chars stripped, lowercased), so a worktree directory generated from a branch name will be recognized as matching that branch and stay suppressed.

### Details

- Visible suffix is truncated at 30 characters; the untruncated basename is included in `searchableName` so existing menu search still matches long directory names.
- Suffix position: between the branch name and `(main)` / session / status markers — so the suffix never appears for the main worktree anyway, but the order is well-defined.
- Dashboard rows are **intentionally left untouched**: they already prefix entries with `${projectName} :: ` and adding the directory name would make the row too wide for the common case. Happy to extend it there too if maintainers prefer.
- No new config flag. Happy to add `worktree.showDirectoryName` (or `auto | always | never`) as a follow-up if this should be opt-in.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 8 new tests pass, no other tests regress (the two `Session.test` failures exist on `main` and are unrelated)
- [x] New tests in `src/utils/worktreeUtils.test.ts` cover: directory shown when it differs / suppressed for branch-tail match / suppressed for sanitized-full-branch match / suppressed for main / truncation in displayed label / untruncated basename retained in `searchableName` / order of branch · dir · session · status / `lengths.base` stays consistent so column alignment is not broken