### PR TITLE
feat: delete a worktree from the Space actions menu

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,6 +6,7 @@ import Dashboard from './Dashboard.js';
 import Session from './Session.js';
 import NewWorktree from './NewWorktree.js';
 import DeleteWorktree from './DeleteWorktree.js';
+import DeleteConfirmation from './DeleteConfirmation.js';
 import MergeWorktree from './MergeWorktree.js';
 import Configuration from './Configuration.js';
 import PresetSelector from './PresetSelector.js';
@@ -36,7 +37,10 @@ import {ConfigScope} from '../types/index.js';
 import {ENV_VARS} from '../constants/env.js';
 import {MULTI_PROJECT_ERRORS} from '../constants/error.js';
 import {projectManager} from '../services/projectManager.js';
-import {generateWorktreeDirectory} from '../utils/worktreeUtils.js';
+import {
+	generateWorktreeDirectory,
+	isDeletableWorktree,
+} from '../utils/worktreeUtils.js';
 
 type View =
 	| 'menu'
@@ -48,6 +52,7 @@ type View =
 	| 'creating-session'
 	| 'creating-session-preset'
 	| 'delete-worktree'
+	| 'confirm-delete-worktree'
 	| 'deleting-worktree'
 	| 'merge-worktree'
 	| 'configuration'
@@ -96,9 +101,17 @@ const App: React.FC<AppProps> = ({
 		name?: string;
 	} | null>(null);
 	const [sessionActionsTarget, setSessionActionsTarget] = useState<{
-		session: ISession;
 		worktreePath: string;
+		session?: ISession;
+		// Present only when the actions menu was opened from a menu row, which is
+		// the only entry point that knows the worktree; the Dashboard opens it
+		// from a session alone and therefore offers no worktree deletion.
+		worktree?: Worktree;
 	} | null>(null);
+	// Worktree awaiting confirmation of the per-row delete action
+	const [worktreeToDelete, setWorktreeToDelete] = useState<Worktree | null>(
+		null,
+	);
 	const [selectedProject, setSelectedProject] = useState<GitProject | null>(
 		null,
 	); // Store selected project in multi-project mode
@@ -498,8 +511,9 @@ const App: React.FC<AppProps> = ({
 				return;
 			case 'sessionActions':
 				setSessionActionsTarget({
+					worktreePath: action.worktree.path,
 					session: action.session,
-					worktreePath: action.worktreePath,
+					worktree: action.worktree,
 				});
 				navigateWithClear('session-actions');
 				return;
@@ -798,6 +812,11 @@ const App: React.FC<AppProps> = ({
 	const handleDeleteWorktrees = async (
 		worktreePaths: string[],
 		deleteBranch: boolean,
+		options?: {
+			// Where to send the user when a deletion fails. Defaults to the
+			// multi-select delete screen, which is where this flow starts.
+			onError?: () => void;
+		},
 	) => {
 		// Set loading context before showing loading view
 		setLoadingContext({deleteBranch});
@@ -846,7 +865,11 @@ const App: React.FC<AppProps> = ({
 			handleReturnToMenu();
 		} else {
 			// Show error
-			setView('delete-worktree');
+			if (options?.onError) {
+				options.onError();
+			} else {
+				setView('delete-worktree');
+			}
 		}
 	};
 
@@ -1092,10 +1115,16 @@ const App: React.FC<AppProps> = ({
 	}
 
 	if (view === 'session-actions' && sessionActionsTarget) {
-		const {session: targetSession, worktreePath} = sessionActionsTarget;
-		const label = targetSession.sessionName
-			? `${worktreePath} : ${targetSession.sessionName}`
-			: `${worktreePath} #${targetSession.sessionNumber}`;
+		const {
+			session: targetSession,
+			worktreePath,
+			worktree: targetWorktree,
+		} = sessionActionsTarget;
+		const label = !targetSession
+			? worktreePath
+			: targetSession.sessionName
+				? `${worktreePath} : ${targetSession.sessionName}`
+				: `${worktreePath} #${targetSession.sessionNumber}`;
 
 		const handleSessionAction = async (action: SessionActionType) => {
 			setSessionActionsTarget(null);
@@ -1112,6 +1141,7 @@ const App: React.FC<AppProps> = ({
 					);
 					return;
 				case 'rename':
+					if (!targetSession) return;
 					setRenameTarget({
 						id: targetSession.id,
 						name: targetSession.sessionName,
@@ -1119,8 +1149,14 @@ const App: React.FC<AppProps> = ({
 					navigateWithClear('rename-session');
 					return;
 				case 'kill':
+					if (!targetSession) return;
 					sessionManager.destroySession(targetSession.id);
 					handleReturnToMenu();
+					return;
+				case 'deleteWorktree':
+					if (!targetWorktree) return;
+					setWorktreeToDelete(targetWorktree);
+					navigateWithClear('confirm-delete-worktree');
 					return;
 			}
 		};
@@ -1128,9 +1164,35 @@ const App: React.FC<AppProps> = ({
 		return (
 			<SessionActions
 				sessionLabel={label}
+				hasSession={!!targetSession}
+				canDeleteWorktree={
+					!!targetWorktree && isDeletableWorktree(targetWorktree)
+				}
 				onSelect={handleSessionAction}
 				onCancel={() => {
 					setSessionActionsTarget(null);
+					handleReturnToMenu();
+				}}
+			/>
+		);
+	}
+
+	if (view === 'confirm-delete-worktree' && worktreeToDelete) {
+		const target = worktreeToDelete;
+
+		return (
+			<DeleteConfirmation
+				worktrees={[target]}
+				onConfirm={deleteBranch => {
+					setWorktreeToDelete(null);
+					void handleDeleteWorktrees([target.path], deleteBranch, {
+						// The multi-select delete screen was never opened in this flow,
+						// so surface the failure on the menu instead.
+						onError: handleReturnToMenu,
+					});
+				}}
+				onCancel={() => {
+					setWorktreeToDelete(null);
 					handleReturnToMenu();
 				}}
 			/>

--- a/src/components/DeleteWorktree.tsx
+++ b/src/components/DeleteWorktree.tsx
@@ -1,5 +1,4 @@
 import React, {useState, useEffect} from 'react';
-import path from 'path';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 import {Effect} from 'effect';
@@ -11,6 +10,7 @@ import {useSearchMode} from '../hooks/useSearchMode.js';
 import {useDynamicLimit} from '../hooks/useDynamicLimit.js';
 import {filterWorktreesByQuery} from '../utils/filterByQuery.js';
 import SearchableList from './SearchableList.js';
+import {isDeletableWorktree} from '../utils/worktreeUtils.js';
 
 interface DeleteWorktreeProps {
 	projectPath?: string;
@@ -59,19 +59,9 @@ const DeleteWorktree: React.FC<DeleteWorktreeProps> = ({
 				);
 
 				if (!cancelled) {
-					// Filter out main worktree and current working directory worktree
-					const resolvedCwd = path.resolve(process.cwd());
-					const deletableWorktrees = allWorktrees.filter(wt => {
-						if (wt.isMainWorktree) return false;
-						const resolvedPath = path.resolve(wt.path);
-						if (
-							resolvedCwd === resolvedPath ||
-							resolvedCwd.startsWith(resolvedPath + path.sep)
-						) {
-							return false;
-						}
-						return true;
-					});
+					const deletableWorktrees = allWorktrees.filter(wt =>
+						isDeletableWorktree(wt),
+					);
 					setWorktrees(deletableWorktrees);
 					setIsLoading(false);
 				}

--- a/src/components/Menu.test.tsx
+++ b/src/components/Menu.test.tsx
@@ -473,8 +473,62 @@ describe('Menu component Effect-based error handling', () => {
 
 		expect(onMenuAction).toHaveBeenCalledWith({
 			type: 'sessionActions',
+			worktree: cachedWorktree,
 			session: cachedSession,
-			worktreePath: '/test/cached',
+		});
+	});
+
+	it('should open the actions menu with Space on a worktree row that has no session', async () => {
+		const {Effect} = await import('effect');
+		const sessionlessWorktree = {
+			path: '/test/no-session',
+			branch: 'feature/no-session',
+			isMainWorktree: false,
+			hasSession: false,
+		};
+
+		vi.spyOn(sessionManager, 'getAllSessions').mockReturnValue([]);
+		vi.spyOn(worktreeService, 'getWorktreesEffect').mockReturnValue(
+			Effect.succeed([sessionlessWorktree]),
+		);
+		vi.spyOn(worktreeService, 'getDefaultBranchEffect').mockReturnValue(
+			Effect.succeed('main'),
+		);
+
+		const onMenuAction = vi.fn();
+		vi.mocked(useInput).mockClear();
+
+		render(
+			<Menu
+				sessionManager={sessionManager}
+				worktreeService={worktreeService}
+				initialSnapshot={{
+					worktrees: [sessionlessWorktree],
+					defaultBranch: 'main',
+				}}
+				onMenuAction={onMenuAction}
+				version="test"
+			/>,
+		);
+
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Menu's hotkey handler bails out when raw mode is unavailable.
+		const origSetRawMode = process.stdin.setRawMode;
+		process.stdin.setRawMode = vi.fn() as never;
+		try {
+			const calls = vi.mocked(useInput).mock.calls;
+			const handler = calls[calls.length - 1]?.[0];
+			expect(handler).toBeDefined();
+			handler!(' ', makeKey() as never);
+		} finally {
+			process.stdin.setRawMode = origSetRawMode;
+		}
+
+		expect(onMenuAction).toHaveBeenCalledWith({
+			type: 'sessionActions',
+			worktree: sessionlessWorktree,
+			session: undefined,
 		});
 	});
 });

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -126,15 +126,15 @@ const Menu: React.FC<MenuProps> = ({
 	const worktrees = useGitStatus(baseWorktrees, defaultBranch);
 	// Seed from the in-memory session list so the cached snapshot renders with its
 	// sessions attached. Waiting for the async git load would leave every row
-	// session-less for that window, disabling the Space session-actions shortcut.
+	// session-less for that window, hiding the session entries of the Space
+	// actions menu.
 	const [sessions, setSessions] = useState<Session[]>(() =>
 		sessionManager.getAllSessions(),
 	);
 	const [items, setItems] = useState<MenuItem[]>([]);
 	const [recentProjects, setRecentProjects] = useState<RecentProject[]>([]);
-	const [highlightedWorktreePath, setHighlightedWorktreePath] = useState<
-		string | null
-	>(null);
+	const [highlightedWorktree, setHighlightedWorktree] =
+		useState<Worktree | null>(null);
 	const [highlightedSession, setHighlightedSession] = useState<
 		Session | undefined
 	>(undefined);
@@ -420,20 +420,23 @@ const Menu: React.FC<MenuProps> = ({
 		}
 		setItems(menuItems);
 
-		// Ensure highlighted worktree path is valid for hotkey support
-		setHighlightedWorktreePath(prev => {
-			if (
-				prev &&
-				menuItems.some(
-					item => item.type === 'worktree' && item.worktree.path === prev,
-				)
-			) {
-				return prev;
+		// Ensure highlighted worktree is valid for hotkey support
+		setHighlightedWorktree(prev => {
+			const stillListed = prev
+				? menuItems.find(
+						item =>
+							item.type === 'worktree' && item.worktree.path === prev.path,
+					)
+				: undefined;
+			if (stillListed && stillListed.type === 'worktree') {
+				// Re-read the item so the highlighted worktree keeps up with
+				// refreshed git status instead of pinning the stale object.
+				return stillListed.worktree;
 			}
 			const first = menuItems.find(item => item.type === 'worktree');
 			if (first && first.type === 'worktree') {
 				setHighlightedSession(first.session);
-				return first.worktree.path;
+				return first.worktree;
 			}
 			setHighlightedSession(undefined);
 			return null;
@@ -521,18 +524,21 @@ const Menu: React.FC<MenuProps> = ({
 		switch (keyPressed) {
 			case 'a':
 				// Toggle auto-approval for the currently highlighted worktree
-				if (configReader.isAutoApprovalEnabled() && highlightedWorktreePath) {
-					sessionManager.toggleAutoApprovalForWorktree(highlightedWorktreePath);
+				if (configReader.isAutoApprovalEnabled() && highlightedWorktree) {
+					sessionManager.toggleAutoApprovalForWorktree(
+						highlightedWorktree.path,
+					);
 					setAutoApprovalToggleCounter(c => c + 1);
 				}
 				break;
 			case ' ':
-				// Open session actions for highlighted session
-				if (highlightedSession && highlightedWorktreePath) {
+				// Open the row actions for the highlighted worktree. Rows without a
+				// session open the same menu with only the worktree-level entries.
+				if (highlightedWorktree) {
 					onMenuAction({
 						type: 'sessionActions',
+						worktree: highlightedWorktree,
 						session: highlightedSession,
-						worktreePath: highlightedWorktreePath,
 					});
 				}
 				break;
@@ -673,7 +679,7 @@ const Menu: React.FC<MenuProps> = ({
 						const item = items.find(i => i.value === raw?.value);
 						if (!item) return;
 						if (item.type === 'worktree') {
-							setHighlightedWorktreePath(item.worktree.path);
+							setHighlightedWorktree(item.worktree);
 							setHighlightedSession(item.session);
 						}
 					}}
@@ -712,12 +718,12 @@ const Menu: React.FC<MenuProps> = ({
 					{isSearchMode
 						? 'Search Mode: Type to filter, Enter to exit search, ESC to exit search'
 						: searchQuery
-							? `Controls: ↑↓ Navigate Enter Select | /-Search ESC-Clear 0-9 Quick Select Tab-State Filter Space-Session actions (session rows only) N-New M-Merge D-Delete ${
+							? `Controls: ↑↓ Navigate Enter Select | /-Search ESC-Clear 0-9 Quick Select Tab-State Filter Space-Worktree actions N-New M-Merge D-Delete ${
 									configReader.isAutoApprovalEnabled() ? 'A-AutoApproval ' : ''
 								}${
 									multiProject ? 'C-Config' : 'P-ProjConfig C-GlobalConfig'
 								} ${projectName ? 'B-Back' : 'Q-Quit'}`
-							: `Controls: ↑↓ Navigate Enter Select | Hotkeys: 0-9 Quick Select /-Search Tab-State Filter Space-Session actions (session rows only) N-New M-Merge D-Delete ${
+							: `Controls: ↑↓ Navigate Enter Select | Hotkeys: 0-9 Quick Select /-Search Tab-State Filter Space-Worktree actions N-New M-Merge D-Delete ${
 									configReader.isAutoApprovalEnabled() ? 'A-AutoApproval ' : ''
 								}${
 									multiProject ? 'C-Config' : 'P-ProjConfig C-GlobalConfig'

--- a/src/components/SessionActions.test.tsx
+++ b/src/components/SessionActions.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import {render} from 'ink-testing-library';
+import {useInput} from 'ink';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import SessionActions from './SessionActions.js';
+
+const makeKey = (
+	overrides: Record<string, boolean> = {},
+): Record<string, boolean> => ({
+	upArrow: false,
+	downArrow: false,
+	leftArrow: false,
+	rightArrow: false,
+	pageDown: false,
+	pageUp: false,
+	home: false,
+	end: false,
+	return: false,
+	escape: false,
+	ctrl: false,
+	shift: false,
+	tab: false,
+	backspace: false,
+	delete: false,
+	meta: false,
+	...overrides,
+});
+
+// Mock ink to avoid stdin issues and to capture the hotkey handler
+vi.mock('ink', async () => {
+	const actual = await vi.importActual<typeof import('ink')>('ink');
+	return {
+		...actual,
+		useInput: vi.fn(),
+	};
+});
+
+// Mock SelectInput to render items as simple text
+vi.mock('ink-select-input', async () => {
+	const React = await vi.importActual<typeof import('react')>('react');
+	const {Text, Box} = await vi.importActual<typeof import('ink')>('ink');
+
+	return {
+		default: ({items}: {items: Array<{label: string; value: string}>}) =>
+			React.createElement(
+				Box,
+				{flexDirection: 'column'},
+				items.map((item: {label: string}, index: number) =>
+					React.createElement(Text, {key: index}, item.label),
+				),
+			),
+	};
+});
+
+const getLastInputHandler = () => {
+	const calls = vi.mocked(useInput).mock.calls;
+	const handler = calls[calls.length - 1]?.[0];
+	expect(handler).toBeDefined();
+	return handler!;
+};
+
+describe('SessionActions', () => {
+	beforeEach(() => {
+		vi.mocked(useInput).mockClear();
+	});
+
+	it('should show session actions and the delete entry for a deletable worktree', () => {
+		const {lastFrame} = render(
+			<SessionActions
+				sessionLabel="/repo/worktrees/feature #1"
+				hasSession
+				canDeleteWorktree
+				onSelect={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+
+		const frame = lastFrame();
+		expect(frame).toContain('Session Actions');
+		expect(frame).toContain('New session in this worktree');
+		expect(frame).toContain('Rename this session');
+		expect(frame).toContain('Close session');
+		expect(frame).toContain('Delete this worktree');
+	});
+
+	it('should hide session-specific actions for a worktree without a session', () => {
+		const {lastFrame} = render(
+			<SessionActions
+				sessionLabel="/repo/worktrees/feature"
+				hasSession={false}
+				canDeleteWorktree
+				onSelect={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+
+		const frame = lastFrame();
+		expect(frame).toContain('Worktree Actions');
+		expect(frame).toContain('New session in this worktree');
+		expect(frame).toContain('Delete this worktree');
+		expect(frame).not.toContain('Rename this session');
+		expect(frame).not.toContain('Close session');
+	});
+
+	it('should hide the delete entry when the worktree cannot be deleted', () => {
+		const {lastFrame} = render(
+			<SessionActions
+				sessionLabel="/repo #1"
+				hasSession
+				canDeleteWorktree={false}
+				onSelect={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+
+		expect(lastFrame()).not.toContain('Delete this worktree');
+	});
+
+	it('should dispatch deleteWorktree on the D hotkey when deletion is offered', () => {
+		const onSelect = vi.fn();
+		render(
+			<SessionActions
+				sessionLabel="/repo/worktrees/feature"
+				hasSession={false}
+				canDeleteWorktree
+				onSelect={onSelect}
+				onCancel={vi.fn()}
+			/>,
+		);
+
+		getLastInputHandler()('d', makeKey() as never);
+
+		expect(onSelect).toHaveBeenCalledWith('deleteWorktree');
+	});
+
+	it('should ignore hotkeys of actions that are not offered', () => {
+		const onSelect = vi.fn();
+		render(
+			<SessionActions
+				sessionLabel="/repo #1"
+				hasSession
+				canDeleteWorktree={false}
+				onSelect={onSelect}
+				onCancel={vi.fn()}
+			/>,
+		);
+
+		const handler = getLastInputHandler();
+		handler('d', makeKey() as never);
+		expect(onSelect).not.toHaveBeenCalled();
+
+		handler('x', makeKey() as never);
+		expect(onSelect).toHaveBeenCalledWith('kill');
+	});
+
+	it('should cancel on Escape', () => {
+		const onCancel = vi.fn();
+		render(
+			<SessionActions
+				sessionLabel="/repo #1"
+				hasSession
+				canDeleteWorktree
+				onSelect={vi.fn()}
+				onCancel={onCancel}
+			/>,
+		);
+
+		getLastInputHandler()('', makeKey({escape: true}) as never);
+
+		expect(onCancel).toHaveBeenCalled();
+	});
+});

--- a/src/components/SessionActions.tsx
+++ b/src/components/SessionActions.tsx
@@ -2,48 +2,76 @@ import React from 'react';
 import {Box, Text, useInput} from 'ink';
 import SelectInput from 'ink-select-input';
 
-export type SessionActionType = 'newSession' | 'rename' | 'kill';
+export type SessionActionType =
+	| 'newSession'
+	| 'rename'
+	| 'kill'
+	| 'deleteWorktree';
 
 interface SessionActionsProps {
 	sessionLabel: string;
+	/**
+	 * Whether the row this menu was opened from has a running session. Session
+	 * specific actions (rename, close) are hidden when it does not.
+	 */
+	hasSession?: boolean;
+	/**
+	 * Whether the worktree of this row may be deleted; see isDeletableWorktree.
+	 * The delete entry is hidden rather than shown-and-rejected so no
+	 * unselectable option appears.
+	 */
+	canDeleteWorktree?: boolean;
 	onSelect: (action: SessionActionType) => void;
 	onCancel: () => void;
 }
 
-const items: Array<{label: string; value: SessionActionType}> = [
-	{label: 'S  New session in same directory', value: 'newSession'},
-	{label: 'R  Rename this session', value: 'rename'},
-	{label: 'X  Close session', value: 'kill'},
-];
+const buildItems = (
+	hasSession: boolean,
+	canDeleteWorktree: boolean,
+): Array<{label: string; value: SessionActionType}> => {
+	const items: Array<{label: string; value: SessionActionType}> = [
+		{label: 'S  New session in this worktree', value: 'newSession'},
+	];
+
+	if (hasSession) {
+		items.push({label: 'R  Rename this session', value: 'rename'});
+		items.push({label: 'X  Close session', value: 'kill'});
+	}
+
+	if (canDeleteWorktree) {
+		items.push({label: 'D  Delete this worktree', value: 'deleteWorktree'});
+	}
+
+	return items;
+};
 
 const SessionActions: React.FC<SessionActionsProps> = ({
 	sessionLabel,
+	hasSession = true,
+	canDeleteWorktree = false,
 	onSelect,
 	onCancel,
 }) => {
+	const items = buildItems(hasSession, canDeleteWorktree);
+
 	useInput((input, key) => {
 		if (key.escape) {
 			onCancel();
 			return;
 		}
 
-		switch (input.toLowerCase()) {
-			case 's':
-				onSelect('newSession');
-				break;
-			case 'r':
-				onSelect('rename');
-				break;
-			case 'x':
-				onSelect('kill');
-				break;
+		const shortcut = items.find(
+			item => item.label[0]?.toLowerCase() === input.toLowerCase(),
+		);
+		if (shortcut) {
+			onSelect(shortcut.value);
 		}
 	});
 
 	return (
 		<Box flexDirection="column" padding={1}>
 			<Text bold color="cyan">
-				Session Actions
+				{hasSession ? 'Session Actions' : 'Worktree Actions'}
 			</Text>
 			<Box marginTop={1}>
 				<Text dimColor>{sessionLabel}</Text>
@@ -52,7 +80,10 @@ const SessionActions: React.FC<SessionActionsProps> = ({
 				<SelectInput items={items} onSelect={item => onSelect(item.value)} />
 			</Box>
 			<Box marginTop={1}>
-				<Text dimColor>S/R/X or arrow keys + Enter | Escape to cancel</Text>
+				<Text dimColor>
+					{items.map(item => item.label[0]).join('/')} or arrow keys + Enter |
+					Escape to cancel
+				</Text>
 			</Box>
 		</Box>
 	);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,9 +85,12 @@ export type MenuAction =
 	| {type: 'renameSession'; session: Session}
 	| {type: 'killSession'; sessionId: string}
 	| {
+			// Row-level actions opened with Space. `session` is absent for a
+			// worktree row that has no session yet; the actions menu then offers
+			// only the worktree-level entries.
 			type: 'sessionActions';
-			session: Session;
-			worktreePath: string;
+			worktree: Worktree;
+			session?: Session;
 	  }
 	| {type: 'deleteWorktree'}
 	| {type: 'mergeWorktree'}

--- a/src/utils/worktreeUtils.test.ts
+++ b/src/utils/worktreeUtils.test.ts
@@ -6,6 +6,7 @@ import {
 	prepareSessionItems,
 	calculateColumnPositions,
 	assembleSessionLabel,
+	isDeletableWorktree,
 } from './worktreeUtils.js';
 import {Worktree, Session} from '../types/index.js';
 import {execSync} from 'child_process';
@@ -464,5 +465,54 @@ describe('column alignment', () => {
 		// Check alignment by stripping ANSI codes
 		const plain = result.replace(/\x1b\[[0-9;]*m/g, '');
 		expect(plain.indexOf('+10 -5')).toBe(21); // Should start at column 21
+	});
+});
+
+describe('isDeletableWorktree', () => {
+	it('should reject the main worktree', () => {
+		expect(
+			isDeletableWorktree(
+				{path: '/repo', isMainWorktree: true},
+				'/somewhere/else',
+			),
+		).toBe(false);
+	});
+
+	it('should reject the worktree holding the current working directory', () => {
+		expect(
+			isDeletableWorktree(
+				{path: '/repo/worktrees/feature', isMainWorktree: false},
+				'/repo/worktrees/feature',
+			),
+		).toBe(false);
+	});
+
+	it('should reject a worktree that is an ancestor of the current working directory', () => {
+		expect(
+			isDeletableWorktree(
+				{path: '/repo/worktrees/feature', isMainWorktree: false},
+				'/repo/worktrees/feature/src/components',
+			),
+		).toBe(false);
+	});
+
+	it('should accept a sibling worktree with a shared path prefix', () => {
+		// '/repo/worktrees/feature-2' starts with the '/repo/worktrees/feature'
+		// string but is a different directory, so it stays deletable.
+		expect(
+			isDeletableWorktree(
+				{path: '/repo/worktrees/feature', isMainWorktree: false},
+				'/repo/worktrees/feature-2',
+			),
+		).toBe(true);
+	});
+
+	it('should accept an unrelated linked worktree', () => {
+		expect(
+			isDeletableWorktree(
+				{path: '/repo/worktrees/feature', isMainWorktree: false},
+				'/repo',
+			),
+		).toBe(true);
 	});
 });

--- a/src/utils/worktreeUtils.ts
+++ b/src/utils/worktreeUtils.ts
@@ -461,3 +461,33 @@ export function assembleSessionLabel(
 
 	return label;
 }
+
+/**
+ * Whether a worktree may be deleted by CCManager.
+ *
+ * Two worktrees are off limits:
+ * - the main worktree, because git refuses to remove it and the repository
+ *   would be left without a checkout;
+ * - the worktree that contains the current working directory, because removing
+ *   the directory CCManager is running in breaks the running process.
+ *
+ * Single source of truth for the rule, shared by the multi-select delete screen
+ * and the per-row delete action.
+ */
+export function isDeletableWorktree(
+	worktree: Pick<Worktree, 'path' | 'isMainWorktree'>,
+	cwd: string = process.cwd(),
+): boolean {
+	if (worktree.isMainWorktree) return false;
+
+	const resolvedCwd = path.resolve(cwd);
+	const resolvedPath = path.resolve(worktree.path);
+	if (
+		resolvedCwd === resolvedPath ||
+		resolvedCwd.startsWith(resolvedPath + path.sep)
+	) {
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
## Why

Deleting a worktree required the `D` screen, which lists every worktree and makes you locate the one that is already highlighted in the menu. Space now opens the row actions for the highlighted worktree and can delete it directly.

## What changed

- **Space works on any worktree row**, not only rows that have a session. Rename/Close are session-specific and stay hidden when the row has no session, so the menu title switches to "Worktree Actions".
- **The delete entry is hidden when the worktree cannot be deleted** (the main worktree, and the worktree containing the current working directory) instead of being shown and rejected. That rule moved into `isDeletableWorktree()` in `src/utils/worktreeUtils.ts`, and the existing `D` screen now uses it too, so both paths share one source.
- **Choosing it reuses the existing confirmation and deletion path**: `DeleteConfirmation` (uncommitted-changes warning, branch option, Cancel selected by default) followed by `handleDeleteWorktrees`, which kills the worktree's sessions before removing it. On failure this flow returns to the menu with the error, because the multi-select delete screen was never opened here.
- The Dashboard entry point into the actions menu has only a session and no worktree, so it offers no deletion.

`MenuAction.sessionActions` now carries the `Worktree` instead of a bare `worktreePath` (the path is read from it, so the two no longer duplicate each other).

## Verification

- `bun run lint`, `bun run typecheck`: pass.
- `bun run test`: 1788 passed. The `*.submodule.test.ts` files fail in `beforeAll` in my local environment because `git config --global protocol.file.allow always` cannot write `~/.gitconfig` there; this is unrelated to the change (the prebuilt, unmodified `dist` copies of those tests fail identically). CI should run them normally.
- New tests: `src/components/SessionActions.test.tsx` (which entries are offered, hotkey dispatch), a `Menu.test.tsx` case for Space on a session-less row, and `isDeletableWorktree` cases in `src/utils/worktreeUtils.test.ts`.
- Not verified by driving the actual TUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
