### PR TITLE
perf: cache git status across menu remounts to avoid refetch flash

### DIFF
--- a/src/hooks/useGitStatus.test.ts
+++ b/src/hooks/useGitStatus.test.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import {render, cleanup} from 'ink-testing-library';
 import {Text} from 'ink';
 import {Effect, Exit} from 'effect';
-import {useGitStatus} from './useGitStatus.js';
+import {useGitStatus, clearGitStatusCache} from './useGitStatus.js';
 import type {Worktree} from '../types/index.js';
 import {
 	getGitStatusLimited,
@@ -41,6 +41,9 @@ describe('useGitStatus', () => {
 
 	beforeEach(() => {
 		vi.useFakeTimers();
+		// The status cache is module-level and persists across tests; clear it so
+		// each test starts from a cold cache.
+		clearGitStatusCache();
 		mockGetGitStatus.mockClear();
 		mockGetLastCommitDate.mockClear();
 		// Default: return a date for all worktrees
@@ -87,6 +90,31 @@ describe('useGitStatus', () => {
 		// Should have correct status for each worktree
 		expect(hookResult[0]?.gitStatus).toEqual(gitStatus1);
 		expect(hookResult[1]?.gitStatus).toEqual(gitStatus2);
+	});
+
+	it('should hydrate from cache on remount so status shows immediately', async () => {
+		const worktrees = [createWorktree('/path1')];
+		const gitStatus1 = createGitStatus(7, 2);
+		mockGetGitStatus.mockReturnValue(Effect.succeed(gitStatus1));
+
+		let hookResult: Worktree[] = [];
+		const TestComponent = () => {
+			hookResult = useGitStatus(worktrees, 'main', 100);
+			return React.createElement(Text, null, 'test');
+		};
+
+		// First mount: fetch populates the module-level cache.
+		const first = render(React.createElement(TestComponent));
+		await vi.waitFor(() => {
+			expect(hookResult[0]?.gitStatus).toEqual(gitStatus1);
+		});
+		first.unmount();
+
+		// Remount: cached status must be present on the very first render, before
+		// any new fetch resolves, so the menu does not flash "[fetching...]".
+		hookResult = [];
+		render(React.createElement(TestComponent));
+		expect(hookResult[0]?.gitStatus).toEqual(gitStatus1);
 	});
 
 	it('should handle empty worktree array', () => {

--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -14,6 +14,68 @@ interface WorktreeStatusResult {
 	dateExit: Exit.Exit<Date, GitError>;
 }
 
+interface CachedStatus {
+	gitStatus?: GitStatus;
+	gitStatusError?: string;
+	lastCommitDate?: Date;
+}
+
+/**
+ * Module-level cache of the last fetched git status, keyed by worktree path.
+ *
+ * The menu is fully unmounted and remounted on every return to it (App renders
+ * `<Menu key={menuKey} />`, and the key changes on navigation), which would
+ * otherwise wipe this hook's state and force every worktree to flash
+ * "[fetching...]" and refetch from scratch each time. Seeding state from this
+ * cache shows each worktree's last known status instantly; background polling
+ * still refreshes it. Entries are intentionally not pruned so switching between
+ * projects keeps each project's cached status.
+ */
+const statusCache = new Map<string, CachedStatus>();
+
+/** Clear the module-level git-status cache. Intended for tests. */
+export function clearGitStatusCache(): void {
+	statusCache.clear();
+}
+
+/**
+ * Merge any cached status onto the given worktrees so a remount can show the
+ * last known status immediately instead of "[fetching...]". Returns the same
+ * array reference when nothing was cached, so React can skip a re-render.
+ */
+function hydrateFromCache(worktrees: Worktree[]): Worktree[] {
+	let changed = false;
+	const next = worktrees.map(wt => {
+		const cached = statusCache.get(wt.path);
+		if (!cached) {
+			return wt;
+		}
+		changed = true;
+		return {
+			...wt,
+			gitStatus: cached.gitStatus,
+			gitStatusError: cached.gitStatusError,
+			lastCommitDate: cached.lastCommitDate,
+		};
+	});
+	return changed ? next : worktrees;
+}
+
+/** Record a worktree's latest status update into the module-level cache. */
+function cacheStatusUpdate(path: string, update: Partial<Worktree>): void {
+	const next: CachedStatus = {...statusCache.get(path)};
+	if ('gitStatus' in update) {
+		next.gitStatus = update.gitStatus;
+	}
+	if ('gitStatusError' in update) {
+		next.gitStatusError = update.gitStatusError;
+	}
+	if ('lastCommitDate' in update) {
+		next.lastCommitDate = update.lastCommitDate;
+	}
+	statusCache.set(path, next);
+}
+
 /**
  * Custom hook for polling git status and commit dates of worktrees with Effect-based execution
  *
@@ -37,7 +99,9 @@ export function useGitStatus(
 	defaultBranch: string | null,
 	updateInterval = 5000,
 ): Worktree[] {
-	const [worktreesWithStatus, setWorktreesWithStatus] = useState(worktrees);
+	const [worktreesWithStatus, setWorktreesWithStatus] = useState(() =>
+		hydrateFromCache(worktrees),
+	);
 
 	useEffect(() => {
 		if (!defaultBranch) {
@@ -96,7 +160,7 @@ export function useGitStatus(
 			}
 		};
 
-		setWorktreesWithStatus(worktrees);
+		setWorktreesWithStatus(hydrateFromCache(worktrees));
 
 		runCycle().catch(() => {
 			// Ignore errors - the fetch failed or was aborted
@@ -134,6 +198,7 @@ function applyStatusResults(
 		const update = buildStatusUpdate(result.statusExit, result.dateExit);
 		if (update) {
 			updatesByPath.set(result.path, update);
+			cacheStatusUpdate(result.path, update);
 		}
 	}
 


### PR DESCRIPTION
## Problem

Returning to the worktree menu felt laggy: every worktree row flashed `[fetching...]` and the navigation stuttered while the status was re-fetched, and this happened *every* time the menu was reopened.

## Root cause

The menu is fully unmounted and remounted on every return — `App` renders `<Menu key={menuKey} />` and the `key` changes on navigation. That remount wipes `useGitStatus`'s state, so `baseWorktrees` reloads from empty and every worktree loses its previously fetched `gitStatus`. `gitStatusColumns` renders `[fetching...]` whenever a worktree has neither `gitStatus` nor `gitStatusError` (`src/utils/worktreeUtils.ts`), and a fresh poll cycle then re-runs the git subprocesses for all worktrees. That re-fetch burst is the source of the perceived lag on return.

## Fix

Add a module-level cache in `useGitStatus.ts`, keyed by worktree path, holding the last fetched `gitStatus` / `gitStatusError` / `lastCommitDate`. The hook seeds its state from this cache on mount (`hydrateFromCache`), so a remount shows each worktree's last known status instantly instead of flashing `[fetching...]`. Background polling still runs and refreshes the values, and each fetch result updates the cache. Cache entries are intentionally not pruned so switching between projects keeps each project's status warm.

This builds on the earlier batching/no-op-skipping change (#315): that reduced churn within a single mount; this removes the refetch-from-scratch on every remount.

## Verification

- `npm run lint`, `npm run typecheck` pass
- `useGitStatus.test.ts` passes, including a new test asserting that a remount hydrates cached status on the first render (no `[fetching...]` flash)
- Full Vitest suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)