### PR TITLE
feat: add open-shell-in-worktree action

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://github.com/user-attachments/assets/15914a88-e288-4ac9-94d5-8127f2e19dbf
 - Switch between sessions seamlessly
 - Visual status indicators for session states (busy, waiting, idle)
 - Create, merge, and delete worktrees from within the app
+- Open a plain shell in a worktree's directory (Session Actions → `O`)
 - **Copy Claude Code session data** between worktrees to maintain conversation context
 - Configurable keyboard shortcuts
 - Command presets with automatic fallback support

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1111,6 +1111,21 @@ const App: React.FC<AppProps> = ({
 						{forceNew: true},
 					);
 					return;
+				case 'openShell':
+					setView('creating-session');
+					try {
+						const shellSession =
+							await sessionManager.createShellSession(worktreePath);
+						navigateToSession(shellSession);
+					} catch (err) {
+						setError(
+							`Failed to open shell: ${
+								err instanceof Error ? err.message : String(err)
+							}`,
+						);
+						navigateWithClear('menu');
+					}
+					return;
 				case 'rename':
 					setRenameTarget({
 						id: targetSession.id,

--- a/src/components/ConfigureCommand.tsx
+++ b/src/components/ConfigureCommand.tsx
@@ -32,6 +32,7 @@ const createStrategyItems = (): {
 		cline: {label: 'Cline', value: 'cline'},
 		opencode: {label: 'OpenCode', value: 'opencode'},
 		kimi: {label: 'Kimi', value: 'kimi'},
+		shell: {label: 'Shell (no agent detection)', value: 'shell'},
 	};
 
 	return Object.values(strategies);
@@ -50,6 +51,7 @@ const DEFAULT_COMMANDS: Record<StateDetectionStrategy, string> = {
 	cline: 'cline',
 	opencode: 'opencode',
 	kimi: 'kimi',
+	shell: 'bash',
 };
 
 interface ConfigureCommandProps {
@@ -81,6 +83,8 @@ const formatDetectionStrategy = (strategy: string | undefined): string => {
 			return 'OpenCode';
 		case 'kimi':
 			return 'Kimi';
+		case 'shell':
+			return 'Shell';
 		default:
 			return 'Claude';
 	}

--- a/src/components/SessionActions.tsx
+++ b/src/components/SessionActions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 
-export type SessionActionType = 'newSession' | 'rename' | 'kill';
+export type SessionActionType = 'newSession' | 'openShell' | 'rename' | 'kill';
 
 interface SessionActionsProps {
 	sessionLabel: string;
@@ -12,6 +12,7 @@ interface SessionActionsProps {
 
 const items: Array<{label: string; value: SessionActionType}> = [
 	{label: 'S  New session in same directory', value: 'newSession'},
+	{label: 'O  Open shell in this directory', value: 'openShell'},
 	{label: 'R  Rename this session', value: 'rename'},
 	{label: 'X  Close session', value: 'kill'},
 ];
@@ -30,6 +31,9 @@ const SessionActions: React.FC<SessionActionsProps> = ({
 		switch (input.toLowerCase()) {
 			case 's':
 				onSelect('newSession');
+				break;
+			case 'o':
+				onSelect('openShell');
 				break;
 			case 'r':
 				onSelect('rename');
@@ -52,7 +56,7 @@ const SessionActions: React.FC<SessionActionsProps> = ({
 				<SelectInput items={items} onSelect={item => onSelect(item.value)} />
 			</Box>
 			<Box marginTop={1}>
-				<Text dimColor>S/R/X or arrow keys + Enter | Escape to cancel</Text>
+				<Text dimColor>S/O/R/X or arrow keys + Enter | Escape to cancel</Text>
 			</Box>
 		</Box>
 	);

--- a/src/services/sessionManager.ts
+++ b/src/services/sessionManager.ts
@@ -566,6 +566,29 @@ export class SessionManager extends EventEmitter implements ISessionManager {
 		});
 	}
 
+	/**
+	 * Create a plain shell session in the given worktree directory.
+	 *
+	 * Unlike agent sessions, this spawns the user's login shell (`$SHELL`, or
+	 * `/bin/sh` as a fallback) with no arguments and uses the always-idle
+	 * 'shell' detection strategy. It coexists with any agent session already
+	 * running in the same worktree.
+	 *
+	 * @param {string} worktreePath - Path to the worktree
+	 * @returns {Promise<Session>} The created shell session
+	 */
+	async createShellSession(worktreePath: string): Promise<Session> {
+		const shell = process.env['SHELL'] ?? '/bin/sh';
+		const ptyProcess = await this.spawn(shell, [], worktreePath);
+
+		return this.createSessionInternal(worktreePath, ptyProcess, {
+			isPrimaryCommand: false,
+			command: shell,
+			presetName: 'Shell',
+			detectionStrategy: 'shell',
+		});
+	}
+
 	private setupDataHandler(session: Session): void {
 		// This handler always runs for all data
 		session.process.onData((data: string) => {

--- a/src/services/stateDetector/index.ts
+++ b/src/services/stateDetector/index.ts
@@ -8,6 +8,7 @@ import {GitHubCopilotStateDetector} from './github-copilot.js';
 import {ClineStateDetector} from './cline.js';
 import {OpenCodeStateDetector} from './opencode.js';
 import {KimiStateDetector} from './kimi.js';
+import {ShellStateDetector} from './shell.js';
 
 export function createStateDetector(
 	strategy: StateDetectionStrategy = 'claude',
@@ -29,6 +30,8 @@ export function createStateDetector(
 			return new OpenCodeStateDetector();
 		case 'kimi':
 			return new KimiStateDetector();
+		case 'shell':
+			return new ShellStateDetector();
 		default:
 			return new ClaudeStateDetector();
 	}

--- a/src/services/stateDetector/shell.test.ts
+++ b/src/services/stateDetector/shell.test.ts
@@ -1,0 +1,36 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {ShellStateDetector} from './shell.js';
+import {createMockTerminal} from './testUtils.js';
+
+describe('ShellStateDetector', () => {
+	let detector: ShellStateDetector;
+
+	beforeEach(() => {
+		detector = new ShellStateDetector();
+	});
+
+	it('always reports idle, regardless of terminal content', () => {
+		const terminal = createMockTerminal([
+			'user@host project % ls',
+			'src  package.json  README.md',
+			'user@host project % ',
+		]);
+		expect(detector.detectState(terminal, 'busy')).toBe('idle');
+	});
+
+	it('reports idle for an empty terminal', () => {
+		const terminal = createMockTerminal([]);
+		expect(detector.detectState(terminal, 'idle')).toBe('idle');
+	});
+
+	it('reports idle even when output resembles agent busy text', () => {
+		const terminal = createMockTerminal(['esc to interrupt', 'Thinking...']);
+		expect(detector.detectState(terminal, 'idle')).toBe('idle');
+	});
+
+	it('never reports background tasks or team members', () => {
+		const terminal = createMockTerminal(['some output']);
+		expect(detector.detectBackgroundTask(terminal)).toBe(0);
+		expect(detector.detectTeamMembers(terminal)).toBe(0);
+	});
+});

--- a/src/services/stateDetector/shell.ts
+++ b/src/services/stateDetector/shell.ts
@@ -1,0 +1,23 @@
+import {SessionState, Terminal} from '../../types/index.js';
+import {BaseStateDetector} from './base.js';
+
+/**
+ * State detector for plain shell sessions.
+ *
+ * A shell is not an agent, so there is no "thinking"/"waiting for approval"
+ * output to parse. It is always considered idle; the worktree list simply
+ * shows it as a running session without agent-style busy indicators.
+ */
+export class ShellStateDetector extends BaseStateDetector {
+	detectState(_terminal: Terminal, _currentState: SessionState): SessionState {
+		return 'idle';
+	}
+
+	detectBackgroundTask(_terminal: Terminal): number {
+		return 0;
+	}
+
+	detectTeamMembers(_terminal: Terminal): number {
+		return 0;
+	}
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,7 +23,8 @@ export type StateDetectionStrategy =
 	| 'github-copilot'
 	| 'cline'
 	| 'opencode'
-	| 'kimi';
+	| 'kimi'
+	| 'shell';
 
 export interface Worktree {
 	path: string;


### PR DESCRIPTION
## What

Adds an **"Open shell in this directory"** action (key `O`) to the Session Actions menu, so you can open a plain shell in a worktree's directory without leaving ccmanager.

Closes #229.

## How

A shell is just another command spawned into the worktree, so it reuses the existing PTY session pipeline rather than introducing a second PTY per session (the approach explored in the earlier #22):

- `SessionManager.createShellSession(worktreePath)` spawns `$SHELL` (falling back to `/bin/sh`) with no args via the same `spawn()` used for agent sessions, as a non-primary session that coexists with any agent session in the same worktree.
- New `'openShell'` entry in `SessionActions` (menu item + `O` key), routed through a new `case` in `App.tsx`'s `handleSessionAction` that navigates into the normal session view — same flow as `newSession`.
- A `'shell'` state-detection strategy whose detector always reports `idle`, since a plain shell has no agent output to parse (avoids false busy/waiting icons in the worktree list).

## Tests

- New `shell.test.ts` (4 cases) covering always-idle behaviour, empty terminal, agent-like output, and zero background/team counts.
- `bun run lint`, `bun run typecheck`, and the full `bun run test` suite (1792 passing) all green.

## Design note

Because `StateDetectionStrategy` is enforced via `Record<StateDetectionStrategy, …>` in `ConfigureCommand.tsx`, adding the `shell` strategy also surfaces it in the preset detection-strategy picker (labelled "Shell (no agent detection)"). That's harmless and arguably useful for making a shell preset, but if you'd prefer to keep it out of the agent-strategy picker I'm happy to hide it there in a follow-up.
