### PR TITLE
fix: rebuild host terminal scrollback from session buffer on restore

### DIFF
--- a/src/components/Session.tsx
+++ b/src/components/Session.tsx
@@ -88,8 +88,14 @@ const Session: React.FC<SessionProps> = ({
 
 		stdin.on('data', handleStdinData);
 
-		// Clear screen when entering session
-		stdout.write('\x1B[2J\x1B[H');
+		// Clear the viewport and the host terminal's scrollback (\x1b[3J) when
+		// entering a session. The restore snapshot then rebuilds the whole
+		// canvas — scrollback included — from this session's headless buffer,
+		// so content left behind by the menu or other sessions can never
+		// appear when the user scrolls up. \x1b[2J runs first because some
+		// emulators (e.g. xterm.js-based ones) push the erased viewport into
+		// scrollback, which \x1b[3J must then discard.
+		stdout.write('\x1B[2J\x1B[3J\x1B[H');
 
 		// Restore the current terminal state from the headless xterm snapshot.
 		// The xterm serialize addon relies on auto-wrap (DECAWM) being enabled

--- a/src/services/sessionManager.test.ts
+++ b/src/services/sessionManager.test.ts
@@ -1328,7 +1328,7 @@ describe('SessionManager', () => {
 			expect(session.restoreScrollbackBaseLine).toBe(0);
 		});
 
-		it('should skip scrollback that grows during cursor-addressed redraws', async () => {
+		it('should keep scrollback that grows during cursor-addressed redraws', async () => {
 			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
 				id: '1',
 				name: 'Main',
@@ -1349,47 +1349,7 @@ describe('SessionManager', () => {
 
 			mockPty.emit('data', '\x1b[Hredrawn status\n');
 
-			expect(session.restoreScrollbackBaseLine).toBe(12);
-		});
-
-		it('should keep cursor-addressed redraw tracking active for a short quiet window', async () => {
-			vi.useFakeTimers();
-			try {
-				vi.mocked(configReader.getDefaultPreset).mockReturnValue({
-					id: '1',
-					name: 'Main',
-					command: 'claude',
-				});
-				vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
-
-				const session = await Effect.runPromise(
-					sessionManager.createSessionWithPresetEffect('/test/worktree'),
-				);
-				const normalBuffer = session.terminal.buffer.normal as unknown as {
-					baseY: number;
-				};
-				normalBuffer.baseY = 10;
-				vi.mocked(session.terminal.write).mockImplementation(() => {
-					if (normalBuffer.baseY === 10) {
-						return;
-					}
-					normalBuffer.baseY++;
-				});
-
-				mockPty.emit('data', '\x1b[Hredraw frame');
-				normalBuffer.baseY = 11;
-				mockPty.emit('data', 'plain continuation that scrolls');
-
-				expect(session.restoreScrollbackBaseLine).toBe(12);
-
-				vi.advanceTimersByTime(501);
-				normalBuffer.baseY = 20;
-				mockPty.emit('data', 'ordinary output after quiet window');
-
-				expect(session.restoreScrollbackBaseLine).toBe(12);
-			} finally {
-				vi.useRealTimers();
-			}
+			expect(session.restoreScrollbackBaseLine).toBe(0);
 		});
 
 		it('should flush live session data after the restore snapshot completes', async () => {
@@ -1564,7 +1524,7 @@ describe('SessionManager', () => {
 			}
 		});
 
-		it('should advance the restore baseline when transitioning out of busy', async () => {
+		it('should retain the restore baseline when transitioning out of busy', async () => {
 			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
 				id: '1',
 				name: 'Main',
@@ -1585,31 +1545,6 @@ describe('SessionManager', () => {
 				}
 			).updateSessionState.bind(sessionManager);
 			await updateState(session, 'idle');
-
-			expect(session.restoreScrollbackBaseLine).toBe(42);
-		});
-
-		it('should not advance the restore baseline on transitions that do not leave busy', async () => {
-			vi.mocked(configReader.getDefaultPreset).mockReturnValue({
-				id: '1',
-				name: 'Main',
-				command: 'claude',
-			});
-			vi.mocked(spawn).mockReturnValue(mockPty as unknown as IPty);
-
-			const session = await Effect.runPromise(
-				sessionManager.createSessionWithPresetEffect('/test/worktree'),
-			);
-			(session.terminal.buffer.normal as unknown as {baseY: number}).baseY = 42;
-			session.restoreScrollbackBaseLine = 5;
-			await session.stateMutex.update(data => ({...data, state: 'idle'}));
-
-			const updateState = (
-				sessionManager as unknown as {
-					updateSessionState: (s: Session, next: SessionState) => Promise<void>;
-				}
-			).updateSessionState.bind(sessionManager);
-			await updateState(session, 'busy');
 
 			expect(session.restoreScrollbackBaseLine).toBe(5);
 		});

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -45,11 +45,6 @@ const RESIZE_SUPPRESS_MS = 250;
 // streaming session still restores within a small bounded delay.
 const RESTORE_DEFER_QUIET_MS = 80;
 const RESTORE_DEFER_MAX_MS = 250;
-// Cursor-addressed redraws (progress bars, spinners, TUIs) can leave transient
-// rows in scrollback if the viewport scrolls before those rows are overwritten.
-// Keep a short generic redraw window so restore can skip that ghost-bearing
-// range without depending on any specific CLI output text.
-const REDRAW_SCROLLBACK_QUIET_MS = 500;
 
 export interface SessionCounts {
 	idle: number;
@@ -72,8 +67,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	private resizeSuppressTimers: Map<string, NodeJS.Timeout> = new Map();
 	private restoreDeferTimers: Map<string, NodeJS.Timeout> = new Map();
 	private restoreDeferDeadlines: Map<string, number> = new Map();
-	private cursorRedrawSessions: Set<string> = new Set();
-	private cursorRedrawTimers: Map<string, NodeJS.Timeout> = new Map();
 
 	private async spawn(
 		command: string,
@@ -302,15 +295,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		}));
 
 		if (oldState !== newState) {
-			// While busy, cursor-addressed footer redraws (spinner, token stats,
-			// "accept edits on …" line) can push ghost frames into scrollback as
-			// chat content scrolls. Once the busy turn ends, advance the restore
-			// baseline so the next session restore replays only post-busy
-			// scrollback and skips the ghost-bearing range.
-			if (oldState === 'busy' && newState !== 'busy') {
-				session.restoreScrollbackBaseLine =
-					session.terminal.buffer.normal.baseY;
-			}
 			void Effect.runPromise(executeStatusHook(oldState, newState, session));
 			this.emit('sessionStateChanged', session);
 		}
@@ -336,50 +320,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 			data.includes('\x1b[2J') ||
 			data.includes('\x1b[3J') ||
 			data.includes('\x1bc')
-		);
-	}
-
-	private hasCursorAddressedRedraw(data: string): boolean {
-		return (
-			// CSI cursor movement/positioning, erase, and scroll controls.
-			/\x1b\[[0-?]*[ -/]*[ABCDEFGHJKSTX`abcdefg]/.test(data) ||
-			// DEC save/restore cursor.
-			/\x1b[78]/.test(data) ||
-			// Synchronized output mode usually brackets full-frame redraws.
-			/\x1b\[\?2026[hl]/.test(data)
-		);
-	}
-
-	private markCursorRedrawActive(session: Session): void {
-		this.cursorRedrawSessions.add(session.id);
-
-		const existing = this.cursorRedrawTimers.get(session.id);
-		if (existing !== undefined) {
-			clearTimeout(existing);
-		}
-
-		const timer = setTimeout(() => {
-			this.cursorRedrawTimers.delete(session.id);
-			this.cursorRedrawSessions.delete(session.id);
-		}, REDRAW_SCROLLBACK_QUIET_MS);
-		this.cursorRedrawTimers.set(session.id, timer);
-	}
-
-	private handleScrollbackGrowthDuringRedraw(
-		session: Session,
-		beforeBaseY: number,
-	): void {
-		const afterBaseY = session.terminal.buffer.normal.baseY;
-		if (
-			afterBaseY <= beforeBaseY ||
-			!this.cursorRedrawSessions.has(session.id)
-		) {
-			return;
-		}
-
-		session.restoreScrollbackBaseLine = Math.max(
-			session.restoreScrollbackBaseLine,
-			afterBaseY,
 		);
 	}
 
@@ -629,14 +569,8 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 	private setupDataHandler(session: Session): void {
 		// This handler always runs for all data
 		session.process.onData((data: string) => {
-			const beforeBaseY = session.terminal.buffer.normal.baseY;
-			if (this.hasCursorAddressedRedraw(data)) {
-				this.markCursorRedrawActive(session);
-			}
-
 			// Write data to virtual terminal
 			session.terminal.write(data);
-			this.handleScrollbackGrowthDuringRedraw(session, beforeBaseY);
 
 			if (this.shouldResetRestoreScrollback(data)) {
 				session.restoreScrollbackBaseLine =
@@ -940,15 +874,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		this.restoreDeferDeadlines.delete(sessionId);
 	}
 
-	private clearCursorRedrawTracking(sessionId: string): void {
-		this.cursorRedrawSessions.delete(sessionId);
-		const timer = this.cursorRedrawTimers.get(sessionId);
-		if (timer !== undefined) {
-			clearTimeout(timer);
-			this.cursorRedrawTimers.delete(sessionId);
-		}
-	}
-
 	cancelAutoApproval(sessionId: string, reason = 'User input received'): void {
 		const session = this.sessions.get(sessionId);
 		if (!session) {
@@ -1035,7 +960,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 				clearTimeout(resizeTimer);
 				this.resizeSuppressTimers.delete(sessionId);
 			}
-			this.clearCursorRedrawTracking(sessionId);
 			this.cancelRestoreDefer(sessionId);
 			this.emit('sessionDestroyed', session);
 		}
@@ -1103,7 +1027,6 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 					clearTimeout(resizeTimer);
 					this.resizeSuppressTimers.delete(sessionId);
 				}
-				this.clearCursorRedrawTracking(sessionId);
 				this.cancelRestoreDefer(sessionId);
 				this.emit('sessionDestroyed', session);
 			},


### PR DESCRIPTION
## Problem

Re-entering a session restored only the current viewport: scrolling up showed leftover content from the menu and other sessions instead of the session's own history.

Two causes, both by construction:

1. **The session's own scrollback was excluded from the restore snapshot.** Every `busy → non-busy` transition advanced `restoreScrollbackBaseLine` to the current `baseY`, and any scrollback growth within 500 ms of a cursor-addressed escape sequence did the same. Claude produces all of its output during busy turns while redrawing its footer at ~10 Hz, so the restore range collapsed to the viewport.
2. **The host terminal's scrollback was never cleared** (only `\x1b[2J`, never `\x1b[3J`), so whatever the menu and other sessions had previously written stayed above the restored viewport.

These exclusions were added (#299, #302) to hide ghost footer rows that Claude's Ink renderer pushes into scrollback, trading away scrollback recall to get it. This PR takes the opposite trade: treat the host terminal's scrollback as a projection of the session's headless xterm buffer, rebuilt on every session entry, instead of a shared append-only canvas reconciled by heuristics.

## Changes

- Clear the host scrollback (`\x1b[3J`) alongside the viewport when entering a session, so the restore snapshot rebuilds the entire canvas from this session's buffer. `\x1b[2J` runs first because xterm.js-based emulators push the erased viewport into scrollback, which `\x1b[3J` must then discard.
- Remove the busy-transition baseline bump and the cursor-redraw scrollback tracking. Restore now replays the full retained scrollback (bounded by `TERMINAL_RESTORE_SCROLLBACK_LINES` = 5000 lines); the baseline advances only on explicit clear-screen sequences (`/clear` etc.).
- The deferred-snapshot and resize-suppression mechanisms are kept: they address partial-frame capture and SIGWINCH duplication, not scrollback retention.

Replay cost stays bounded by the scrollback limit regardless of how much output the session produced, because the snapshot serializes the final buffer state, not the raw PTY stream — so this does not reintroduce the slow chunk-replay restores that #271 fixed.

## Trade-offs

- Ghost footer rows in scrollback can reappear, but only up to parity with running `claude` directly in a plain terminal (the headless xterm sees the same byte stream).
- `\x1b[3J` also wipes terminal history from before ccmanager was launched. This is inherent to any design that uses the host's native scrollback as the display medium.
- After a terminal resize, scrollback keeps the old wrapping until the next session re-entry rebuilds it (resize still repaints viewport-only, unchanged from before).

## Verification

- `npm run lint`, `npm run typecheck`, `npm run test` all pass (1764 tests).
- Manual check matrix: re-enter a session while idle / while busy / after a terminal resize / after `/clear`, then scroll up — only the session's own history should be visible in each case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)