### PR TITLE
fix: detect Claude in Chrome permission prompts as waiting_input

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,11 +37,11 @@
         "vitest": "^4.0.16",
       },
       "optionalDependencies": {
-        "@kodaikabasawa/ccmanager-darwin-arm64": "4.2.1",
-        "@kodaikabasawa/ccmanager-darwin-x64": "4.2.1",
-        "@kodaikabasawa/ccmanager-linux-arm64": "4.2.1",
-        "@kodaikabasawa/ccmanager-linux-x64": "4.2.1",
-        "@kodaikabasawa/ccmanager-win32-x64": "4.2.1",
+        "@kodaikabasawa/ccmanager-darwin-arm64": "4.2.2",
+        "@kodaikabasawa/ccmanager-darwin-x64": "4.2.2",
+        "@kodaikabasawa/ccmanager-linux-arm64": "4.2.2",
+        "@kodaikabasawa/ccmanager-linux-x64": "4.2.2",
+        "@kodaikabasawa/ccmanager-win32-x64": "4.2.2",
       },
     },
   },
@@ -127,16 +127,6 @@
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
-
-    "@kodaikabasawa/ccmanager-darwin-arm64": ["@kodaikabasawa/ccmanager-darwin-arm64@4.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gW4DQbACWB11NGMOAvbscZm2IFoCLG75eIpu58ZVqTV6776f8eqEnYlDSXK2fnFME9ierWtJhiXntN8Fakjp/w=="],
-
-    "@kodaikabasawa/ccmanager-darwin-x64": ["@kodaikabasawa/ccmanager-darwin-x64@4.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vqGGLc+ucEBkwmmGw+VY66xf+Cg480DJfwrTmGenggQt6LubdVvy9bMy9OYzqSJ9+Z0x/zaLCbdlX40ozraI+Q=="],
-
-    "@kodaikabasawa/ccmanager-linux-arm64": ["@kodaikabasawa/ccmanager-linux-arm64@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-x+pW0RFpn6ULajp9axeXySfCMUd5/yztyVWjuFTbFCesSFBnXeW6Kg7PCeCMh99QsZsv/606o/m+21z1N7+T3A=="],
-
-    "@kodaikabasawa/ccmanager-linux-x64": ["@kodaikabasawa/ccmanager-linux-x64@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Q5f7NA/Bbt/XxGjMT6dzYHq4YuinNvO4vcF0d6qhSm9x3MO+QTIflV6i+ab/yYgj4Jc9mUaClI8KZWCyyo5Ing=="],
-
-    "@kodaikabasawa/ccmanager-win32-x64": ["@kodaikabasawa/ccmanager-win32-x64@4.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-s5mpLC4T2FpLkL6G9OmOVsCo9C88k9fhlrtUdd1kg0FFifVntmePE+YjIJ/tzQFjz0UXNH5JOlW2fPTu0vL3uQ=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 

--- a/src/services/stateDetector/claude.test.ts
+++ b/src/services/stateDetector/claude.test.ts
@@ -296,6 +296,43 @@ describe('ClaudeStateDetector', () => {
 			expect(state).toBe('waiting_input');
 		});
 
+		it('should detect waiting_input for Claude in Chrome permission prompt (Allow/Deny)', () => {
+			// Arrange - browser permission prompt without "Do you want" phrasing
+			terminal = createMockTerminal([
+				'──────────────────────────────',
+				' Claude in Chrome wants to create a browser window and read your tabs',
+				'',
+				' ❯ 1. Allow',
+				'   2. Deny (esc)',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
+		it('should detect waiting_input for Claude in Chrome navigation prompt (Allow all / Deny)', () => {
+			// Arrange - three-option variant with "Allow all actions" entry
+			terminal = createMockTerminal([
+				'──────────────────────────────',
+				' Claude in Chrome wants to navigate on example.com',
+				'',
+				' https://example.com/app',
+				'',
+				' ❯ 1. Allow',
+				'   2. Allow all actions on example.com for this session',
+				'   3. Deny (esc)',
+			]);
+
+			// Act
+			const state = detector.detectState(terminal, 'idle');
+
+			// Assert
+			expect(state).toBe('waiting_input');
+		});
+
 		it('should prioritize "esc to cancel" over "esc to interrupt" when both above prompt box', () => {
 			// Arrange
 			terminal = createMockTerminal([

--- a/src/services/stateDetector/claude.ts
+++ b/src/services/stateDetector/claude.ts
@@ -150,6 +150,15 @@ export class ClaudeStateDetector extends BaseStateDetector {
 			return 'waiting_input';
 		}
 
+		// Check for permission menus without question phrasing, e.g.
+		// "Claude in Chrome wants to navigate on example.com" with:
+		//   ❯ 1. Allow
+		//     2. Deny (esc)
+		// The numbered "Deny (esc)" option is the stable marker across variants.
+		if (/\d+\.\s*deny\s*\(esc\)/.test(fullLowerContent)) {
+			return 'waiting_input';
+		}
+
 		// Content above the prompt box only for busy detection
 		const abovePromptBox = this.getRecentContentAbovePromptBox(terminal, 30);
 		const aboveLowerContent = abovePromptBox.toLowerCase();


### PR DESCRIPTION
## Problem

Claude Code shows browser-extension permission prompts (e.g. "Claude in Chrome wants to create a browser window and read your tabs") as a numbered Allow/Deny menu:

```
 Claude in Chrome wants to navigate on example.com

 https://example.com/app

 ❯ 1. Allow
   2. Allow all actions on example.com for this session
   3. Deny (esc)
```

These prompts contain none of the markers the Claude state detector currently keys on — no "Do you want" / "Would you like" phrasing and no "esc to cancel" footer — so ccmanager reports the session as idle while it is actually blocked waiting for the user to answer. The user gets no waiting-input indication (status icon, notification hooks) for these prompts.

The fix detects the numbered `N. Deny (esc)` option line, which is present in both the 2-option (Allow / Deny) and 3-option (Allow / Allow all actions / Deny) variants, and classifies it as `waiting_input`. The "wants to ..." sentence itself is deliberately not used as a marker because that phrase commonly appears in ordinary assistant prose and would cause false positives.

## Verification

Prerequisites:
- `bun install` from repo root.

Steps:
- [x] `bun run test src/services/stateDetector/claude.test.ts` — 77 tests pass, including two new cases that reproduce the 2-option and 3-option permission prompts verbatim and assert `waiting_input`.
- [x] `bun run lint`, `bun run typecheck`, and full `bun run test` (1790 passed / 10 skipped) succeed on the branch.
- [ ] Manual check: inside a ccmanager session, trigger a Claude in Chrome permission prompt (e.g. ask Claude Code to open a page with the Chrome extension enabled) and confirm the session status changes to the waiting-input state instead of idle while the Allow/Deny menu is displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
