### PR TITLE
fix: reject prose output when generating worktree branch names

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:npm.flatt.tech)"
+    ]
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -37,11 +37,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "4.1.20",
-        "@kodaikabasawa/ccmanager-darwin-x64": "4.1.20",
-        "@kodaikabasawa/ccmanager-linux-arm64": "4.1.20",
-        "@kodaikabasawa/ccmanager-linux-x64": "4.1.20",
-        "@kodaikabasawa/ccmanager-win32-x64": "4.1.20",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "4.1.21",
+        "@kodaikabasawa/ccmanager-darwin-x64": "4.1.21",
+        "@kodaikabasawa/ccmanager-linux-arm64": "4.1.21",
+        "@kodaikabasawa/ccmanager-linux-x64": "4.1.21",
+        "@kodaikabasawa/ccmanager-win32-x64": "4.1.21",
       },
     },
   },
@@ -128,15 +128,15 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@4.1.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xPxF58q5ugt6YxbZxxe1lzahYmTfVGYz6YSsNo64NDIaK0AdxU+oxZCln5HOD6SJ0cfcvqcXadZ2blwENzkLfg=="],
+    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@4.1.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-S/mx1w1hzEM+S+ET+x7jPT4XtN64N6JxrrvLtPbglhqm8TeGHBLFCXSD/StT1fljzgiS6+NP3q0FByHJCtw3Uw=="],
 
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@4.1.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-8OmVKLcUeKC5tDi+WalSPuC454A8wFsuhW02rpclqa+eed4VJ4yaDDrOYGOXiPrcwyGenXHP1RUKe2EezfwC8w=="],
+    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@4.1.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-OCuY2cKsf50KxlgnTckIwhkcQCU85UB+Zl/kFdSPGiWU9LBR+5VXJSLMyWxDptB2WvXRCZU4Ly8ZrYMrcFA0dQ=="],
 
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@4.1.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rm2S7jrNDgze5nx1G1tVpQUO3uWUkSpQ0NLZ4kuQO4Ez4mQiUk43L3ASt/Z5Tq4lzNMdo34R+Po+Li7U5c0wPQ=="],
+    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@4.1.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPObnKGQDAU6kLGExb+W7YB1KVYNKgIP6Vy2Jz1370ez6tmW0mHgc6wQncmtH5Xp+5ZPog3G9CjJbNZ4xiSF6g=="],
 
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@4.1.20", "", { "os": "linux", "cpu": "x64" }, "sha512-042q9NUpkAs2VKNDviqynC4/ion87NKhDdFTjH+oabu4JuF94sPuEjHef+tw7dmuR1BQ8mC6mgCezr2XJpCSyg=="],
+    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@4.1.21", "", { "os": "linux", "cpu": "x64" }, "sha512-l9JQCFI9lfcKjuFYrfI/gN/03SlH7nsrwCPEzE0syhYBVo9gN5Q+Gb0t9085JQIWTEg+LFP+cIy/RU6l8zgLgg=="],
 
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@4.1.20", "", { "os": "win32", "cpu": "x64" }, "sha512-Hc7orJAWOR9+N8OeD7Zhg4uIvddJSY269d740FqHpN4+A86zK/1SBmWaWImbL9UlJQ/8VhCR7ABqSvimY0aBvA=="],
+    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@4.1.21", "", { "os": "win32", "cpu": "x64" }, "sha512-WT/emydqYzk2it6Cc+66bqlN1u1RiU8h24GWLpaeg1mvAOfRaTpSPo0cGF5oEx6hAFdyAuoqD+pHI/Dj7Wq0lQ=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/src/services/worktreeNameGenerator.test.ts
+++ b/src/services/worktreeNameGenerator.test.ts
@@ -39,6 +39,30 @@ describe('WorktreeNameGenerator output parsing', () => {
 
 		expect(value).toBe('fix/trim-worktree-name');
 	});
+
+	it('rejects prose refusals that overflow the length budget', () => {
+		// `claude -p` sometimes puts a refusal sentence into the branchName field
+		// instead of a name; the caller relies on this throwing to use a fallback.
+		expect(() =>
+			extractBranchNameFromOutput(
+				'{"branchName":"i can t generate an informed branch name without understanding issue 310 could you either grant permission for webfetch or paste the issue description"}',
+			),
+		).toThrow();
+	});
+
+	it('rejects names with too many words even when short', () => {
+		expect(() =>
+			extractBranchNameFromOutput('{"branchName":"a-b-c-d-e-f-g-h-i-j-k-l"}'),
+		).toThrow();
+	});
+
+	it('accepts a normal multi-word branch name', () => {
+		const value = extractBranchNameFromOutput(
+			'{"branchName":"feature/add-prompt-mode-toggle"}',
+		);
+
+		expect(value).toBe('feature/add-prompt-mode-toggle');
+	});
 });
 
 describe('deduplicateBranchName', () => {

--- a/src/services/worktreeNameGenerator.ts
+++ b/src/services/worktreeNameGenerator.ts
@@ -15,6 +15,15 @@ const JSON_SCHEMA = JSON.stringify({
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+// Generated branch names are short by construction. When `claude -p` returns
+// prose instead of a name (e.g. a refusal, or a request for an issue's
+// contents it cannot fetch), normalizing that text yields an unusually long,
+// many-segment slug. These bounds let us detect that case and reject it so the
+// caller falls back to a generated name instead of branching off a whole
+// sentence. They are also surfaced to the model in the prompt.
+const MAX_GENERATED_BRANCH_NAME_LENGTH = 60;
+const MAX_GENERATED_BRANCH_NAME_SEGMENTS = 10;
+
 const buildPrompt = (
 	userPrompt: string,
 	baseBranch: string,
@@ -25,7 +34,10 @@ Task prompt:
 ${userPrompt}
 
 Return a short git branch name using lowercase letters, numbers, hyphens, and forward slashes only.
+Use at most ${MAX_GENERATED_BRANCH_NAME_SEGMENTS} hyphen- or slash-separated words and keep it under ${MAX_GENERATED_BRANCH_NAME_LENGTH} characters.
 Do not include markdown, explanations, refs/heads/, or surrounding quotes.
+Always output a branch name. Never refuse, never ask for clarification, and never request more information or access.
+If the task prompt references context you cannot access (for example an issue number, ticket, or URL), do not mention that limitation: just produce a best-effort name from the words available in the task prompt itself.
 Examples: feature/add-prompt-mode, fix/worktree-loading-state`;
 
 const normalizeBranchName = (branchName: string): string => {
@@ -45,6 +57,19 @@ const normalizeBranchName = (branchName: string): string => {
 
 	if (!normalized) {
 		throw new Error('Generated branch name was empty');
+	}
+
+	if (normalized.length > MAX_GENERATED_BRANCH_NAME_LENGTH) {
+		throw new Error(
+			`Generated branch name was too long (${normalized.length} > ${MAX_GENERATED_BRANCH_NAME_LENGTH} chars); treating it as invalid output`,
+		);
+	}
+
+	const segmentCount = normalized.split(/[/-]/).filter(Boolean).length;
+	if (segmentCount > MAX_GENERATED_BRANCH_NAME_SEGMENTS) {
+		throw new Error(
+			`Generated branch name had too many words (${segmentCount} > ${MAX_GENERATED_BRANCH_NAME_SEGMENTS}); treating it as invalid output`,
+		);
 	}
 
 	return normalized;


### PR DESCRIPTION
## Problem

When generating a worktree branch name, `claude -p` runs with `--json-schema`. When it cannot complete the task — for example the prompt references an issue number or URL whose contents it cannot fetch — it satisfies the schema by putting its *refusal sentence into the `branchName` field*. The JSON parses cleanly, so `normalizeBranchName` turns the whole sentence into a giant hyphenated slug (e.g. `i-can-t-generate-an-informed-branch-name-without-understanding-issue-310-...`). Because that result is non-empty, the existing fallback in `App.tsx` never triggers and the branch is created off a sentence.

## Approach

Two complementary changes in `src/services/worktreeNameGenerator.ts`:

1. **Strengthen the fallback trigger.** `normalizeBranchName` — the single choke point every extraction path passes through — now rejects results that exceed a length/word-count budget (`MAX_GENERATED_BRANCH_NAME_LENGTH`, `MAX_GENERATED_BRANCH_NAME_SEGMENTS`). Rejection propagates as an error, so the *existing* `generateFallbackBranchName(...)` path takes over. No new fallback mechanism is introduced — it reuses the one already wired up in `App.tsx`.
2. **Prompt enforcement.** `buildPrompt` now instructs the model to always emit a name, never refuse or ask for clarification, and to produce a best-effort name from the available words when referenced context is inaccessible. The length/word limits are read from the same two constants so the prompt and validator cannot drift.

## Verification

- New unit tests: prose refusal rejected, too-many-words rejected, normal multi-word name accepted.
- `npm run lint`, `npm run typecheck`, and the generator suite pass. (Pre-existing `*.submodule.test` failures are unrelated — they fail on `git config --global protocol.file.allow always` in the sandbox.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)