### PR TITLE
fix: enable Space session actions immediately after returning to menu

### DIFF
--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -1,9 +1,33 @@
 import React from 'react';
 import {render} from 'ink-testing-library';
+import {useInput} from 'ink';
 import Menu from './Menu.js';
 import {SessionManager} from '../services/sessionManager.js';
 import {WorktreeService} from '../services/worktreeService.js';
+import {Session} from '../types/index.js';
 import {vi, describe, it, expect, beforeEach, afterEach} from 'vitest';
+
+const makeKey = (
+	overrides: Record<string, boolean> = {},
+): Record<string, boolean> => ({
+	upArrow: false,
+	downArrow: false,
+	leftArrow: false,
+	rightArrow: false,
+	pageDown: false,
+	pageUp: false,
+	home: false,
+	end: false,
+	return: false,
+	escape: false,
+	ctrl: false,
+	shift: false,
+	tab: false,
+	backspace: false,
+	delete: false,
+	meta: false,
+	...overrides,
+});
 
 // Mock bunTerminal to avoid native module issues in tests
 vi.mock('../services/bunTerminal.js', () => ({
@@ -384,6 +408,73 @@ describe('Menu component Effect-based error handling', () => {
 			worktrees: [cachedWorktree],
 			defaultBranch: 'main',
 			loadError: expect.stringContaining('temporary failure'),
+		});
+	});
+
+	it('should handle the Space session-actions shortcut on a cached snapshot before the refresh completes', async () => {
+		const {Effect} = await import('effect');
+		const cachedWorktree = {
+			path: '/test/cached',
+			branch: 'cached-branch',
+			isMainWorktree: true,
+			hasSession: true,
+		};
+		const cachedSession = {
+			id: 'session-cached',
+			worktreePath: '/test/cached',
+			lastAccessedAt: 1,
+			stateMutex: {
+				getSnapshot: () => ({
+					state: 'idle',
+					backgroundTaskCount: 0,
+					teamMemberCount: 0,
+				}),
+			},
+		} as unknown as Session;
+
+		vi.spyOn(sessionManager, 'getAllSessions').mockReturnValue([cachedSession]);
+		// Never resolve the refresh, so only the cached snapshot is on screen.
+		vi.spyOn(worktreeService, 'getWorktreesEffect').mockReturnValue(
+			Effect.promise(() => new Promise<never>(() => {})),
+		);
+		vi.spyOn(worktreeService, 'getDefaultBranchEffect').mockReturnValue(
+			Effect.succeed('main'),
+		);
+
+		const onMenuAction = vi.fn();
+		vi.mocked(useInput).mockClear();
+
+		render(
+			<Menu
+				sessionManager={sessionManager}
+				worktreeService={worktreeService}
+				initialSnapshot={{
+					worktrees: [cachedWorktree],
+					defaultBranch: 'main',
+				}}
+				onMenuAction={onMenuAction}
+				version="test"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Menu's hotkey handler bails out when raw mode is unavailable.
+		const origSetRawMode = process.stdin.setRawMode;
+		process.stdin.setRawMode = vi.fn() as never;
+		try {
+			const calls = vi.mocked(useInput).mock.calls;
+			const handler = calls[calls.length - 1]?.[0];
+			expect(handler).toBeDefined();
+			handler!(' ', makeKey() as never);
+		} finally {
+			process.stdin.setRawMode = origSetRawMode;
+		}
+
+		expect(onMenuAction).toHaveBeenCalledWith({
+			type: 'sessionActions',
+			session: cachedSession,
+			worktreePath: '/test/cached',
 		});
 	});
 });

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -124,7 +124,12 @@ const Menu: React.FC<MenuProps> = ({
 		loadError: initialSnapshot?.loadError ?? null,
 	});
 	const worktrees = useGitStatus(baseWorktrees, defaultBranch);
-	const [sessions, setSessions] = useState<Session[]>([]);
+	// Seed from the in-memory session list so the cached snapshot renders with its
+	// sessions attached. Waiting for the async git load would leave every row
+	// session-less for that window, disabling the Space session-actions shortcut.
+	const [sessions, setSessions] = useState<Session[]>(() =>
+		sessionManager.getAllSessions(),
+	);
 	const [items, setItems] = useState<MenuItem[]>([]);
 	const [recentProjects, setRecentProjects] = useState<RecentProject[]>([]);
 	const [highlightedWorktreePath, setHighlightedWorktreePath] = useState<


### PR DESCRIPTION
## Problem

Right after returning to the menu from a session, the Space shortcut (open session actions for the highlighted row) did nothing until the background Git refresh finished.

`Menu` initialized its session list as empty and only populated it inside the `.then()` of that refresh. #318 made the menu render its cached worktree snapshot immediately rather than waiting on Git, but the session list was not given the same treatment. During the refresh window every row was therefore built with no session attached, the auto-highlight effect set `highlightedSession` to `undefined`, and the Space handler — which requires a highlighted session — bailed out.

## Fix

Seed the session state from `SessionManager.getAllSessions()`, a synchronous read of an in-memory map. There is no reason for it to wait on Git, so the cached snapshot now renders with its sessions already attached and Space works on the first frame.

## Verification

- New regression test in `Menu.test.tsx` renders a cached snapshot with the Git refresh left pending, then invokes the captured `useInput` handler with a space. Confirmed it fails on the pre-fix code (`onMenuAction` never called) and passes with the fix.
- `bun run lint`, `bun run typecheck`, and `bun run test` (1785 passed, 10 skipped) all succeed.

## Not covered

`Worktree.hasSession` is still only recomputed once the Git refresh resolves, so cached rows carry the previous snapshot's value during that window. That affects display only, not the shortcut, and is left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)