### PR TITLE
feat: add MiniMax auto-approval verifier

### DIFF
--- a/docs/auto-approval.md
+++ b/docs/auto-approval.md
@@ -1,35 +1,75 @@
 # Auto Approval (Experimental)
 
 ## Overview
+
 - Auto approval lets CCManager decide whether a paused Claude Code session can continue without you typing Enter.
 - When enabled, CCManager checks a waiting prompt and either auto-approves it or leaves it for your manual review.
 - The feature is experimental—expect occasional false positives/negatives and keep an eye on prompts that matter.
 - Default expectation: CCManager assumes the `claude` CLI is already installed and on your PATH; it is **not** bundled. If you don’t have `claude`, either install it or set a custom command.
 
 ## Enabling It (UI)
+
 1. Run `ccmanager`.
 2. Open **Global Configuration** → **Other & Experimental**.
 3. Choose **Auto Approval (experimental)** to toggle it to ✅ Enabled.
-4. (Optional) Pick **Edit Custom Command** to supply your own approver command (see "Custom Command" below).
-5. Select **Save Changes**.
+4. Choose the verifier. Select **MiniMax** to configure its model, region, and compatibility protocol.
+5. (Optional) Pick **Edit Custom Command** to supply your own approver command (see "Custom Command" below).
+6. Select **Save Changes**.
 
 ## Enabling It (config file)
+
 If you prefer editing the config directly:
+
 - Linux/macOS: `~/.config/ccmanager/config.json`
 - Windows: `%APPDATA%\\ccmanager\\config.json`
 
 Set:
+
 ```json
 {
-  "autoApproval": {
-    "enabled": true
-  }
+	"autoApproval": {
+		"enabled": true
+	}
 }
 ```
+
 Leave `"enabled": false` to turn it off. You can also add `"customCommand": "my-checker"` if you want CCManager to call something other than the default Claude command.
 
+## MiniMax Verifier
+
+Set `verifier` to `minimax` to call MiniMax directly:
+
+```json
+{
+	"autoApproval": {
+		"enabled": true,
+		"verifier": "minimax",
+		"minimaxModel": "MiniMax-M3",
+		"minimaxRegion": "global_en",
+		"minimaxProtocol": "openai"
+	}
+}
+```
+
+Supported settings:
+
+- `minimaxModel`: `MiniMax-M3` or `MiniMax-M2.7`.
+- `minimaxRegion`: `global_en` or `cn_zh`.
+- `minimaxProtocol`: `openai` or `anthropic`.
+- Credential: set `MINIMAX_API_KEY` in the environment before starting CCManager.
+
+The verifier uses the matching documented endpoint:
+
+| Region | OpenAI-compatible             | Anthropic-compatible                 |
+| ------ | ----------------------------- | ------------------------------------ |
+| Global | `https://api.minimax.io/v1`   | `https://api.minimax.io/anthropic`   |
+| CN     | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+Responses must match the same `{"needsPermission": true|false, "reason"?: "short string"}` contract used by the default verifier. Missing credentials, unsupported settings, request failures, timeouts, malformed response envelopes, and schema mismatches all require manual approval.
+
 ## Custom Command (optional power users)
-- Purpose: replace the default `claude --model haiku` call (uses your installed `claude` CLI; CCManager does not bundle it) with any executable or script you control.
+
+- Purpose: override the selected verifier with any executable or script you control.
 - How CCManager calls it:
   - Runs via your shell: `spawn(customCommand, [], {shell: true})`.
   - Environment variables provided:
@@ -51,13 +91,15 @@ Leave `"enabled": false` to turn it off. You can also add `"customCommand": "my-
   Set this command as your custom command in **Other & Experimental**. CCManager will pass `DEFAULT_PROMPT`/`TERMINAL_OUTPUT`, Codex will write the JSON result to `/tmp/codex-output.json`, and CCManager will read and parse it.
 
 ## How It Works
+
 - **When it runs:** If a session enters a prompt state that normally waits for your input, CCManager marks it as “Auto-approval pending…” and grabs the most recent terminal output (up to 300 lines).
-- **Approval step:** By default CCManager runs `claude --model haiku -p --output-format json --json-schema …`, passing the captured terminal output into the prompt so Claude can judge whether the action needs your permission.
-- **Decision:** If Claude replies that permission is not needed and the session is still waiting, CCManager sends a carriage return (`\r`) to the session—equivalent to pressing Enter for you. If Claude says permission is needed, the check times out (60s), errors, or you press any key while it’s pending, auto approval stops and the session stays in manual approval with a short reason displayed.
+- **Approval step:** CCManager runs the selected verifier with the captured terminal output and the auto-approval JSON schema. A custom command, when configured, takes precedence.
+- **Decision:** If the verifier replies that permission is not needed and the session is still waiting, CCManager sends a carriage return (`\r`) to the session—equivalent to pressing Enter for you. If permission is needed, the check reaches its configured timeout, errors, or you press any key while it’s pending, auto approval stops and the session stays in manual approval with a short reason displayed.
 - **Safety:** When the helper fails for any reason, CCManager defaults to requiring your approval instead of proceeding automatically.
 
 ## Things to Keep in Mind
-- Requires the `claude` CLI to be installed and accessible in your PATH (or supply a custom command).
+
+- The default verifier requires the `claude` CLI to be installed and accessible in your PATH. The MiniMax verifier requires `MINIMAX_API_KEY` instead.
 - Auto-approval only sends `\r` (Enter). It is unsuitable for CLIs that expect arbitrary typed input beyond a simple confirmation.
 - Experimental: review critical prompts yourself, especially before running commands that change files or system settings.
 - You can always interrupt by typing anything while the status bar says “Auto-approval pending…”.

--- a/src/components/ConfigureOther.test.tsx
+++ b/src/components/ConfigureOther.test.tsx
@@ -105,6 +105,7 @@ describe('ConfigureOther', () => {
 		);
 
 		expect(lastFrame()).toContain('Other & Experimental Settings');
+		expect(lastFrame()).toContain('Verifier: Default CLI');
 		expect(lastFrame()).toContain('Auto Approval (experimental): ✅ Enabled');
 		expect(lastFrame()).toContain('Custom auto-approval command: Empty');
 		expect(lastFrame()).toContain('Edit Custom Command');
@@ -127,5 +128,27 @@ describe('ConfigureOther', () => {
 		expect(lastFrame()).toContain('Custom auto-approval command:');
 		expect(lastFrame()).toContain('jq -n');
 		expect(lastFrame()).toContain('Edit Custom Command');
+	});
+
+	it('shows MiniMax verifier settings', () => {
+		mockFns.getAutoApprovalConfig.mockReturnValue({
+			enabled: true,
+			timeout: DEFAULT_TIMEOUT_SECONDS,
+			verifier: 'minimax',
+			minimaxModel: 'MiniMax-M2.7',
+			minimaxRegion: 'cn_zh',
+			minimaxProtocol: 'anthropic',
+		});
+
+		const {lastFrame} = render(
+			<ConfigEditorProvider scope="global">
+				<ConfigureOther onComplete={vi.fn()} />
+			</ConfigEditorProvider>,
+		);
+
+		expect(lastFrame()).toContain('Verifier: MiniMax');
+		expect(lastFrame()).toContain('MiniMax Model: MiniMax-M2.7');
+		expect(lastFrame()).toContain('MiniMax Region: CN');
+		expect(lastFrame()).toContain('MiniMax Protocol: Anthropic-compatible');
 	});
 });

--- a/src/components/ConfigureOther.tsx
+++ b/src/components/ConfigureOther.tsx
@@ -3,7 +3,22 @@ import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 import {useConfigEditor} from '../contexts/ConfigEditorContext.js';
 import {shortcutManager} from '../services/shortcutManager.js';
-import {DEFAULT_TIMEOUT_SECONDS} from '../constants/autoApproval.js';
+import {
+	DEFAULT_AUTO_APPROVAL_VERIFIER,
+	DEFAULT_MINIMAX_MODEL,
+	DEFAULT_MINIMAX_PROTOCOL,
+	DEFAULT_MINIMAX_REGION,
+	DEFAULT_TIMEOUT_SECONDS,
+	MINIMAX_MODELS,
+	MINIMAX_PROTOCOLS,
+	MINIMAX_REGIONS,
+} from '../constants/autoApproval.js';
+import type {
+	AutoApprovalVerifier,
+	MiniMaxModel,
+	MiniMaxProtocol,
+	MiniMaxRegion,
+} from '../types/index.js';
 import ConfigureCustomCommand from './ConfigureCustomCommand.js';
 import ConfigureTimeout from './ConfigureTimeout.js';
 import CustomCommandSummary from './CustomCommandSummary.js';
@@ -18,6 +33,11 @@ interface MenuItem {
 }
 
 type OtherView = 'main' | 'customCommand' | 'timeout';
+
+const nextValue = <T,>(values: readonly T[], value: T): T => {
+	const index = values.indexOf(value);
+	return values[(index + 1) % values.length]!;
+};
 
 const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 	const configEditor = useConfigEditor();
@@ -37,6 +57,18 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 		autoApprovalConfig.timeout ?? DEFAULT_TIMEOUT_SECONDS,
 	);
 	const [timeoutDraft, setTimeoutDraft] = useState(timeout);
+	const [verifier, setVerifier] = useState<AutoApprovalVerifier>(
+		autoApprovalConfig.verifier ?? DEFAULT_AUTO_APPROVAL_VERIFIER,
+	);
+	const [minimaxModel, setMinimaxModel] = useState<MiniMaxModel>(
+		autoApprovalConfig.minimaxModel ?? DEFAULT_MINIMAX_MODEL,
+	);
+	const [minimaxRegion, setMinimaxRegion] = useState<MiniMaxRegion>(
+		autoApprovalConfig.minimaxRegion ?? DEFAULT_MINIMAX_REGION,
+	);
+	const [minimaxProtocol, setMinimaxProtocol] = useState<MiniMaxProtocol>(
+		autoApprovalConfig.minimaxProtocol ?? DEFAULT_MINIMAX_PROTOCOL,
+	);
 	// Show if inheriting from global (for project scope)
 	const isInheriting =
 		scope === 'project' && !configEditor.hasProjectOverride('autoApproval');
@@ -58,6 +90,26 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 	});
 
 	const menuItems: MenuItem[] = [
+		{
+			label: `Verifier: ${verifier === 'minimax' ? 'MiniMax' : 'Default CLI'}`,
+			value: 'verifier',
+		},
+		...(verifier === 'minimax'
+			? ([
+					{
+						label: `MiniMax Model: ${minimaxModel}`,
+						value: 'minimaxModel',
+					},
+					{
+						label: `MiniMax Region: ${minimaxRegion === 'global_en' ? 'Global' : 'CN'}`,
+						value: 'minimaxRegion',
+					},
+					{
+						label: `MiniMax Protocol: ${minimaxProtocol === 'openai' ? 'OpenAI-compatible' : 'Anthropic-compatible'}`,
+						value: 'minimaxProtocol',
+					},
+				] satisfies MenuItem[])
+			: []),
 		{
 			label: `Auto Approval (experimental): ${autoApprovalEnabled ? '✅ Enabled' : '❌ Disabled'}`,
 			value: 'toggleAutoApproval',
@@ -82,6 +134,18 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 
 	const handleSelect = (item: MenuItem) => {
 		switch (item.value) {
+			case 'verifier':
+				setVerifier(verifier === 'minimax' ? 'default' : 'minimax');
+				break;
+			case 'minimaxModel':
+				setMinimaxModel(nextValue(MINIMAX_MODELS, minimaxModel));
+				break;
+			case 'minimaxRegion':
+				setMinimaxRegion(nextValue(MINIMAX_REGIONS, minimaxRegion));
+				break;
+			case 'minimaxProtocol':
+				setMinimaxProtocol(nextValue(MINIMAX_PROTOCOLS, minimaxProtocol));
+				break;
 			case 'toggleAutoApproval':
 				setAutoApprovalEnabled(!autoApprovalEnabled);
 				break;
@@ -98,6 +162,10 @@ const ConfigureOther: React.FC<ConfigureOtherProps> = ({onComplete}) => {
 					enabled: autoApprovalEnabled,
 					customCommand: customCommand.trim() || undefined,
 					timeout,
+					verifier,
+					...(verifier === 'minimax'
+						? {minimaxModel, minimaxRegion, minimaxProtocol}
+						: {}),
 				});
 				onComplete();
 				break;

--- a/src/constants/autoApproval.ts
+++ b/src/constants/autoApproval.ts
@@ -2,3 +2,25 @@
  * Default timeout in seconds for auto-approval verification.
  */
 export const DEFAULT_TIMEOUT_SECONDS = 120;
+
+export const DEFAULT_AUTO_APPROVAL_VERIFIER = 'default' as const;
+
+export const MINIMAX_MODELS = ['MiniMax-M3', 'MiniMax-M2.7'] as const;
+export const DEFAULT_MINIMAX_MODEL = MINIMAX_MODELS[0];
+
+export const MINIMAX_REGIONS = ['global_en', 'cn_zh'] as const;
+export const DEFAULT_MINIMAX_REGION = MINIMAX_REGIONS[0];
+
+export const MINIMAX_PROTOCOLS = ['openai', 'anthropic'] as const;
+export const DEFAULT_MINIMAX_PROTOCOL = MINIMAX_PROTOCOLS[0];
+
+export const MINIMAX_ENDPOINTS = {
+	global_en: {
+		openai: 'https://api.minimax.io/v1',
+		anthropic: 'https://api.minimax.io/anthropic',
+	},
+	cn_zh: {
+		openai: 'https://api.minimaxi.com/v1',
+		anthropic: 'https://api.minimaxi.com/anthropic',
+	},
+} as const;

--- a/src/services/autoApprovalVerifier.test.ts
+++ b/src/services/autoApprovalVerifier.test.ts
@@ -12,7 +12,11 @@ import {
 	DANGEROUS_COMMAND_PATTERNS,
 } from './autoApprovalVerifier.js';
 
-const execFileMock = vi.fn();
+const {execFileMock, getAutoApprovalConfigMock, fetchMock} = vi.hoisted(() => ({
+	execFileMock: vi.fn(),
+	getAutoApprovalConfigMock: vi.fn(),
+	fetchMock: vi.fn(),
+}));
 
 vi.mock('child_process', () => ({
 	execFile: (...args: unknown[]) => execFileMock(...args),
@@ -20,13 +24,30 @@ vi.mock('child_process', () => ({
 
 vi.mock('./config/configReader.js', () => ({
 	configReader: {
-		getAutoApprovalConfig: vi.fn().mockReturnValue({enabled: false}),
+		getAutoApprovalConfig: getAutoApprovalConfigMock,
 	},
 }));
+
+const responseWithJson = (
+	payload: unknown,
+	ok = true,
+	status = 200,
+): {ok: boolean; status: number; json: () => Promise<unknown>} => ({
+	ok,
+	status,
+	json: vi.fn().mockResolvedValue(payload),
+});
+
+let originalMiniMaxApiKey: string | undefined;
 
 describe('AutoApprovalVerifier', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
+		getAutoApprovalConfigMock.mockReturnValue({enabled: false});
+		fetchMock.mockReset();
+		vi.stubGlobal('fetch', fetchMock);
+		originalMiniMaxApiKey = process.env['MINIMAX_API_KEY'];
+		delete process.env['MINIMAX_API_KEY'];
 		execFileMock.mockImplementation(
 			(
 				_cmd: string,
@@ -50,6 +71,12 @@ describe('AutoApprovalVerifier', () => {
 	});
 
 	afterEach(() => {
+		if (originalMiniMaxApiKey === undefined) {
+			delete process.env['MINIMAX_API_KEY'];
+		} else {
+			process.env['MINIMAX_API_KEY'] = originalMiniMaxApiKey;
+		}
+		vi.unstubAllGlobals();
 		vi.useRealTimers();
 		vi.clearAllMocks();
 	});
@@ -83,6 +110,122 @@ describe('AutoApprovalVerifier', () => {
 		);
 		expect(child.stdin.write).toHaveBeenCalledTimes(1);
 		expect(child.stdin.end).toHaveBeenCalledTimes(1);
+	});
+
+	it('uses the configured MiniMax OpenAI-compatible endpoint', async () => {
+		process.env['MINIMAX_API_KEY'] = 'test-key';
+		getAutoApprovalConfigMock.mockReturnValue({
+			enabled: false,
+			verifier: 'minimax',
+			minimaxModel: 'MiniMax-M3',
+			minimaxRegion: 'global_en',
+			minimaxProtocol: 'openai',
+		});
+		fetchMock.mockResolvedValue(
+			responseWithJson({
+				choices: [{message: {content: '{"needsPermission":false}'}}],
+			}),
+		);
+
+		const {autoApprovalVerifier} = await import('./autoApprovalVerifier.js');
+		const result = await Effect.runPromise(
+			autoApprovalVerifier.verifyNeedsPermission('safe output'),
+		);
+
+		expect(result).toEqual({needsPermission: false});
+		expect(execFileMock).not.toHaveBeenCalled();
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.minimax.io/v1/chat/completions',
+			expect.objectContaining({
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					authorization: 'Bearer test-key',
+				},
+			}),
+		);
+		const request = JSON.parse(fetchMock.mock.calls[0]![1].body as string) as {
+			model: string;
+			messages: Array<{content: string}>;
+		};
+		expect(request.model).toBe('MiniMax-M3');
+		expect(request.messages[0]!.content).toContain('needsPermission');
+	});
+
+	it('uses the configured MiniMax Anthropic-compatible CN endpoint', async () => {
+		process.env['MINIMAX_API_KEY'] = 'test-key';
+		getAutoApprovalConfigMock.mockReturnValue({
+			enabled: false,
+			verifier: 'minimax',
+			minimaxModel: 'MiniMax-M2.7',
+			minimaxRegion: 'cn_zh',
+			minimaxProtocol: 'anthropic',
+		});
+		fetchMock.mockResolvedValue(
+			responseWithJson({
+				content: [
+					{type: 'text', text: '{"needsPermission":true,"reason":"Review"}'},
+				],
+			}),
+		);
+
+		const {autoApprovalVerifier} = await import('./autoApprovalVerifier.js');
+		const result = await Effect.runPromise(
+			autoApprovalVerifier.verifyNeedsPermission('unsafe output'),
+		);
+
+		expect(result).toEqual({needsPermission: true, reason: 'Review'});
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.minimaxi.com/anthropic/v1/messages',
+			expect.objectContaining({
+				headers: {
+					'content-type': 'application/json',
+					'x-api-key': 'test-key',
+					'anthropic-version': '2023-06-01',
+				},
+			}),
+		);
+		const request = JSON.parse(fetchMock.mock.calls[0]![1].body as string) as {
+			model: string;
+		};
+		expect(request.model).toBe('MiniMax-M2.7');
+	});
+
+	it('fails closed when the MiniMax credential is missing', async () => {
+		getAutoApprovalConfigMock.mockReturnValue({
+			enabled: false,
+			verifier: 'minimax',
+		});
+
+		const {autoApprovalVerifier} = await import('./autoApprovalVerifier.js');
+		const result = await Effect.runPromise(
+			autoApprovalVerifier.verifyNeedsPermission('safe output'),
+		);
+
+		expect(result.needsPermission).toBe(true);
+		expect(result.reason).toContain('MINIMAX_API_KEY');
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('fails closed when MiniMax returns a response outside the JSON schema', async () => {
+		process.env['MINIMAX_API_KEY'] = 'test-key';
+		getAutoApprovalConfigMock.mockReturnValue({
+			enabled: false,
+			verifier: 'minimax',
+		});
+		fetchMock.mockResolvedValue(
+			responseWithJson({
+				choices: [{message: {content: '{"needsPermission":"false"}'}}],
+			}),
+		);
+
+		const {autoApprovalVerifier} = await import('./autoApprovalVerifier.js');
+		const result = await Effect.runPromise(
+			autoApprovalVerifier.verifyNeedsPermission('safe output'),
+		);
+
+		expect(result.needsPermission).toBe(true);
+		expect(result.reason).toContain('JSON');
 	});
 
 	it('returns true when Claude response indicates permission is needed', async () => {

--- a/src/services/autoApprovalVerifier.ts
+++ b/src/services/autoApprovalVerifier.ts
@@ -1,8 +1,24 @@
 import {Effect} from 'effect';
 import {ProcessError} from '../types/errors.js';
-import {AutoApprovalResponse} from '../types/index.js';
+import type {
+	AutoApprovalConfig,
+	AutoApprovalResponse,
+	MiniMaxModel,
+	MiniMaxProtocol,
+	MiniMaxRegion,
+} from '../types/index.js';
 import {configReader} from './config/configReader.js';
-import {DEFAULT_TIMEOUT_SECONDS} from '../constants/autoApproval.js';
+import {
+	DEFAULT_AUTO_APPROVAL_VERIFIER,
+	DEFAULT_MINIMAX_MODEL,
+	DEFAULT_MINIMAX_PROTOCOL,
+	DEFAULT_MINIMAX_REGION,
+	DEFAULT_TIMEOUT_SECONDS,
+	MINIMAX_ENDPOINTS,
+	MINIMAX_MODELS,
+	MINIMAX_PROTOCOLS,
+	MINIMAX_REGIONS,
+} from '../constants/autoApproval.js';
 import {logger} from '../utils/logger.js';
 import {
 	execFile,
@@ -411,10 +427,147 @@ export const checkDangerousPatterns = (
 const buildPrompt = (terminalOutput: string): string =>
 	PROMPT_TEMPLATE.replace(PLACEHOLDER.terminal, terminalOutput);
 
+const AUTO_APPROVAL_JSON_SCHEMA = {
+	type: 'object',
+	properties: {
+		needsPermission: {
+			type: 'boolean',
+			description: 'Whether user permission is needed before auto-approval',
+		},
+		reason: {
+			type: 'string',
+			description: 'Optional reason describing why user permission is needed',
+		},
+	},
+	required: ['needsPermission'],
+	additionalProperties: false,
+};
+
+const AUTO_APPROVAL_JSON_SCHEMA_TEXT = JSON.stringify(
+	AUTO_APPROVAL_JSON_SCHEMA,
+);
+
+const parseAutoApprovalResponse = (
+	responseText: string,
+): AutoApprovalResponse => {
+	const parsed: unknown = JSON.parse(responseText);
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		throw new SyntaxError('Auto-approval response must be a JSON object');
+	}
+
+	const response = parsed as Record<string, unknown>;
+	const keys = Object.keys(response);
+	if (
+		!Object.prototype.hasOwnProperty.call(response, 'needsPermission') ||
+		typeof response['needsPermission'] !== 'boolean' ||
+		keys.some(key => key !== 'needsPermission' && key !== 'reason') ||
+		(response['reason'] !== undefined && typeof response['reason'] !== 'string')
+	) {
+		throw new SyntaxError(
+			'Auto-approval response does not match its JSON schema',
+		);
+	}
+
+	return response['reason'] === undefined
+		? {needsPermission: response['needsPermission']}
+		: {
+				needsPermission: response['needsPermission'],
+				reason: response['reason'],
+			};
+};
+
+const isMiniMaxModel = (value: unknown): value is MiniMaxModel =>
+	typeof value === 'string' &&
+	(MINIMAX_MODELS as readonly string[]).includes(value);
+
+const isMiniMaxRegion = (value: unknown): value is MiniMaxRegion =>
+	typeof value === 'string' &&
+	(MINIMAX_REGIONS as readonly string[]).includes(value);
+
+const isMiniMaxProtocol = (value: unknown): value is MiniMaxProtocol =>
+	typeof value === 'string' &&
+	(MINIMAX_PROTOCOLS as readonly string[]).includes(value);
+
+interface MiniMaxSettings {
+	model: MiniMaxModel;
+	region: MiniMaxRegion;
+	protocol: MiniMaxProtocol;
+	baseUrl: string;
+}
+
+const getMiniMaxSettings = (config: AutoApprovalConfig): MiniMaxSettings => {
+	const model = config.minimaxModel ?? DEFAULT_MINIMAX_MODEL;
+	const region = config.minimaxRegion ?? DEFAULT_MINIMAX_REGION;
+	const protocol = config.minimaxProtocol ?? DEFAULT_MINIMAX_PROTOCOL;
+
+	if (!isMiniMaxModel(model)) {
+		throw new Error('Unsupported MiniMax verifier model');
+	}
+	if (!isMiniMaxRegion(region)) {
+		throw new Error('Unsupported MiniMax verifier region');
+	}
+	if (!isMiniMaxProtocol(protocol)) {
+		throw new Error('Unsupported MiniMax verifier protocol');
+	}
+
+	return {
+		model,
+		region,
+		protocol,
+		baseUrl: MINIMAX_ENDPOINTS[region][protocol],
+	};
+};
+
+const getTextFromContent = (content: unknown): string => {
+	if (typeof content === 'string') return content;
+	if (!Array.isArray(content)) {
+		throw new Error('MiniMax verifier response did not contain text content');
+	}
+
+	const text = content
+		.map(block => {
+			if (
+				typeof block === 'object' &&
+				block !== null &&
+				'text' in block &&
+				typeof block.text === 'string'
+			) {
+				return block.text;
+			}
+			return '';
+		})
+		.join('');
+
+	if (!text) {
+		throw new Error('MiniMax verifier response did not contain text content');
+	}
+	return text;
+};
+
+const getMiniMaxResponseText = (
+	payload: unknown,
+	protocol: MiniMaxProtocol,
+): string => {
+	if (typeof payload !== 'object' || payload === null) {
+		throw new Error('MiniMax verifier response was not an object');
+	}
+
+	if (protocol === 'openai') {
+		const choices = (payload as {choices?: unknown}).choices;
+		if (!Array.isArray(choices) || choices.length === 0) {
+			throw new Error('MiniMax verifier response did not contain a choice');
+		}
+		const message = (choices[0] as {message?: {content?: unknown}})?.message;
+		return getTextFromContent(message?.content);
+	}
+
+	return getTextFromContent((payload as {content?: unknown}).content);
+};
+
 /**
  * Service to verify if auto-approval should be granted for pending states
- * Uses Claude Haiku model to analyze terminal output and determine if
- * user permission is required before proceeding
+ * Uses the configured verifier to determine if user permission is required
+ * before proceeding.
  */
 export class AutoApprovalVerifier {
 	private readonly model = 'haiku';
@@ -530,6 +683,87 @@ export class AutoApprovalVerifier {
 				}
 			});
 		});
+	}
+
+	private async runMiniMaxPrompt(
+		prompt: string,
+		jsonSchema: string,
+		config: AutoApprovalConfig,
+		signal?: AbortSignal,
+	): Promise<string> {
+		const settings = getMiniMaxSettings(config);
+		const apiKey = process.env['MINIMAX_API_KEY']?.trim();
+		if (!apiKey) {
+			throw new Error('MINIMAX_API_KEY is required for the MiniMax verifier');
+		}
+
+		const requestPrompt = `${prompt}\n\nReturn JSON matching this schema exactly:\n${jsonSchema}`;
+		const url =
+			settings.protocol === 'openai'
+				? `${settings.baseUrl}/chat/completions`
+				: `${settings.baseUrl}/v1/messages`;
+		const headers: Record<string, string> = {
+			'content-type': 'application/json',
+		};
+		if (settings.protocol === 'openai') {
+			headers['authorization'] = `Bearer ${apiKey}`;
+		} else {
+			headers['x-api-key'] = apiKey;
+			headers['anthropic-version'] = '2023-06-01';
+		}
+
+		const body =
+			settings.protocol === 'openai'
+				? {
+						model: settings.model,
+						messages: [{role: 'user', content: requestPrompt}],
+					}
+				: {
+						model: settings.model,
+						max_tokens: 1024,
+						messages: [{role: 'user', content: requestPrompt}],
+					};
+
+		const controller = new AbortController();
+		let timedOut = false;
+		const timeoutMs = getTimeoutMs();
+		const timeoutId = setTimeout(() => {
+			timedOut = true;
+			controller.abort();
+		}, timeoutMs);
+		const abortListener = () => controller.abort();
+
+		try {
+			if (signal) {
+				if (signal.aborted) throw createAbortError();
+				signal.addEventListener('abort', abortListener, {once: true});
+			}
+
+			const response = await globalThis.fetch(url, {
+				method: 'POST',
+				headers,
+				body: JSON.stringify(body),
+				signal: controller.signal,
+			});
+			if (!response.ok) {
+				throw new Error(
+					`MiniMax verifier request failed with status ${response.status}`,
+				);
+			}
+
+			return getMiniMaxResponseText(await response.json(), settings.protocol);
+		} catch (error) {
+			if (signal?.aborted) throw createAbortError();
+			if (timedOut) {
+				throw new Error(
+					`MiniMax verifier request timed out after ${timeoutMs / 1000}s`,
+				);
+			}
+			throw error instanceof Error ? error : new Error(String(error));
+		} finally {
+			clearTimeout(timeoutId);
+			signal?.removeEventListener('abort', abortListener);
+		}
 	}
 
 	private async runCustomCommand(
@@ -653,23 +887,7 @@ export class AutoApprovalVerifier {
 				const autoApprovalConfig = configReader.getAutoApprovalConfig();
 				const customCommand = autoApprovalConfig.customCommand?.trim();
 				const prompt = buildPrompt(terminalOutput);
-
-				const jsonSchema = JSON.stringify({
-					type: 'object',
-					properties: {
-						needsPermission: {
-							type: 'boolean',
-							description:
-								'Whether user permission is needed before auto-approval',
-						},
-						reason: {
-							type: 'string',
-							description:
-								'Optional reason describing why user permission is needed',
-						},
-					},
-					required: ['needsPermission'],
-				});
+				const jsonSchema = AUTO_APPROVAL_JSON_SCHEMA_TEXT;
 
 				const signal = options?.signal;
 
@@ -677,16 +895,31 @@ export class AutoApprovalVerifier {
 					throw createAbortError();
 				}
 
-				const responseText = customCommand
-					? await this.runCustomCommand(
-							customCommand,
-							prompt,
-							terminalOutput,
-							signal,
-						)
-					: await this.runClaudePrompt(prompt, jsonSchema, signal);
+				let responseText: string;
+				if (customCommand) {
+					responseText = await this.runCustomCommand(
+						customCommand,
+						prompt,
+						terminalOutput,
+						signal,
+					);
+				} else if (autoApprovalConfig.verifier === 'minimax') {
+					responseText = await this.runMiniMaxPrompt(
+						prompt,
+						jsonSchema,
+						autoApprovalConfig,
+						signal,
+					);
+				} else if (
+					autoApprovalConfig.verifier === undefined ||
+					autoApprovalConfig.verifier === DEFAULT_AUTO_APPROVAL_VERIFIER
+				) {
+					responseText = await this.runClaudePrompt(prompt, jsonSchema, signal);
+				} else {
+					throw new Error('Unsupported auto-approval verifier');
+				}
 
-				return JSON.parse(responseText) as AutoApprovalResponse;
+				return parseAutoApprovalResponse(responseText);
 			},
 			catch: (error: unknown) =>
 				error instanceof Error ? error : new Error(String(error)),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -187,6 +187,10 @@ export interface ConfigurationData {
 		enabled: boolean; // Whether auto-approval is enabled
 		customCommand?: string; // Custom verification command; must output JSON matching AutoApprovalResponse
 		timeout?: number; // Timeout in seconds for auto-approval verification (default: DEFAULT_TIMEOUT_SECONDS)
+		verifier?: AutoApprovalVerifier;
+		minimaxModel?: MiniMaxModel;
+		minimaxRegion?: MiniMaxRegion;
+		minimaxProtocol?: MiniMaxProtocol;
 	};
 }
 
@@ -197,7 +201,16 @@ export interface AutoApprovalConfig {
 	enabled: boolean;
 	customCommand?: string;
 	timeout?: number;
+	verifier?: AutoApprovalVerifier;
+	minimaxModel?: MiniMaxModel;
+	minimaxRegion?: MiniMaxRegion;
+	minimaxProtocol?: MiniMaxProtocol;
 }
+
+export type AutoApprovalVerifier = 'default' | 'minimax';
+export type MiniMaxModel = 'MiniMax-M3' | 'MiniMax-M2.7';
+export type MiniMaxRegion = 'global_en' | 'cn_zh';
+export type MiniMaxProtocol = 'openai' | 'anthropic';
 
 export interface ProjectConfigurationData {
 	shortcuts?: ShortcutConfig;


### PR DESCRIPTION
Reason: Add a first-class MiniMax verifier path for the auto-approval safety gate.

- Add configurable MiniMax model, region, and compatibility protocol settings.
- Route requests to the supplied Global and CN endpoints for MiniMax-M3 and MiniMax-M2.7.
- Preserve the JSON response schema and return manual approval on missing credentials, transport failures, invalid configuration, or malformed responses.
- Add focused verifier and settings tests and document configuration and credentials.

Checks:
- `bunx --bun prettier@3.7.4 --check src/constants/autoApproval.ts src/types/index.ts src/services/autoApprovalVerifier.ts src/services/autoApprovalVerifier.test.ts src/components/ConfigureOther.tsx src/components/ConfigureOther.test.tsx docs/auto-approval.md`
- `bun run typecheck`
- `bun run eslint src --rule 'prettier/prettier: off'` (semantic lint; the installed formatter version reports unrelated baseline formatting differences)
- `bun run test -- src/services/autoApprovalVerifier.test.ts src/components/ConfigureOther.test.tsx`
- `bun run build`
- `git diff origin/main...HEAD --no-ext-diff --check`
- Diff secret scan passed.
