### PR TITLE
fix: resolve ambiguous remote branch right after base branch selection

### DIFF
--- a/src/components/NewWorktree.test.tsx
+++ b/src/components/NewWorktree.test.tsx
@@ -378,6 +378,11 @@ describe('NewWorktree component Effect integration', () => {
 			return {
 				getAllBranchesEffect: vi.fn(() => Effect.succeed(mockBranches)),
 				getDefaultBranchEffect: vi.fn(() => Effect.succeed(mockDefaultBranch)),
+				resolveBaseBranch: vi.fn((name: string) => ({
+					kind: 'local',
+					ref: name,
+					localName: name,
+				})),
 			} as unknown as InstanceType<typeof WorktreeService>;
 		});
 
@@ -400,6 +405,46 @@ describe('NewWorktree component Effect integration', () => {
 		expect(output).toContain('How do you want to create the new worktree?');
 		expect(output).toContain('Choose the branch name yourself');
 		expect(output).toContain('Enter a prompt first');
+	});
+
+	it('should keep the base branch selection when the default branch is ambiguous across remotes', async () => {
+		const {Effect} = await import('effect');
+		const {WorktreeService} = await import('../services/worktreeService.js');
+		const {configReader} = await import('../services/config/configReader.js');
+
+		vi.spyOn(configReader, 'getWorktreeConfig').mockReturnValue({
+			autoDirectory: true,
+			autoDirectoryPattern: '../{project}-{branch}',
+			copySessionData: true,
+			autoUseDefaultBranch: true,
+		});
+
+		// Default branch has no local ref and exists on two remotes: it cannot
+		// be picked silently, so the base-branch step must not be skipped.
+		vi.mocked(WorktreeService).mockImplementation(function () {
+			return {
+				getAllBranchesEffect: vi.fn(() => Effect.succeed(['main', 'develop'])),
+				getDefaultBranchEffect: vi.fn(() => Effect.succeed('main')),
+				resolveBaseBranch: vi.fn(() => ({
+					kind: 'ambiguous',
+					branchName: 'main',
+					matches: [
+						{remote: 'origin', branch: 'main', fullRef: 'origin/main'},
+						{remote: 'upstream', branch: 'main', fullRef: 'upstream/main'},
+					],
+				})),
+			} as unknown as InstanceType<typeof WorktreeService>;
+		});
+
+		const {lastFrame} = render(
+			<NewWorktree onComplete={vi.fn()} onCancel={vi.fn()} />,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 100));
+
+		const output = lastFrame();
+		expect(output).toContain('Select base branch');
+		expect(output).not.toContain('How do you want to create the new worktree?');
 	});
 
 	it('should show base branch selection when autoUseDefaultBranch is disabled', async () => {

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -158,19 +158,19 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 					setDefaultBranch(result.defaultBranch);
 					setIsLoadingBranches(false);
 
-					if (isAutoUseDefaultBranch && result.defaultBranch) {
-						const resolution = service.resolveBaseBranch(result.defaultBranch);
-						if (resolution.kind === 'ambiguous') {
-							// The default branch only exists on multiple remotes; we
-							// can't pick one silently, so keep the base-branch step and
-							// let the user choose explicitly.
-						} else {
-							setBaseBranch(resolution.ref);
-							setBaseBranchLocalName(resolution.localName);
-							setStep(currentStep =>
-								currentStep === 'base-branch' ? 'creation-mode' : currentStep,
-							);
-						}
+					// When the default branch is ambiguous across remotes we can't
+					// pick one silently, so keep the base-branch step and let the
+					// user choose.
+					const resolution =
+						isAutoUseDefaultBranch && result.defaultBranch
+							? service.resolveBaseBranch(result.defaultBranch)
+							: null;
+					if (resolution && resolution.kind !== 'ambiguous') {
+						setBaseBranch(resolution.ref);
+						setBaseBranchLocalName(resolution.localName);
+						setStep(currentStep =>
+							currentStep === 'base-branch' ? 'creation-mode' : currentStep,
+						);
 					}
 				}
 			}

--- a/src/components/NewWorktree.tsx
+++ b/src/components/NewWorktree.tsx
@@ -9,8 +9,10 @@ import {WorktreeService} from '../services/worktreeService.js';
 import {useSearchMode} from '../hooks/useSearchMode.js';
 import {useDynamicLimit} from '../hooks/useDynamicLimit.js';
 import SearchableList from './SearchableList.js';
+import RemoteBranchSelector from './RemoteBranchSelector.js';
 import {Effect} from 'effect';
 import type {AppError} from '../types/errors.js';
+import type {RemoteBranchMatch} from '../types/index.js';
 import {
 	describePromptInjection,
 	getPromptInjectionMethod,
@@ -47,6 +49,7 @@ export type NewWorktreeRequest =
 type Step =
 	| 'path'
 	| 'base-branch'
+	| 'remote-branch-confirm'
 	| 'creation-mode'
 	| 'branch-strategy'
 	| 'branch'
@@ -83,6 +86,13 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	const [path, setPath] = useState('');
 	const [branch, setBranch] = useState('');
 	const [baseBranch, setBaseBranch] = useState('');
+	// Short branch name to use when creating a local branch from baseBranch
+	// (differs from baseBranch when baseBranch is a remote ref like "origin/x")
+	const [baseBranchLocalName, setBaseBranchLocalName] = useState('');
+	const [ambiguousBase, setAmbiguousBase] = useState<{
+		branchName: string;
+		matches: RemoteBranchMatch[];
+	} | null>(null);
 	const [copyClaudeDirectory, setCopyClaudeDirectory] = useState(true);
 	const [copySessionData, setCopySessionData] = useState(
 		worktreeConfig.copySessionData ?? true,
@@ -98,9 +108,14 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
 	const [defaultBranch, setDefaultBranch] = useState<string>('main');
 
+	const worktreeService = useMemo(
+		() => new WorktreeService(projectPath),
+		[projectPath],
+	);
+
 	useEffect(() => {
 		let cancelled = false;
-		const service = new WorktreeService(projectPath);
+		const service = worktreeService;
 
 		const loadBranches = async () => {
 			const branchesEffect = includeRemoteBranches
@@ -144,10 +159,18 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 					setIsLoadingBranches(false);
 
 					if (isAutoUseDefaultBranch && result.defaultBranch) {
-						setBaseBranch(result.defaultBranch);
-						setStep(currentStep =>
-							currentStep === 'base-branch' ? 'creation-mode' : currentStep,
-						);
+						const resolution = service.resolveBaseBranch(result.defaultBranch);
+						if (resolution.kind === 'ambiguous') {
+							// The default branch only exists on multiple remotes; we
+							// can't pick one silently, so keep the base-branch step and
+							// let the user choose explicitly.
+						} else {
+							setBaseBranch(resolution.ref);
+							setBaseBranchLocalName(resolution.localName);
+							setStep(currentStep =>
+								currentStep === 'base-branch' ? 'creation-mode' : currentStep,
+							);
+						}
 					}
 				}
 			}
@@ -163,7 +186,7 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 		return () => {
 			cancelled = true;
 		};
-	}, [projectPath, isAutoUseDefaultBranch, includeRemoteBranches]);
+	}, [worktreeService, isAutoUseDefaultBranch, includeRemoteBranches]);
 
 	const allBranchItems: BranchItem[] = useMemo(() => {
 		const defaultRemoteSuffix = `/${defaultBranch}`;
@@ -226,6 +249,12 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	);
 
 	useInput((input, key) => {
+		if (step === 'remote-branch-confirm') {
+			// RemoteBranchSelector handles its own cancel shortcut (returns to
+			// the base-branch list); don't also cancel the whole wizard here.
+			return;
+		}
+
 		if (shortcutManager.matchesShortcut('cancel', input, key)) {
 			onCancel();
 		}
@@ -235,21 +264,58 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 		}
 	});
 
+	/**
+	 * Resolves the selected base branch right away. Returns true when the
+	 * selection is settled; returns false when the branch exists on multiple
+	 * remotes, in which case the remote-branch-confirm step is shown so the
+	 * user can disambiguate immediately (instead of failing later when the
+	 * worktree is actually created).
+	 */
+	const applyBaseBranchSelection = (name: string): boolean => {
+		const resolution = worktreeService.resolveBaseBranch(name);
+		if (resolution.kind === 'ambiguous') {
+			setAmbiguousBase({
+				branchName: resolution.branchName,
+				matches: resolution.matches,
+			});
+			setStep('remote-branch-confirm');
+			return false;
+		}
+		setBaseBranch(resolution.ref);
+		setBaseBranchLocalName(resolution.localName);
+		return true;
+	};
+
 	const handlePathSubmit = (value: string) => {
 		if (!value.trim()) return;
 
 		setPath(value.trim());
 		if (isAutoUseDefaultBranch && defaultBranch) {
-			setBaseBranch(defaultBranch);
-			setStep('creation-mode');
+			if (applyBaseBranchSelection(defaultBranch)) {
+				setStep('creation-mode');
+			}
 		} else {
 			setStep('base-branch');
 		}
 	};
 
 	const handleBaseBranchSelect = (item: {label: string; value: string}) => {
-		setBaseBranch(item.value);
+		if (applyBaseBranchSelection(item.value)) {
+			setStep('creation-mode');
+		}
+	};
+
+	const handleAmbiguousBaseSelect = (selectedRemoteRef: string) => {
+		if (!ambiguousBase) return;
+		setBaseBranch(selectedRemoteRef);
+		setBaseBranchLocalName(ambiguousBase.branchName);
+		setAmbiguousBase(null);
 		setStep('creation-mode');
+	};
+
+	const handleAmbiguousBaseCancel = () => {
+		setAmbiguousBase(null);
+		setStep('base-branch');
 	};
 
 	const handleCreationModeSelect = (item: {label: string; value: string}) => {
@@ -264,7 +330,10 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 	const handleBranchStrategySelect = (item: {label: string; value: string}) => {
 		const useExisting = item.value === 'existing';
 		if (useExisting) {
-			setBranch(baseBranch);
+			// Use the short branch name: when baseBranch is a remote ref
+			// (e.g. "origin/feature/x"), the local branch to attach/create is
+			// "feature/x", not a branch literally named "origin/feature/x".
+			setBranch(baseBranchLocalName || baseBranch);
 			setStep('copy-settings');
 		} else {
 			setStep('branch');
@@ -507,6 +576,15 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 				</Box>
 			)}
 
+			{step === 'remote-branch-confirm' && ambiguousBase && (
+				<RemoteBranchSelector
+					branchName={ambiguousBase.branchName}
+					matches={ambiguousBase.matches}
+					onSelect={handleAmbiguousBaseSelect}
+					onCancel={handleAmbiguousBaseCancel}
+				/>
+			)}
+
 			{step === 'creation-mode' && (
 				<Box flexDirection="column">
 					<Box marginBottom={1}>
@@ -709,11 +787,13 @@ const NewWorktree: React.FC<NewWorktreeProps> = ({
 				</Box>
 			)}
 
-			<Box marginTop={1}>
-				<Text dimColor>
-					Press {shortcutManager.getShortcutDisplay('cancel')} to cancel
-				</Text>
-			</Box>
+			{step !== 'remote-branch-confirm' && (
+				<Box marginTop={1}>
+					<Text dimColor>
+						Press {shortcutManager.getShortcutDisplay('cancel')} to cancel
+					</Text>
+				</Box>
+			)}
 		</Box>
 	);
 };

--- a/src/services/worktreeService.test.ts
+++ b/src/services/worktreeService.test.ts
@@ -565,6 +565,147 @@ origin/feature/test
 		});
 	});
 
+	describe('resolveBaseBranch', () => {
+		it('should classify a local branch as local without checking remotes', () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd === 'git show-ref --verify --quiet refs/heads/feature/x') {
+						return ''; // Local branch exists
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			const result = service.resolveBaseBranch('feature/x');
+			expect(result).toEqual({
+				kind: 'local',
+				ref: 'feature/x',
+				localName: 'feature/x',
+			});
+		});
+
+		it('should classify a remote-qualified ref as remote with the short local name', () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
+						throw new Error('Local branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\nupstream\n';
+					}
+					if (
+						cmd ===
+						'git show-ref --verify --quiet refs/remotes/origin/feature/x'
+					) {
+						return '';
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			const result = service.resolveBaseBranch('origin/feature/x');
+			expect(result).toEqual({
+				kind: 'remote',
+				ref: 'origin/feature/x',
+				localName: 'feature/x',
+			});
+		});
+
+		it('should classify a branch existing on a single remote as remote', () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
+						throw new Error('Local branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\nupstream\n';
+					}
+					if (
+						cmd ===
+						'git show-ref --verify --quiet refs/remotes/origin/feature/x'
+					) {
+						return '';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						throw new Error('Remote branch not found');
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			const result = service.resolveBaseBranch('feature/x');
+			expect(result).toEqual({
+				kind: 'remote',
+				ref: 'origin/feature/x',
+				localName: 'feature/x',
+			});
+		});
+
+		it('should classify a branch existing on multiple remotes as ambiguous', () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
+						throw new Error('Local branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\nupstream\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						return ''; // Both remotes have the branch
+					}
+				}
+				throw new Error('Command not mocked: ' + cmd);
+			});
+
+			const result = service.resolveBaseBranch('feature/x');
+			expect(result).toEqual({
+				kind: 'ambiguous',
+				branchName: 'feature/x',
+				matches: [
+					{remote: 'origin', branch: 'feature/x', fullRef: 'origin/feature/x'},
+					{
+						remote: 'upstream',
+						branch: 'feature/x',
+						fullRef: 'upstream/feature/x',
+					},
+				],
+			});
+		});
+
+		it('should classify an unknown branch as none', () => {
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					if (cmd === 'git remote') {
+						return 'origin\n';
+					}
+				}
+				throw new Error('Branch not found');
+			});
+
+			const result = service.resolveBaseBranch('nonexistent');
+			expect(result).toEqual({
+				kind: 'none',
+				ref: 'nonexistent',
+				localName: 'nonexistent',
+			});
+		});
+	});
+
 	describe('hasClaudeDirectoryInBranchEffect', () => {
 		it('should return Effect with true when .claude directory exists in branch worktree', async () => {
 			mockedExecSync.mockImplementation((cmd, _options) => {
@@ -964,7 +1105,53 @@ branch refs/heads/feature
 			expect(worktreeAddCmd).toContain('"origin/feature/remote-only"');
 		});
 
-		it('should return Effect Left with AmbiguousBranchError when branch exists in multiple remotes', async () => {
+		it('should fall back to baseBranch when the new branch name exists in multiple remotes', async () => {
+			const executedCommands: string[] = [];
+			mockedExecSync.mockImplementation((cmd, _options) => {
+				if (typeof cmd === 'string') {
+					executedCommands.push(cmd);
+					if (cmd === 'git rev-parse --git-common-dir') {
+						return '/fake/path/.git\n';
+					}
+					// baseBranch "main" exists locally; the new branch does not
+					if (cmd === 'git show-ref --verify --quiet refs/heads/main') {
+						return '';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/heads/')) {
+						throw new Error('Branch not found');
+					}
+					if (cmd === 'git remote') {
+						return 'origin\nkbwo-fork\n';
+					}
+					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
+						return ''; // Both remotes have the new branch name
+					}
+					if (cmd.includes('git worktree add')) {
+						return '';
+					}
+				}
+				return '';
+			});
+
+			// The user explicitly chose "main" as base branch; the ambiguity of
+			// "feature/feed-mention" across remotes must not fail the creation.
+			const effect = service.createWorktreeEffect(
+				'/path/to/worktree',
+				'feature/feed-mention',
+				'main',
+			);
+			const result = await Effect.runPromise(Effect.either(effect));
+
+			expect(result._tag).toBe('Right');
+
+			const worktreeAddCmd = executedCommands.find(c =>
+				c.includes('git worktree add'),
+			);
+			expect(worktreeAddCmd).toContain('-b "feature/feed-mention"');
+			expect(worktreeAddCmd).toContain('"main"');
+		});
+
+		it('should return Effect Left with AmbiguousBranchError when baseBranch exists in multiple remotes', async () => {
 			mockedExecSync.mockImplementation((cmd, _options) => {
 				if (typeof cmd === 'string') {
 					if (cmd === 'git rev-parse --git-common-dir') {
@@ -976,8 +1163,20 @@ branch refs/heads/feature
 					if (cmd === 'git remote') {
 						return 'origin\nkbwo-fork\n';
 					}
+					// Only the baseBranch exists on the remotes; the new branch
+					// name matches nothing anywhere.
+					if (
+						cmd.includes(
+							'show-ref --verify --quiet refs/remotes/origin/feature/feed-mention',
+						) ||
+						cmd.includes(
+							'show-ref --verify --quiet refs/remotes/kbwo-fork/feature/feed-mention',
+						)
+					) {
+						return '';
+					}
 					if (cmd.includes('show-ref --verify --quiet refs/remotes/')) {
-						return ''; // Both remotes have the branch
+						throw new Error('Remote branch not found');
 					}
 				}
 				throw new Error('Command not mocked: ' + cmd);
@@ -985,8 +1184,8 @@ branch refs/heads/feature
 
 			const effect = service.createWorktreeEffect(
 				'/path/to/worktree',
+				'new-feature',
 				'feature/feed-mention',
-				'main',
 			);
 			const result = await Effect.runPromise(Effect.either(effect));
 

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -6,6 +6,7 @@ import {
 	Worktree,
 	CreateWorktreeResult,
 	AmbiguousBranchError,
+	BaseBranchResolution,
 	RemoteBranchMatch,
 	MergeConfig,
 } from '../types/index.js';
@@ -197,6 +198,83 @@ export class WorktreeService {
 				throw error;
 			},
 		});
+	}
+
+	/**
+	 * Classifies a base branch picked in the UI, without throwing.
+	 *
+	 * Unlike resolveBranchReference(), this is meant to run right after the
+	 * user selects a base branch so that:
+	 * - a local branch is confirmed immediately (never routed to the
+	 *   ambiguous-remote confirmation), and
+	 * - an ambiguous branch (same name in multiple remotes) can be
+	 *   disambiguated right away instead of failing later at creation time.
+	 *
+	 * @param {string} branchName - Branch name or remote-qualified ref
+	 *   (e.g. "feature/x" or "origin/feature/x") selected as base branch
+	 * @returns {BaseBranchResolution} Classification result (see type docs)
+	 */
+	resolveBaseBranch(branchName: string): BaseBranchResolution {
+		// Local branch has the highest priority
+		try {
+			execSync(`git show-ref --verify --quiet refs/heads/${branchName}`, {
+				cwd: this.rootPath,
+				encoding: 'utf8',
+			});
+			return {kind: 'local', ref: branchName, localName: branchName};
+		} catch {
+			// Not a local branch, check remotes below
+		}
+
+		const remotes = this.getAllRemotes();
+
+		// Already remote-qualified (e.g. "origin/feature/x" selected from the
+		// remote section of the branch list): not ambiguous by construction.
+		for (const remote of remotes) {
+			const prefix = `${remote}/`;
+			if (!branchName.startsWith(prefix)) continue;
+			try {
+				execSync(`git show-ref --verify --quiet refs/remotes/${branchName}`, {
+					cwd: this.rootPath,
+					encoding: 'utf8',
+				});
+				return {
+					kind: 'remote',
+					ref: branchName,
+					localName: branchName.slice(prefix.length),
+				};
+			} catch {
+				// Not an existing remote-tracking ref; fall through to matching
+			}
+		}
+
+		const matches: RemoteBranchMatch[] = [];
+		for (const remote of remotes) {
+			try {
+				execSync(
+					`git show-ref --verify --quiet refs/remotes/${remote}/${branchName}`,
+					{
+						cwd: this.rootPath,
+						encoding: 'utf8',
+					},
+				);
+				matches.push({
+					remote,
+					branch: branchName,
+					fullRef: `${remote}/${branchName}`,
+				});
+			} catch {
+				// This remote doesn't have the branch, continue
+			}
+		}
+
+		if (matches.length === 1) {
+			return {kind: 'remote', ref: matches[0]!.fullRef, localName: branchName};
+		}
+		if (matches.length > 1) {
+			return {kind: 'ambiguous', branchName, matches};
+		}
+		return {kind: 'none', ref: branchName, localName: branchName};
 	}
 
 	/**
@@ -1000,7 +1078,16 @@ export class WorktreeService {
 				// Use it directly to avoid re-triggering AmbiguousBranchError.
 				command = `git worktree add -b "${branch}" "${resolvedPath}" "${baseBranch}"`;
 			} else {
-				const resolvedRef = yield* self.resolveBranchReferenceEffect(branch);
+				// The new branch name itself may match remote branches (checkout
+				// semantics: typing "feature/x" checks out origin/feature/x when it
+				// exists on exactly one remote). When the name exists on MULTIPLE
+				// remotes, don't fail with AmbiguousBranchError: the user already
+				// chose baseBranch explicitly, so create the new branch from
+				// baseBranch instead of asking which remote to track.
+				const resolvedRef = yield* Effect.catchAll(
+					self.resolveBranchReferenceEffect(branch),
+					() => Effect.succeed(branch),
+				);
 				const isRemoteBranch = resolvedRef !== branch;
 				const startPoint = isRemoteBranch
 					? resolvedRef

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -322,6 +322,22 @@ export interface RemoteBranchMatch {
 	fullRef: string; // e.g., "origin/foo/bar-xyz"
 }
 
+/**
+ * Result of classifying a base branch the user picked in the UI.
+ *
+ * - 'local': branch exists locally; `ref` is the branch name as-is.
+ * - 'remote': resolved to exactly one remote-tracking ref; `ref` is the full
+ *   ref (e.g. "origin/foo") and `localName` the short branch name to use when
+ *   creating a local branch from it.
+ * - 'ambiguous': branch exists in multiple remotes; the user must pick one.
+ * - 'none': nothing matched; pass `ref` through and let git report errors.
+ */
+export type BaseBranchResolution =
+	| {kind: 'local'; ref: string; localName: string}
+	| {kind: 'remote'; ref: string; localName: string}
+	| {kind: 'none'; ref: string; localName: string}
+	| {kind: 'ambiguous'; branchName: string; matches: RemoteBranchMatch[]};
+
 export class AmbiguousBranchError extends Error {
 	readonly _tag = 'AmbiguousBranchError' as const;
 	branchName: string;


### PR DESCRIPTION
## Problem

The "⚠️ Ambiguous Branch Reference" confirmation (`RemoteBranchSelector`, shown when a branch name exists on multiple remotes) has two problems in the new-worktree wizard:

- **It appears even when the user already selected a base branch explicitly (including a local branch).** Worktree creation also resolves the *new* branch name against remotes (checkout-by-name semantics), so entering a new branch name that happens to exist on two or more remotes aborts creation with `AmbiguousBranchError` and shows the confirmation — even though the base branch was already chosen.
- **It appears only at the very end of the wizard.** Ambiguity was detected when `git worktree add` was about to run, i.e. after the user had already gone through creation mode, branch name, and copy settings. If the selected base branch is ambiguous, the user should be asked right after selecting it.

## Investigation

### Facts

Reproduced on a scratch repo with two remotes (`origin`, `upstream`) that both have `feature/x` and `feature/x2`, no local refs for them, and a local `main`:

- `createWorktreeEffect('../wtA', 'feature/x2', 'main')` failed with `Ambiguous branch 'feature/x2' found in multiple remotes: origin/feature/x2, upstream/feature/x2. Please specify which remote to use.` even though the base branch `main` is local. The throw comes from resolving the *new branch name* (`resolveBranchReferenceEffect(branch)`) in `createWorktreeEffect`, not from the base branch.
- The confirmation screen was only reachable through App's `AmbiguousBranchError` handler after `createWorktreeEffect` failed — which is why it always showed up at the end of the wizard rather than at branch selection.
- The base-branch list built by `getAllBranchesEffect()` merges remote branches with the `origin/` prefix stripped, so a remote-only branch is indistinguishable from a local one in the list; selecting such an entry also ran into the late confirmation.

### Findings

The fix moves disambiguation to selection time and stops treating the new branch name's ambiguity as an error:

- New `WorktreeService.resolveBaseBranch()` classifies a selected base branch (`local` / single `remote` / `ambiguous` / `none`) without throwing. `NewWorktree` calls it right after the base-branch selection: a local branch is confirmed instantly (never routed to the confirmation), and an ambiguous one shows `RemoteBranchSelector` immediately as a wizard step.
- `createWorktreeEffect` no longer fails when the *new* branch name exists on multiple remotes — the user already picked the base branch, so the new branch is created from it. The single-remote checkout-by-name behavior (typing `feature/x` checks out `origin/feature/x`) is unchanged.
- Side fix: "Use existing base branch" now creates the local branch under its short name when the base resolves to a remote ref; previously a local branch literally named `origin/...` could be created.
- App's late `AmbiguousBranchError` handling is kept as a fallback for callers that pass an unresolved base branch.

## Verification

Prerequisites — build this branch and create a scratch repo whose branch `feature/x` exists on two remotes but not locally:

```bash
# In the ccmanager checkout of this branch
bun install && bun run build
```

```bash
mkdir -p /tmp/ccm-ambiguous && cd /tmp/ccm-ambiguous
git init --bare remote1
git clone remote1 work && cd work
git commit --allow-empty -m init
git branch feature/x && git branch feature/x2
git push origin main feature/x feature/x2
git init --bare ../remote2
git remote add upstream ../remote2
git push upstream --all
git branch -D feature/x feature/x2
git fetch --all
git branch -a
```

Expected output of the final `git branch -a`: only `main` as a local branch; `feature/x` and `feature/x2` appear only under `remotes/origin/` and `remotes/upstream/`.

Steps:

- [x] `bun run lint`, `bun run typecheck`, and `bun run test` all pass (1823 tests, including new unit tests for `resolveBaseBranch` and the creation-time fallback).
- [x] Service level, against the scratch repo: `createWorktreeEffect(path, 'feature/x2', 'main')` succeeds and `git worktree list` shows the new worktree on branch `feature/x2` created from `main`'s commit (before this change it failed with `AmbiguousBranchError`).
- [ ] TUI, immediate confirmation: in `/tmp/ccm-ambiguous/work`, run `node <ccmanager-checkout>/dist/cli.js`, choose "New Worktree", enter a path, and select `feature/x` in "Select base branch". Expected: the "⚠️ Ambiguous Branch Reference" screen listing `origin/feature/x` and `upstream/feature/x` appears **immediately after this selection**, before the "How do you want to create the new worktree?" step. Selecting `origin/feature/x` continues the wizard showing `Base branch: origin/feature/x`.
- [ ] TUI, no confirmation for a local base: restart the wizard, select `main` as base branch, choose "Choose the branch name yourself" → "Create new branch from base branch", and enter `feature/x2` as the new branch name. Expected: the ambiguous confirmation never appears, and after completing the wizard `git worktree list` in `work` shows a worktree on branch `feature/x2` whose commit equals `git rev-parse main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
