### PR TITLE
perf: show cached worktrees when returning to menu

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -19,6 +19,7 @@ import type {
 	DevcontainerConfig,
 	MenuAction,
 } from '../types/index.js';
+import type {MenuSnapshot} from './Menu.js';
 import {ENV_VARS} from '../constants/env.js';
 import {ProcessError} from '../types/errors.js';
 
@@ -27,6 +28,8 @@ type AppComponent = typeof import('./App.js').default;
 type MenuMockProps = {
 	onMenuAction: (action: MenuAction) => void | Promise<void>;
 	onSelectRecentProject?: (project: GitProject) => void | Promise<void>;
+	initialSnapshot?: MenuSnapshot;
+	onSnapshotChange?: (snapshot: MenuSnapshot) => void;
 	error?: string | null;
 };
 
@@ -311,6 +314,67 @@ describe('App component view state', () => {
 });
 
 describe('App component loading state machine', () => {
+	it('updates the cached worktree snapshot after creating and deleting worktrees', async () => {
+		const {unmount} = render(<App version="test" />);
+		await waitForCondition(() => Boolean(menuProps));
+
+		menuProps!.onSnapshotChange?.({
+			worktrees: [
+				{
+					path: '/tmp/existing',
+					branch: 'existing',
+					isMainWorktree: true,
+					hasSession: false,
+				},
+			],
+			defaultBranch: 'main',
+		});
+		await flush();
+
+		await Promise.resolve(menuProps!.onMenuAction({type: 'newWorktree'}));
+		await waitForCondition(() => Boolean(newWorktreeProps));
+		await Promise.resolve(
+			newWorktreeProps!.onComplete({
+				creationMode: 'manual',
+				path: '/tmp/created',
+				branch: 'created',
+				baseBranch: 'main',
+				copySessionData: false,
+				copyClaudeDirectory: false,
+			}),
+		);
+		await waitForCondition(() =>
+			Boolean(
+				menuProps?.initialSnapshot?.worktrees.some(
+					worktree => worktree.path === '/tmp/created',
+				),
+			),
+		);
+
+		await Promise.resolve(menuProps!.onMenuAction({type: 'deleteWorktree'}));
+		await waitForCondition(() => Boolean(deleteWorktreeProps));
+		await Promise.resolve(
+			deleteWorktreeProps!.onComplete(['/tmp/created'], true),
+		);
+		await waitForCondition(
+			() =>
+				!menuProps?.initialSnapshot?.worktrees.some(
+					worktree => worktree.path === '/tmp/created',
+				),
+		);
+
+		expect(menuProps?.initialSnapshot?.worktrees).toEqual([
+			{
+				path: '/tmp/existing',
+				branch: 'existing',
+				isMainWorktree: true,
+				hasSession: false,
+			},
+		]);
+
+		unmount();
+	});
+
 	it('displays copying message while creating a worktree with session data', async () => {
 		let resolveWorktree: (() => void) | undefined;
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect, useCallback} from 'react';
 import {useApp, useInput, Box, Text} from 'ink';
 import {Effect} from 'effect';
-import Menu from './Menu.js';
+import Menu, {type MenuSnapshot} from './Menu.js';
 import Dashboard from './Dashboard.js';
 import Session from './Session.js';
 import NewWorktree from './NewWorktree.js';
@@ -84,6 +84,9 @@ const App: React.FC<AppProps> = ({
 		null,
 	);
 	const [menuKey, setMenuKey] = useState(0); // Force menu refresh
+	const [menuSnapshots, setMenuSnapshots] = useState<
+		Record<string, MenuSnapshot>
+	>({});
 
 	const [selectedWorktree, setSelectedWorktree] = useState<Worktree | null>(
 		null,
@@ -129,6 +132,34 @@ const App: React.FC<AppProps> = ({
 	// State for streaming devcontainer up logs
 	const [devcontainerLogs, setDevcontainerLogs] = useState<string[]>([]);
 	const [canReturnFromHookError, setCanReturnFromHookError] = useState(false);
+	const menuSnapshotKey = selectedProject?.path ?? process.cwd();
+
+	const handleMenuSnapshotChange = useCallback(
+		(snapshot: MenuSnapshot) => {
+			setMenuSnapshots(previous => ({
+				...previous,
+				[menuSnapshotKey]: snapshot,
+			}));
+		},
+		[menuSnapshotKey],
+	);
+
+	const updateMenuSnapshot = useCallback(
+		(update: (snapshot: MenuSnapshot) => MenuSnapshot) => {
+			setMenuSnapshots(previous => {
+				const current = previous[menuSnapshotKey];
+				if (!current) {
+					return previous;
+				}
+
+				return {
+					...previous,
+					[menuSnapshotKey]: update(current),
+				};
+			});
+		},
+		[menuSnapshotKey],
+	);
 
 	useEffect(() => {
 		if (view !== 'worktree-hook-error') {
@@ -393,6 +424,21 @@ const App: React.FC<AppProps> = ({
 		},
 	) => {
 		if (result.success) {
+			updateMenuSnapshot(snapshot => ({
+				...snapshot,
+				worktrees: [
+					...snapshot.worktrees.filter(
+						worktree => worktree.path !== creationData.path,
+					),
+					{
+						path: creationData.path,
+						branch: creationData.branch,
+						isMainWorktree: false,
+						hasSession: false,
+					},
+				],
+			}));
+
 			if (result.warning) {
 				setError(null);
 				setWorktreeHookError(result.warning);
@@ -789,6 +835,13 @@ const App: React.FC<AppProps> = ({
 		}
 
 		if (!hasError) {
+			const deletedPaths = new Set(worktreePaths);
+			updateMenuSnapshot(snapshot => ({
+				...snapshot,
+				worktrees: snapshot.worktrees.filter(
+					worktree => !deletedPaths.has(worktree.path),
+				),
+			}));
 			// Success - return to menu
 			handleReturnToMenu();
 		} else {
@@ -891,6 +944,8 @@ const App: React.FC<AppProps> = ({
 				key={menuKey}
 				sessionManager={sessionManager}
 				worktreeService={worktreeService}
+				initialSnapshot={menuSnapshots[menuSnapshotKey]}
+				onSnapshotChange={handleMenuSnapshotChange}
 				onMenuAction={handleMenuAction}
 				onSelectRecentProject={handleSelectProject}
 				error={error}

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -276,6 +276,115 @@ describe('Menu component Effect-based error handling', () => {
 		expect(getWorktreesSpy).toHaveBeenCalled();
 		expect(getDefaultBranchSpy).toHaveBeenCalled();
 	});
+
+	it('should render a cached snapshot before its background refresh completes', async () => {
+		const {Effect} = await import('effect');
+		const cachedWorktree = {
+			path: '/test/cached',
+			branch: 'cached-branch',
+			isMainWorktree: true,
+			hasSession: false,
+		};
+		const refreshedWorktree = {
+			path: '/test/refreshed',
+			branch: 'refreshed-branch',
+			isMainWorktree: true,
+			hasSession: false,
+		};
+		let resolveWorktrees: (worktrees: (typeof refreshedWorktree)[]) => void;
+		const worktreesPromise = new Promise<(typeof refreshedWorktree)[]>(
+			resolve => {
+				resolveWorktrees = resolve;
+			},
+		);
+		const onSnapshotChange = vi.fn();
+
+		vi.spyOn(worktreeService, 'getWorktreesEffect').mockReturnValue(
+			Effect.promise(() => worktreesPromise),
+		);
+		const getDefaultBranchSpy = vi
+			.spyOn(worktreeService, 'getDefaultBranchEffect')
+			.mockReturnValue(Effect.succeed('main'));
+
+		const {lastFrame} = render(
+			<Menu
+				sessionManager={sessionManager}
+				worktreeService={worktreeService}
+				initialSnapshot={{
+					worktrees: [cachedWorktree],
+					defaultBranch: 'main',
+				}}
+				onSnapshotChange={onSnapshotChange}
+				onMenuAction={vi.fn()}
+				version="test"
+			/>,
+		);
+
+		// The cached rows are assembled in Menu's render effect, without waiting
+		// for the deferred Git refresh.
+		await new Promise(resolve => setTimeout(resolve, 0));
+		expect(lastFrame()).toContain('cached-branch');
+		expect(getDefaultBranchSpy).toHaveBeenCalled();
+
+		resolveWorktrees!([refreshedWorktree]);
+		await new Promise(resolve => setTimeout(resolve, 20));
+
+		expect(lastFrame()).toContain('refreshed-branch');
+		expect(onSnapshotChange).toHaveBeenCalledWith({
+			worktrees: [refreshedWorktree],
+			defaultBranch: 'main',
+			loadError: null,
+		});
+	});
+
+	it('should retain cached worktrees when a background refresh fails', async () => {
+		const {Effect} = await import('effect');
+		const {GitError} = await import('../types/errors.js');
+		const cachedWorktree = {
+			path: '/test/cached',
+			branch: 'cached-branch',
+			isMainWorktree: true,
+			hasSession: false,
+		};
+		const onSnapshotChange = vi.fn();
+
+		vi.spyOn(worktreeService, 'getWorktreesEffect').mockReturnValue(
+			Effect.fail(
+				new GitError({
+					command: 'git worktree list --porcelain',
+					exitCode: 1,
+					stderr: 'temporary failure',
+				}),
+			),
+		);
+		vi.spyOn(worktreeService, 'getDefaultBranchEffect').mockReturnValue(
+			Effect.succeed('main'),
+		);
+
+		const {lastFrame} = render(
+			<Menu
+				sessionManager={sessionManager}
+				worktreeService={worktreeService}
+				initialSnapshot={{
+					worktrees: [cachedWorktree],
+					defaultBranch: 'main',
+				}}
+				onSnapshotChange={onSnapshotChange}
+				onMenuAction={vi.fn()}
+				version="test"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 20));
+
+		expect(lastFrame()).toContain('cached-branch');
+		expect(lastFrame()).toContain('temporary failure');
+		expect(onSnapshotChange).toHaveBeenCalledWith({
+			worktrees: [cachedWorktree],
+			defaultBranch: 'main',
+			loadError: expect.stringContaining('temporary failure'),
+		});
+	});
 });
 
 describe('Menu component rendering', () => {

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 import {Effect} from 'effect';
@@ -35,6 +35,8 @@ import {configReader} from '../services/config/configReader.js';
 interface MenuProps {
 	sessionManager: SessionManager;
 	worktreeService: WorktreeService;
+	initialSnapshot?: MenuSnapshot;
+	onSnapshotChange?: (snapshot: MenuSnapshot) => void;
 	onMenuAction: (action: MenuAction) => void;
 	onSelectRecentProject?: (project: GitProject) => void;
 	error?: string | null;
@@ -42,6 +44,12 @@ interface MenuProps {
 	projectName?: string;
 	multiProject?: boolean;
 	version: string;
+}
+
+export interface MenuSnapshot {
+	worktrees: Worktree[];
+	defaultBranch: string | null;
+	loadError?: string | null;
 }
 
 interface CommonItem {
@@ -91,6 +99,8 @@ const formatGitError = (error: GitError): string => {
 const Menu: React.FC<MenuProps> = ({
 	sessionManager,
 	worktreeService,
+	initialSnapshot,
+	onSnapshotChange,
 	onMenuAction,
 	onSelectRecentProject,
 	error,
@@ -99,9 +109,20 @@ const Menu: React.FC<MenuProps> = ({
 	multiProject = false,
 	version,
 }) => {
-	const [baseWorktrees, setBaseWorktrees] = useState<Worktree[]>([]);
-	const [defaultBranch, setDefaultBranch] = useState<string | null>(null);
-	const [loadError, setLoadError] = useState<string | null>(null);
+	const [baseWorktrees, setBaseWorktrees] = useState<Worktree[]>(
+		() => initialSnapshot?.worktrees ?? [],
+	);
+	const [defaultBranch, setDefaultBranch] = useState<string | null>(
+		() => initialSnapshot?.defaultBranch ?? null,
+	);
+	const [loadError, setLoadError] = useState<string | null>(
+		() => initialSnapshot?.loadError ?? null,
+	);
+	const snapshotRef = useRef<MenuSnapshot>({
+		worktrees: initialSnapshot?.worktrees ?? [],
+		defaultBranch: initialSnapshot?.defaultBranch ?? null,
+		loadError: initialSnapshot?.loadError ?? null,
+	});
 	const worktrees = useGitStatus(baseWorktrees, defaultBranch);
 	const [sessions, setSessions] = useState<Session[]>([]);
 	const [items, setItems] = useState<MenuItem[]>([]);
@@ -132,15 +153,14 @@ const Menu: React.FC<MenuProps> = ({
 	useEffect(() => {
 		let cancelled = false;
 
-		// Load worktrees and default branch using Effect composition
-		// Chain getWorktreesEffect and getDefaultBranchEffect using Effect.flatMap
-		const loadWorktreesAndBranch = Effect.flatMap(
-			worktreeService.getWorktreesEffect(),
-			worktrees =>
-				Effect.map(worktreeService.getDefaultBranchEffect(), defaultBranch => ({
-					worktrees,
-					defaultBranch,
-				})),
+		// These operations are independent. Run them concurrently so the initial
+		// menu load waits only for the slower command.
+		const loadWorktreesAndBranch = Effect.all(
+			{
+				worktrees: worktreeService.getWorktreesEffect(),
+				defaultBranch: worktreeService.getDefaultBranchEffect(),
+			},
+			{concurrency: 'unbounded'},
 		);
 
 		Effect.runPromise(
@@ -171,16 +191,37 @@ const Menu: React.FC<MenuProps> = ({
 						setBaseWorktrees(result.worktrees);
 						setDefaultBranch(result.defaultBranch);
 						setLoadError(null);
+						const snapshot = {
+							worktrees: result.worktrees,
+							defaultBranch: result.defaultBranch,
+							loadError: null,
+						};
+						snapshotRef.current = snapshot;
+						onSnapshotChange?.(snapshot);
 					} else {
 						// Handle GitError with pattern matching
-						setLoadError(formatGitError(result.error));
+						const loadError = formatGitError(result.error);
+						setLoadError(loadError);
+						const snapshot = {
+							...snapshotRef.current,
+							loadError,
+						};
+						snapshotRef.current = snapshot;
+						onSnapshotChange?.(snapshot);
 					}
 				}
 			})
 			.catch((err: unknown) => {
 				// This catch should not normally be reached with Effect.match
 				if (!cancelled) {
-					setLoadError(String(err));
+					const loadError = String(err);
+					setLoadError(loadError);
+					const snapshot = {
+						...snapshotRef.current,
+						loadError,
+					};
+					snapshotRef.current = snapshot;
+					onSnapshotChange?.(snapshot);
 				}
 			});
 
@@ -210,7 +251,7 @@ const Menu: React.FC<MenuProps> = ({
 			sessionManager.off('sessionDestroyed', handleSessionChange);
 			sessionManager.off('sessionStateChanged', handleSessionChange);
 		};
-	}, [sessionManager, worktreeService, multiProject]);
+	}, [sessionManager, worktreeService, multiProject, onSnapshotChange]);
 
 	useEffect(() => {
 		// Prepare worktree items and calculate layout


### PR DESCRIPTION
## Summary
- render the previous worktree snapshot immediately when returning to the menu
- refresh worktrees and the default branch concurrently in the background
- update cached entries immediately after worktree creation and deletion

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test -- src/components/Menu.test.tsx src/components/App.test.tsx`
- [x] `bun run lint`
- [ ] `bun run test` (fails in pre-existing terminal Unicode capability tests, including duplicated `dist` tests)

Made with [Cursor](https://cursor.com)