### PR TITLE
feat: add ccmanager-config skill installable via claude/codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+	"name": "ccmanager",
+	"description": "Plugins that help you work with CCManager, the TUI session manager for AI coding agents across git worktrees",
+	"owner": {
+		"name": "kbwo",
+		"url": "https://github.com/kbwo"
+	},
+	"plugins": [
+		{
+			"name": "ccmanager-config",
+			"description": "Writes, reviews, and fixes CCManager configuration files (.ccmanager.json and the global config.json): command presets, status/worktree hooks, worktree auto-directory patterns, merge arguments, shortcuts, and auto-approval.",
+			"source": "./plugins/ccmanager-config",
+			"category": "productivity",
+			"homepage": "https://github.com/kbwo/ccmanager/tree/main/plugins/ccmanager-config"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ CCManager supports per-project configuration by placing a `.ccmanager.json` file
 
 For detailed configuration options and examples, see [docs/project-config.md](docs/project-config.md).
 
+### Configuring with an AI coding agent
+
+This repository doubles as a plugin marketplace providing the **`ccmanager-config`** skill, which teaches Claude Code or Codex the whole configuration schema and ships a validator for it:
+
+```bash
+# Claude Code
+claude plugin marketplace add kbwo/ccmanager
+claude plugin install ccmanager-config@ccmanager
+
+# Codex CLI
+codex plugin marketplace add kbwo/ccmanager
+codex plugin add ccmanager-config@ccmanager
+```
+
+Then just ask — "set this repo up to run codex in ccmanager", "notify me when a session is waiting for input", "why is my `.ccmanager.json` being ignored?". See [plugins/ccmanager-config/README.md](plugins/ccmanager-config/README.md).
+
 ## Supported AI Assistants
 
 CCManager supports multiple AI coding assistants with tailored state detection for each:

--- a/docs/auto-approval.md
+++ b/docs/auto-approval.md
@@ -35,7 +35,7 @@ Leave `"enabled": false` to turn it off. You can also add `"customCommand": "my-
   - Environment variables provided:
     - `DEFAULT_PROMPT`: the exact prompt text CCManager would have sent to Claude (includes the terminal output and instructions).
     - `TERMINAL_OUTPUT`: the captured terminal output (same content embedded in `DEFAULT_PROMPT`).
-  - Timeout: 60 seconds; if it hangs, CCManager kills it and falls back to manual approval.
+  - Timeout: `autoApproval.timeout` seconds (default 120); if it hangs, CCManager kills it and falls back to manual approval.
 - Expected output: the command must print JSON to stdout matching `{"needsPermission": true|false, "reason"?: "short string"}`. If parsing fails or the exit code is non‑zero, CCManager treats it as “permission needed”.
 - Tips:
   - Keep it lightweight; long-running analysis will delay your prompt.
@@ -53,7 +53,7 @@ Leave `"enabled": false` to turn it off. You can also add `"customCommand": "my-
 ## How It Works
 - **When it runs:** If a session enters a prompt state that normally waits for your input, CCManager marks it as “Auto-approval pending…” and grabs the most recent terminal output (up to 300 lines).
 - **Approval step:** By default CCManager runs `claude --model haiku -p --output-format json --json-schema …`, passing the captured terminal output into the prompt so Claude can judge whether the action needs your permission.
-- **Decision:** If Claude replies that permission is not needed and the session is still waiting, CCManager sends a carriage return (`\r`) to the session—equivalent to pressing Enter for you. If Claude says permission is needed, the check times out (60s), errors, or you press any key while it’s pending, auto approval stops and the session stays in manual approval with a short reason displayed.
+- **Decision:** If Claude replies that permission is not needed and the session is still waiting, CCManager sends a carriage return (`\r`) to the session—equivalent to pressing Enter for you. If Claude says permission is needed, the check times out (`autoApproval.timeout` seconds, default 120), errors, or you press any key while it’s pending, auto approval stops and the session stays in manual approval with a short reason displayed.
 - **Safety:** When the helper fails for any reason, CCManager defaults to requiring your approval instead of proceeding automatically.
 
 ## Things to Keep in Mind

--- a/docs/project-config.md
+++ b/docs/project-config.md
@@ -12,10 +12,11 @@ CCManager supports per-project configuration files that allow you to customize s
 
 ## Configuration Methods
 
-You can configure project settings in two ways:
+You can configure project settings in three ways:
 
 1. **Through the UI**: Select **Project Configuration** from the main menu
 2. **Configuration file**: Directly edit `.ccmanager.json` in your project's git repository root
+3. **With an AI coding agent**: install the [`ccmanager-config` skill](../plugins/ccmanager-config/README.md), which teaches Claude Code or Codex the full configuration schema and ships a validator
 
 ## Configuration File
 
@@ -23,9 +24,16 @@ Example `.ccmanager.json`:
 
 ```json
 {
-  "command": {
-    "name": "gemini",
-    "args": []
+  "commandPresets": {
+    "presets": [
+      {
+        "id": "gemini",
+        "name": "Gemini",
+        "command": "gemini",
+        "detectionStrategy": "gemini"
+      }
+    ],
+    "defaultPresetId": "gemini"
   },
   "shortcuts": {
     "returnToMenu": {
@@ -37,6 +45,12 @@ Example `.ccmanager.json`:
 ```
 
 All options available in the global config can be used in the project config.
+
+Note that CCManager reports nothing when a config file is wrong: a file that is not valid JSON is discarded whole, and unrecognized keys are ignored silently. To check a file before wondering why a setting has no effect:
+
+```bash
+node plugins/ccmanager-config/skills/ccmanager-config/scripts/validate-ccmanager-config.mjs .ccmanager.json
+```
 
 ## Limitations
 

--- a/docs/worktree-auto-directory.md
+++ b/docs/worktree-auto-directory.md
@@ -37,7 +37,7 @@ Edit `~/.config/ccmanager/config.json`:
 ## Pattern Syntax
 
 The pattern supports the following placeholders:
-- `{branch}` or `{branch-name}`: Replaced with the sanitized branch name
+- `{branch}`: Replaced with the sanitized branch name
 - `{project}`: Replaced with the Git repository name (main working directory basename)
 
 ## Branch Name Sanitization

--- a/plugins/ccmanager-config/.claude-plugin/plugin.json
+++ b/plugins/ccmanager-config/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+	"name": "ccmanager-config",
+	"version": "0.1.0",
+	"description": "Writes, reviews, and fixes CCManager configuration files (.ccmanager.json and the global config.json): command presets, status/worktree hooks, worktree auto-directory patterns, merge arguments, shortcuts, and auto-approval.",
+	"author": {
+		"name": "kbwo",
+		"url": "https://github.com/kbwo"
+	},
+	"homepage": "https://github.com/kbwo/ccmanager/tree/main/plugins/ccmanager-config",
+	"repository": "https://github.com/kbwo/ccmanager",
+	"license": "MIT",
+	"keywords": ["ccmanager", "configuration", "git-worktree", "tui"]
+}

--- a/plugins/ccmanager-config/README.md
+++ b/plugins/ccmanager-config/README.md
@@ -1,0 +1,64 @@
+# ccmanager-config
+
+An agent skill that writes, reviews, and repairs CCManager configuration —
+`.ccmanager.json` in a git repository root, and the global
+`~/.config/ccmanager/config.json`.
+
+It exists because CCManager stays silent about bad configuration: a file that
+is not valid JSON is discarded whole, and unknown keys are ignored without a
+message, so a typo looks exactly like a feature that does not work. The skill
+carries the full key reference, worked examples, and a validator that catches
+those silent failures.
+
+## Install
+
+The plugin lives in this repository, which doubles as a plugin marketplace.
+
+**Claude Code**
+
+```bash
+claude plugin marketplace add kbwo/ccmanager
+claude plugin install ccmanager-config@ccmanager
+```
+
+**Codex CLI**
+
+```bash
+codex plugin marketplace add kbwo/ccmanager
+codex plugin add ccmanager-config@ccmanager
+```
+
+Both read the marketplace from [`.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json)
+at the repository root. To try a local checkout instead, pass its path in place
+of `kbwo/ccmanager`.
+
+Once installed, ask for what you want in plain language — "set this repo up to
+run codex in ccmanager", "notify me when a session is waiting", "why is my
+`.ccmanager.json` being ignored?" — and the agent loads the skill on its own.
+
+## Contents
+
+| Path | What it is |
+| --- | --- |
+| `skills/ccmanager-config/SKILL.md` | the procedure the agent follows |
+| `skills/ccmanager-config/references/config-reference.md` | every config key: type, default, behaviour |
+| `skills/ccmanager-config/references/recipes.md` | copy-and-adapt configurations per goal |
+| `skills/ccmanager-config/schema/ccmanager.schema.json` | JSON Schema for both config files |
+| `skills/ccmanager-config/scripts/validate-ccmanager-config.mjs` | validator, also usable on its own |
+
+The validator needs nothing but Node:
+
+```bash
+node skills/ccmanager-config/scripts/validate-ccmanager-config.mjs path/to/.ccmanager.json
+```
+
+## Editor completion
+
+Point your editor at the schema by adding `$schema` to the config file — CCManager
+ignores the key:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/kbwo/ccmanager/main/plugins/ccmanager-config/skills/ccmanager-config/schema/ccmanager.schema.json"
+}
+```

--- a/plugins/ccmanager-config/skills/ccmanager-config/SKILL.md
+++ b/plugins/ccmanager-config/skills/ccmanager-config/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ccmanager-config
+description: Set up, review, or repair a CCManager config — `.ccmanager.json` at a git repository root, or the global `~/.config/ccmanager/config.json`. Use when someone wants ccmanager to launch a different agent CLI (codex, gemini, cursor-agent, copilot…), add command presets, run a command on session state changes or worktree creation, auto-generate worktree directory paths, change merge/rebase arguments, rebind the return-to-menu key, turn on auto-approval — or when a ccmanager setting "does not seem to do anything".
+---
+
+# Configuring CCManager
+
+CCManager (`ccmanager`) is a terminal UI that runs one AI coding agent per git
+worktree. Its behaviour comes from two JSON files with **identical shape**:
+
+| File | Scope | Notes |
+| --- | --- | --- |
+| `<git repository root>/.ccmanager.json` | one repository | commit it to share with the team |
+| `~/.config/ccmanager/config.json` (`%APPDATA%\ccmanager\config.json` on Windows) | the user, all repositories | also written by ccmanager's own **Global Configuration** menu |
+
+Per key, the project file wins over the global file. Both are optional.
+
+The reason this skill exists: **CCManager reports nothing when a config is
+wrong.** A file that is not valid JSON is discarded whole, and unknown keys are
+ignored without a message, so a typo is indistinguishable from a feature that
+does not work. Every change made through this skill therefore ends with the
+validator run in step 4.
+
+## Procedure
+
+### 1. Decide which file to edit
+
+Ask yourself, and the user if it is genuinely ambiguous:
+
+- Does the setting describe **the repository** (which agent CLI to run, what to
+  do after a worktree is created, where worktrees live)? → `.ccmanager.json`,
+  committed.
+- Does it describe **this person's machine or taste** (notification commands,
+  key bindings, personal API/model flags)? → the global `config.json`.
+
+Two traps before you write anything:
+
+- Put `.ccmanager.json` **at the main repository root**, not inside a linked
+  worktree. CCManager resolves any worktree back to the main checkout, so a
+  config file inside a worktree is never read.
+- If ccmanager is started in multi-project mode (the
+  `CCMANAGER_MULTI_PROJECT_ROOT` environment variable is set, or `--multi-project`
+  is passed), project files are skipped entirely and only the global config
+  applies. Say so rather than writing a file that will be ignored.
+
+### 2. Read what is already there
+
+`cat` the target file if it exists, plus the other file in the pair when the
+user's request depends on the merged result. Never rewrite a config from
+scratch when one exists — you would silently drop settings you were not asked
+about.
+
+### 3. Write the config
+
+Look every key up in **`references/config-reference.md`** (in this skill
+directory) before writing it: it lists each key with its type, its default, and
+what it actually does. Do not invent keys — anything not listed there is
+dropped by CCManager without a word.
+
+For the common goals — running codex/gemini/another CLI, several presets,
+desktop notifications, per-worktree setup commands, worktree path patterns,
+merge arguments, auto-approval — start from a worked example in
+**`references/recipes.md`** and adapt it.
+
+Three rules that cause most of the breakage:
+
+1. **Merging happens one key deep.** For each top-level key present in the
+   project file, that key's *fields* override the global ones; anything nested
+   below a field is replaced wholesale, not merged. In particular a project
+   `commandPresets.presets` array replaces the global preset list entirely — so
+   list every preset the repository needs, and give `defaultPresetId` the id of
+   one of *those* presets.
+2. **`args` is argv, one array element per token.** `["--model", "opus"]`, never
+   `["--model opus"]`.
+3. **A hook without `"enabled": true` never runs.** Both `command` and `enabled`
+   are required.
+
+### 4. Validate — always
+
+```bash
+node <skill-dir>/scripts/validate-ccmanager-config.mjs path/to/.ccmanager.json
+```
+
+It parses the file the way CCManager does, checks the shape against
+`schema/ccmanager.schema.json`, flags unknown keys (with a "did you mean"), and
+catches the mistakes JSON alone cannot express: a `defaultPresetId` matching no
+preset, duplicate preset ids, an `args` entry with spaces in it, a detection
+strategy that does not match the command, a shortcut that can never fire, a
+disabled hook, a worktree pattern without `{branch}`, a config file sitting in a
+linked worktree. It exits non-zero on errors; warnings are advisory.
+
+Report what it printed. If you cannot run it (no Node available), say so
+explicitly instead of claiming the config is fine.
+
+### 5. Tell the user how to pick it up
+
+CCManager reads config at start-up and when it reloads. After editing a file by
+hand, they should return to the ccmanager menu or restart it; sessions already
+running keep the command and detection strategy they were started with.
+
+## Reviewing an existing config ("this setting does nothing")
+
+Work down this list — these are the silent failures, in the order they bite:
+
+1. Run the validator (step 4). Invalid JSON and unknown/misspelled keys are the
+   two most common causes and both are invisible in the TUI.
+2. Check the file location: main repository root, not a worktree; and
+   multi-project mode disabled.
+3. Check the *other* file. The project file only overrides keys it actually
+   contains; everything else still comes from the global config.
+4. For presets: a `defaultPresetId` pointing at a preset that lives in the other
+   file silently falls back to the first preset in the list.
+5. For a session that reports the wrong status: `detectionStrategy` must match
+   the CLI being run — see the table in `references/config-reference.md`.
+
+## Files in this skill
+
+- `references/config-reference.md` — every key: type, default, behaviour, and
+  the hook environment variables.
+- `references/recipes.md` — copy-and-adapt configurations for the usual goals.
+- `schema/ccmanager.schema.json` — JSON Schema for both config files; usable as
+  `$schema` in an editor for completion.
+- `scripts/validate-ccmanager-config.mjs` — the validator from step 4.

--- a/plugins/ccmanager-config/skills/ccmanager-config/references/config-reference.md
+++ b/plugins/ccmanager-config/skills/ccmanager-config/references/config-reference.md
@@ -1,0 +1,296 @@
+# CCManager configuration reference
+
+Applies to both `.ccmanager.json` (git repository root) and
+`~/.config/ccmanager/config.json` — they accept the same keys.
+
+Written against **CCManager v4.2.3**. The authoritative definition is
+`ConfigurationData` / `ProjectConfigurationData` in
+[`src/types/index.ts`](https://github.com/kbwo/ccmanager/blob/main/src/types/index.ts);
+this document and `../schema/ccmanager.schema.json` follow it. If a key here
+disagrees with that file, that file wins.
+
+Top-level keys — all optional:
+
+| Key | Purpose |
+| --- | --- |
+| [`commandPresets`](#commandpresets) | which CLI(s) a session can start |
+| [`statusHooks`](#statushooks) | run a command when a session becomes idle/busy/waiting |
+| [`worktreeHooks`](#worktreehooks) | run a command before/after a worktree is created |
+| [`worktree`](#worktree) | worktree creation and list behaviour |
+| [`mergeConfig`](#mergeconfig) | arguments for the merge/rebase action |
+| [`shortcuts`](#shortcuts) | key bindings inside a session |
+| [`autoApproval`](#autoapproval) | experimental automatic answering of prompts |
+
+## How the two files combine
+
+For every top-level key the project file defines, its **fields** override the
+global file's fields; fields it omits keep the global value. The merge stops
+there — a nested array or object that a field holds is taken as a whole, never
+merged element by element (`ConfigReader` in
+`src/services/config/configReader.ts` does `{...global, ...project}` per key).
+
+Consequences worth planning around:
+
+- `commandPresets.presets` in the project file **replaces** the global preset
+  list. Repeat every preset the repository needs.
+- `commandPresets.defaultPresetId` is a separate field: if the project file
+  omits it, the *global* value is used, which usually points at a preset that no
+  longer exists — CCManager then falls back to the first preset in the list.
+- `shortcuts.returnToMenu` is replaced as a whole object, so give it every field
+  (`key` and `ctrl`), not just the one you are changing.
+
+---
+
+## `commandPresets`
+
+```json
+{
+  "commandPresets": {
+    "presets": [
+      {
+        "id": "1",
+        "name": "Claude",
+        "command": "claude",
+        "args": ["--model", "opus"],
+        "fallbackArgs": [],
+        "detectionStrategy": "claude"
+      }
+    ],
+    "defaultPresetId": "1",
+    "selectPresetOnStart": false
+  }
+}
+```
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `presets` | array, required | one preset running `claude` | The list offered when starting a session. |
+| `defaultPresetId` | string, required | `"1"` | `id` of the preset used when no choice is made. No match → first preset in the list. |
+| `selectPresetOnStart` | boolean | `false` | Show the picker before every new session instead of using the default. |
+
+Per preset:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `id` | string, required | Unique within `presets`. Any string; the UI generates `"1"`, `"2"`, … |
+| `name` | string, required | Label in the picker. |
+| `command` | string, required | Executable, resolved on `PATH`. |
+| `args` | string[] | argv entries, **one token per element**. `["--model", "opus"]`. |
+| `fallbackArgs` | string[] | Tried once if the session fails to start with `args`. Keep it minimal — `[]` retries the bare command. |
+| `detectionStrategy` | enum | How session state is read from the terminal. Defaults to `"claude"`. |
+
+### `detectionStrategy` per CLI
+
+Set this whenever `command` is not `claude`, otherwise the session status
+(idle / busy / waiting for input) — and therefore `statusHooks` and
+auto-approval — is read with the wrong patterns and will be wrong.
+
+| CLI | `command` | `detectionStrategy` |
+| --- | --- | --- |
+| Claude Code | `claude` | `claude` (default) |
+| Gemini CLI | `gemini` | `gemini` |
+| Codex CLI | `codex` | `codex` |
+| Cursor Agent | `cursor-agent` | `cursor` |
+| GitHub Copilot CLI | `copilot` | `github-copilot` |
+| Cline CLI | `cline` | `cline` |
+| OpenCode | `opencode` | `opencode` |
+| Kimi CLI | `kimi` | `kimi` |
+
+A wrapper script around one of these takes the strategy of the CLI it wraps.
+
+### Claude Code teammate mode
+
+For `command: "claude"` with the `claude` strategy, CCManager appends
+`--teammate-mode in-process` itself, to keep Claude Code's agent teams from
+fighting its PTY session management. Only set `--teammate-mode` in `args` if you
+deliberately want a different value; yours wins.
+
+---
+
+## `statusHooks`
+
+```json
+{
+  "statusHooks": {
+    "waiting_input": {
+      "command": "notify-send 'Claude' \"waiting in $CCMANAGER_WORKTREE_BRANCH\"",
+      "enabled": true
+    }
+  }
+}
+```
+
+Keys: `idle`, `busy`, `waiting_input`, `pending_auto_approval`. Each takes
+`{"command": string, "enabled": boolean}` — **both required**, and `enabled`
+must be `true` or the hook is skipped.
+
+The command runs through the shell, in the worktree directory, with:
+
+| Variable | Value |
+| --- | --- |
+| `CCMANAGER_OLD_STATE` | previous state |
+| `CCMANAGER_NEW_STATE` | new state |
+| `CCMANAGER_WORKTREE_PATH` | absolute path of the worktree |
+| `CCMANAGER_WORKTREE_DIR` | its basename |
+| `CCMANAGER_WORKTREE_BRANCH` | its branch |
+| `CCMANAGER_SESSION_ID` | session identifier |
+
+Keep hooks fast and non-interactive: they fire on every state transition of
+every session.
+
+---
+
+## `worktreeHooks`
+
+```json
+{
+  "worktreeHooks": {
+    "post_creation": {"command": "bun install", "enabled": true}
+  }
+}
+```
+
+| Hook | Runs | Working directory | On failure |
+| --- | --- | --- | --- |
+| `pre_creation` | before the worktree is created | git root (the worktree does not exist yet) | **non-zero exit aborts creation** — use it for validation |
+| `post_creation` | after creation succeeded | the new worktree | logged, worktree is kept |
+
+Same `{"command", "enabled"}` shape as status hooks. Environment:
+
+| Variable | Value |
+| --- | --- |
+| `CCMANAGER_WORKTREE_PATH` | path of the new worktree (planned path, for `pre_creation`) |
+| `CCMANAGER_WORKTREE_BRANCH` | its branch |
+| `CCMANAGER_GIT_ROOT` | repository root |
+| `CCMANAGER_BASE_BRANCH` | base branch, when known |
+
+From a `post_creation` hook, reach the main checkout with
+`cd "$CCMANAGER_GIT_ROOT" && …`.
+
+---
+
+## `worktree`
+
+```json
+{
+  "worktree": {
+    "autoDirectory": true,
+    "autoDirectoryPattern": "../{project}-worktrees/{branch}",
+    "copySessionData": true,
+    "sortByLastSession": false,
+    "autoUseDefaultBranch": false,
+    "includeRemoteBranches": false
+  }
+}
+```
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `autoDirectory` | boolean | `false` | Derive the directory from the branch name instead of prompting for it. |
+| `autoDirectoryPattern` | string | `"../{branch}"` | Template used when `autoDirectory` is on. |
+| `copySessionData` | boolean | `true` | Default answer to "copy Claude Code session data into the new worktree?". |
+| `sortByLastSession` | boolean | `false` | Order the worktree list by most recently opened session. |
+| `autoUseDefaultBranch` | boolean | `false` | Skip the base-branch prompt; branch off the repository default branch. |
+| `includeRemoteBranches` | boolean | `false` | Offer remote branches when picking a base branch. |
+
+Pattern placeholders: `{branch}` and `{project}`, the basename of the main
+working directory. (`{branch-name}` appears in CCManager's own documentation but
+is left in the path verbatim — the substitution only matches `{word}` with no
+dash. Use `{branch}`.) The branch name is sanitised first:
+`/` → `-`, anything outside `[A-Za-z0-9._-]` dropped, lower-cased, leading and
+trailing dashes trimmed — `Feature/Login` becomes `feature-login`. Relative
+patterns resolve against the repository root. A pattern without `{branch}`
+produces the same directory for every branch and fails after the first.
+
+---
+
+## `mergeConfig`
+
+```json
+{
+  "mergeConfig": {
+    "mergeArgs": ["--no-ff"],
+    "rebaseArgs": ["--autostash"]
+  }
+}
+```
+
+Both arrays are spliced into the command the worktree merge action runs:
+`git merge <mergeArgs> "<source-branch>"` and
+`git rebase <rebaseArgs> "<target-branch>"`. Defaults: `["--no-ff"]` for merge,
+`[]` for rebase. Supplying `mergeArgs` replaces `--no-ff`; include it if you
+still want it.
+
+---
+
+## `shortcuts`
+
+```json
+{
+  "shortcuts": {
+    "returnToMenu": {"ctrl": true, "key": "e"},
+    "cancel": {"key": "escape"}
+  }
+}
+```
+
+Only two bindings exist: `returnToMenu` (default Ctrl+E) and `cancel` (default
+Escape).
+
+- A binding is either `{"key": "escape"}` or `{"ctrl": true, "key": "<single
+  character>"}`.
+- `alt` and `shift` exist in the type but are rejected when matching a
+  keypress — a binding using them can never fire.
+- Omitting `ctrl` on a character binding also never matches.
+- Avoid Ctrl+C, Ctrl+D and Ctrl+[ — the terminal claims them first.
+
+Legacy `~/.config/ccmanager/shortcuts.json` is migrated into the global
+`config.json` automatically on first run.
+
+---
+
+## `autoApproval`
+
+Experimental. When a session stops on a permission prompt, CCManager asks a
+helper whether the action needs a human, and presses Enter for you if it does
+not.
+
+```json
+{
+  "autoApproval": {
+    "enabled": true,
+    "timeout": 120,
+    "customCommand": "my-approver"
+  }
+}
+```
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `enabled` | boolean, required | `false` | Turns the feature on. |
+| `timeout` | number (seconds) | `120` | Verification is killed after this and the prompt goes back to you. |
+| `customCommand` | string | — | Replaces the built-in check. |
+
+Without `customCommand`, CCManager runs the installed `claude` CLI
+(`claude --model <model> -p --output-format json --json-schema …`); it is not
+bundled, so it must be on `PATH`.
+
+A `customCommand` runs through the shell with `DEFAULT_PROMPT` and
+`TERMINAL_OUTPUT` in its environment and must print
+`{"needsPermission": true|false, "reason"?: "…"}` on stdout. Anything else — a
+parse failure, a non-zero exit, the timeout — is treated as "permission
+needed", which leaves the prompt to you. Auto-approval only ever sends Enter,
+so it suits confirmation prompts and nothing else.
+
+---
+
+## Keys that do **not** exist
+
+Silently ignored if you write them:
+
+- `command` / `command.name` — an older CCManager shape. Use `commandPresets`.
+- `presets` at the top level — it belongs inside `commandPresets`.
+- `devcontainer` — devcontainer support is driven by CLI flags, not by these
+  files.
+- `multiProject` — multi-project mode comes from the
+  `CCMANAGER_MULTI_PROJECT_ROOT` environment variable and `--multi-project`.

--- a/plugins/ccmanager-config/skills/ccmanager-config/references/recipes.md
+++ b/plugins/ccmanager-config/skills/ccmanager-config/references/recipes.md
@@ -1,0 +1,253 @@
+# CCManager configuration recipes
+
+Working starting points, one per goal. Adapt, then validate with
+`scripts/validate-ccmanager-config.mjs`. Key-by-key meaning lives in
+`config-reference.md`.
+
+Unless stated otherwise these go in `.ccmanager.json` at the **main** git
+repository root; the same JSON is valid in `~/.config/ccmanager/config.json`.
+
+---
+
+## Run a different agent CLI for this repository
+
+Everyone opening this repository gets Codex instead of Claude Code.
+`detectionStrategy` is what makes the idle/busy/waiting indicator correct — do
+not omit it.
+
+```json
+{
+  "commandPresets": {
+    "presets": [
+      {
+        "id": "codex",
+        "name": "Codex",
+        "command": "codex",
+        "detectionStrategy": "codex"
+      }
+    ],
+    "defaultPresetId": "codex"
+  }
+}
+```
+
+## Offer several agents, and choose per session
+
+`selectPresetOnStart` shows the picker every time a session starts; without it
+the `defaultPresetId` preset starts silently.
+
+```json
+{
+  "commandPresets": {
+    "presets": [
+      {
+        "id": "claude",
+        "name": "Claude (resume)",
+        "command": "claude",
+        "args": ["--resume"],
+        "fallbackArgs": []
+      },
+      {
+        "id": "claude-plan",
+        "name": "Claude (opus, plan mode)",
+        "command": "claude",
+        "args": ["--model", "opus", "--permission-mode", "plan"],
+        "fallbackArgs": ["--model", "opus"]
+      },
+      {
+        "id": "codex",
+        "name": "Codex",
+        "command": "codex",
+        "detectionStrategy": "codex"
+      }
+    ],
+    "defaultPresetId": "claude",
+    "selectPresetOnStart": true
+  }
+}
+```
+
+`fallbackArgs` is the single retry when the first launch fails — keep it to a
+combination that always starts. `[]` retries the bare command.
+
+## Get notified when a session wants your attention
+
+Personal taste, so this belongs in the **global** config. Replace `terminal-notifier`
+with whatever the machine has (`notify-send`, `noti`, `osascript`, …).
+
+```json
+{
+  "statusHooks": {
+    "waiting_input": {
+      "command": "terminal-notifier -title CCManager -message \"waiting: $CCMANAGER_WORKTREE_BRANCH\"",
+      "enabled": true
+    },
+    "idle": {
+      "command": "terminal-notifier -title CCManager -message \"done: $CCMANAGER_WORKTREE_BRANCH\"",
+      "enabled": true
+    }
+  }
+}
+```
+
+Do not hook `busy`: it fires constantly.
+
+## Make a new worktree usable immediately
+
+Untracked but required files (`.env`, local settings) do not come along with a
+new worktree, and dependencies are not installed. A `post_creation` hook runs
+inside the fresh worktree, so relative paths refer to it and
+`$CCMANAGER_GIT_ROOT` refers to the main checkout.
+
+```json
+{
+  "worktreeHooks": {
+    "post_creation": {
+      "command": "cp \"$CCMANAGER_GIT_ROOT/.env\" . 2>/dev/null; bun install",
+      "enabled": true
+    }
+  }
+}
+```
+
+Keep it non-interactive and reasonably quick — worktree creation waits for it.
+
+## Refuse worktrees that break the branch convention
+
+`pre_creation` runs in the git root and a non-zero exit aborts creation, so it
+works as a gate. Write the reason to stderr; it is shown to the user.
+
+```json
+{
+  "worktreeHooks": {
+    "pre_creation": {
+      "command": "case \"$CCMANAGER_WORKTREE_BRANCH\" in feature/*|fix/*|chore/*) exit 0;; *) echo 'branch must start with feature/, fix/ or chore/' >&2; exit 1;; esac",
+      "enabled": true
+    }
+  }
+}
+```
+
+## Put every worktree in one predictable directory
+
+Stops CCManager asking for a path, and keeps worktrees out of the repository.
+`{project}` is the main checkout's directory name, `{branch}` the branch with
+`/` turned into `-`; `feature/login` in `myapp` lands in
+`../myapp-worktrees/feature-login`.
+
+```json
+{
+  "worktree": {
+    "autoDirectory": true,
+    "autoDirectoryPattern": "../{project}-worktrees/{branch}",
+    "autoUseDefaultBranch": true,
+    "sortByLastSession": true
+  }
+}
+```
+
+Drop `autoUseDefaultBranch` if branches are often cut from something other than
+the default branch — it removes the base-branch prompt entirely.
+
+## Change how the merge action integrates a worktree
+
+The default is `git merge --no-ff <source>`. To fast-forward instead, or to make
+rebase stash local edits first:
+
+```json
+{
+  "mergeConfig": {
+    "mergeArgs": ["--ff-only"],
+    "rebaseArgs": ["--autostash"]
+  }
+}
+```
+
+`mergeArgs` replaces the default, so re-list `--no-ff` if you want to keep it.
+
+## Free up Ctrl+E for the agent
+
+Global config; `returnToMenu` must be replaced as a whole object.
+
+```json
+{
+  "shortcuts": {
+    "returnToMenu": {"ctrl": true, "key": "g"},
+    "cancel": {"key": "escape"}
+  }
+}
+```
+
+Ctrl only. Ctrl+C, Ctrl+D and Ctrl+[ are taken by the terminal.
+
+## Auto-approve routine prompts (experimental)
+
+CCManager asks a helper whether a waiting prompt needs a human, and presses
+Enter when it does not. The built-in helper shells out to the `claude` CLI, so
+it must be installed.
+
+```json
+{
+  "autoApproval": {
+    "enabled": true,
+    "timeout": 120
+  }
+}
+```
+
+To judge with something else, print the verdict as JSON on stdout. The prompt
+arrives in `$DEFAULT_PROMPT`, the captured terminal output in
+`$TERMINAL_OUTPUT`; anything unparseable, a non-zero exit, or the timeout means
+"ask the human".
+
+```json
+{
+  "autoApproval": {
+    "enabled": true,
+    "customCommand": "codex exec --json \"$DEFAULT_PROMPT\" --output-schema /abs/path/auto-approval.schema.json --output-last-message /tmp/codex-approval.json > /dev/null && cat /tmp/codex-approval.json"
+  }
+}
+```
+
+(`auto-approval.schema.json` ships in the CCManager repository under `docs/`
+and is not installed with the binary — keep a local copy.)
+
+## A full project file
+
+Everything a repository would reasonably pin, in one file:
+
+```json
+{
+  "commandPresets": {
+    "presets": [
+      {
+        "id": "claude",
+        "name": "Claude",
+        "command": "claude",
+        "args": ["--resume"],
+        "fallbackArgs": []
+      },
+      {
+        "id": "codex",
+        "name": "Codex",
+        "command": "codex",
+        "detectionStrategy": "codex"
+      }
+    ],
+    "defaultPresetId": "claude",
+    "selectPresetOnStart": true
+  },
+  "worktree": {
+    "autoDirectory": true,
+    "autoDirectoryPattern": "../{project}-worktrees/{branch}",
+    "copySessionData": true,
+    "sortByLastSession": true
+  },
+  "worktreeHooks": {
+    "post_creation": {"command": "bun install", "enabled": true}
+  },
+  "mergeConfig": {
+    "mergeArgs": ["--no-ff"]
+  }
+}
+```

--- a/plugins/ccmanager-config/skills/ccmanager-config/schema/ccmanager.schema.json
+++ b/plugins/ccmanager-config/skills/ccmanager-config/schema/ccmanager.schema.json
@@ -1,0 +1,210 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://github.com/kbwo/ccmanager/blob/main/plugins/ccmanager-config/skills/ccmanager-config/schema/ccmanager.schema.json",
+	"title": "CCManager configuration",
+	"description": "Shape of `.ccmanager.json` (per-project, at the git repository root) and of the global `~/.config/ccmanager/config.json`. Both files accept the same keys. Canonical source of truth: `ConfigurationData` / `ProjectConfigurationData` in src/types/index.ts of kbwo/ccmanager (written against v4.2.3).",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"description": "Ignored by CCManager. Present only so editors can offer completion."
+		},
+		"shortcuts": {
+			"type": "object",
+			"description": "Key bindings for the session view. Only the `ctrl` modifier actually works; `alt` and `shift` are rejected at match time.",
+			"additionalProperties": false,
+			"properties": {
+				"returnToMenu": {"$ref": "#/definitions/shortcutKey"},
+				"cancel": {"$ref": "#/definitions/shortcutKey"}
+			}
+		},
+		"statusHooks": {
+			"type": "object",
+			"description": "Shell commands run when a session changes state.",
+			"additionalProperties": false,
+			"properties": {
+				"idle": {"$ref": "#/definitions/hook"},
+				"busy": {"$ref": "#/definitions/hook"},
+				"waiting_input": {"$ref": "#/definitions/hook"},
+				"pending_auto_approval": {"$ref": "#/definitions/hook"}
+			}
+		},
+		"worktreeHooks": {
+			"type": "object",
+			"description": "Shell commands run around worktree creation.",
+			"additionalProperties": false,
+			"properties": {
+				"pre_creation": {"$ref": "#/definitions/hook"},
+				"post_creation": {"$ref": "#/definitions/hook"}
+			}
+		},
+		"worktree": {
+			"type": "object",
+			"description": "Worktree creation and listing behaviour.",
+			"additionalProperties": false,
+			"properties": {
+				"autoDirectory": {
+					"type": "boolean",
+					"description": "Generate the worktree directory from the branch name instead of asking for it. Default false."
+				},
+				"autoDirectoryPattern": {
+					"type": "string",
+					"description": "Path template used when autoDirectory is true. Placeholders: {branch} and {project}. Default \"../{branch}\"."
+				},
+				"copySessionData": {
+					"type": "boolean",
+					"description": "Default answer for \"copy Claude Code session data into the new worktree?\". Default true."
+				},
+				"sortByLastSession": {
+					"type": "boolean",
+					"description": "Sort the worktree list by most recently opened session. Default false."
+				},
+				"autoUseDefaultBranch": {
+					"type": "boolean",
+					"description": "Skip the base-branch prompt and always branch off the repository default branch. Default false."
+				},
+				"includeRemoteBranches": {
+					"type": "boolean",
+					"description": "Offer remote branches in the base-branch picker. Default false."
+				}
+			}
+		},
+		"commandPresets": {
+			"type": "object",
+			"description": "The commands CCManager can start a session with.",
+			"additionalProperties": false,
+			"required": ["presets", "defaultPresetId"],
+			"properties": {
+				"presets": {
+					"type": "array",
+					"minItems": 1,
+					"items": {"$ref": "#/definitions/commandPreset"}
+				},
+				"defaultPresetId": {
+					"type": "string",
+					"description": "`id` of the preset used when no preset is chosen explicitly."
+				},
+				"selectPresetOnStart": {
+					"type": "boolean",
+					"description": "Show the preset picker before every new session. Default false."
+				}
+			}
+		},
+		"mergeConfig": {
+			"type": "object",
+			"description": "Extra arguments for the merge/rebase action in the worktree menu.",
+			"additionalProperties": false,
+			"properties": {
+				"mergeArgs": {
+					"type": "array",
+					"items": {"type": "string"},
+					"description": "Arguments inserted into `git merge <args> \"<source>\"`. Default [\"--no-ff\"]."
+				},
+				"rebaseArgs": {
+					"type": "array",
+					"items": {"type": "string"},
+					"description": "Arguments inserted into `git rebase <args> \"<target>\"`. Default []."
+				}
+			}
+		},
+		"autoApproval": {
+			"type": "object",
+			"description": "Experimental: let CCManager answer a waiting prompt for you by sending Enter.",
+			"additionalProperties": false,
+			"required": ["enabled"],
+			"properties": {
+				"enabled": {"type": "boolean"},
+				"customCommand": {
+					"type": "string",
+					"description": "Shell command replacing the built-in `claude` check. Must print {\"needsPermission\": boolean, \"reason\"?: string} on stdout."
+				},
+				"timeout": {
+					"type": "number",
+					"exclusiveMinimum": 0,
+					"description": "Seconds to wait for the verification command. Default 120."
+				}
+			}
+		}
+	},
+	"definitions": {
+		"shortcutKey": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["key"],
+			"properties": {
+				"key": {
+					"type": "string",
+					"description": "A single character, or the literal \"escape\"."
+				},
+				"ctrl": {"type": "boolean"},
+				"alt": {
+					"type": "boolean",
+					"description": "Accepted by the schema but never matched at runtime; do not use."
+				},
+				"shift": {
+					"type": "boolean",
+					"description": "Accepted by the schema but never matched at runtime; do not use."
+				}
+			}
+		},
+		"hook": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["command", "enabled"],
+			"properties": {
+				"command": {
+					"type": "string",
+					"description": "Runs through the shell, in the worktree directory for status and post_creation hooks, in the git root for pre_creation."
+				},
+				"enabled": {
+					"type": "boolean",
+					"description": "The hook is skipped entirely unless this is true."
+				}
+			}
+		},
+		"commandPreset": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["id", "name", "command"],
+			"properties": {
+				"id": {
+					"type": "string",
+					"description": "Unique within `presets`; referenced by defaultPresetId."
+				},
+				"name": {
+					"type": "string",
+					"description": "Label shown in the preset picker."
+				},
+				"command": {
+					"type": "string",
+					"description": "Executable name, e.g. \"claude\", \"codex\", \"gemini\"."
+				},
+				"args": {
+					"type": "array",
+					"items": {"type": "string"},
+					"description": "One array element per argv entry, e.g. [\"--model\", \"opus\"]."
+				},
+				"fallbackArgs": {
+					"type": "array",
+					"items": {"type": "string"},
+					"description": "Retried once if the session fails to start with `args`."
+				},
+				"detectionStrategy": {
+					"type": "string",
+					"description": "How CCManager reads idle/busy/waiting state out of the terminal. Defaults to \"claude\".",
+					"enum": [
+						"claude",
+						"gemini",
+						"codex",
+						"cursor",
+						"github-copilot",
+						"cline",
+						"opencode",
+						"kimi"
+					]
+				}
+			}
+		}
+	}
+}

--- a/plugins/ccmanager-config/skills/ccmanager-config/scripts/validate-ccmanager-config.mjs
+++ b/plugins/ccmanager-config/skills/ccmanager-config/scripts/validate-ccmanager-config.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+/**
+ * Validates a CCManager config file (`.ccmanager.json` or the global
+ * `config.json`) and prints errors and warnings.
+ *
+ * Why this exists: CCManager never reports a bad config. A file that fails to
+ * parse is dropped whole (src/services/config/projectConfigManager.ts,
+ * loadProjectConfig catches and sets null), and keys it does not know are
+ * silently ignored — so a typo looks exactly like "the setting has no effect".
+ *
+ * Usage:
+ *   node validate-ccmanager-config.mjs [path-to-config]
+ *
+ * Defaults to ./.ccmanager.json. Exits 1 if any error was found, 0 otherwise
+ * (warnings alone do not fail).
+ */
+
+import {readFileSync, existsSync, statSync} from 'node:fs';
+import {dirname, join, resolve, basename} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const SCHEMA_PATH = join(
+	dirname(fileURLToPath(import.meta.url)),
+	'..',
+	'schema',
+	'ccmanager.schema.json',
+);
+
+const errors = [];
+const warnings = [];
+
+const error = (path, message) => errors.push({path, message});
+const warn = (path, message) => warnings.push({path, message});
+
+/* ------------------------------------------------------------------ *
+ * Minimal JSON Schema subset validator
+ * Supports: $ref (local), type, enum, properties, required,
+ * additionalProperties: false, items, minItems, exclusiveMinimum.
+ * ------------------------------------------------------------------ */
+
+function deref(schema, root) {
+	if (!schema || !schema.$ref) return schema;
+	const segments = schema.$ref.replace(/^#\//, '').split('/');
+	return segments.reduce((node, segment) => node?.[segment], root);
+}
+
+function typeOf(value) {
+	if (Array.isArray(value)) return 'array';
+	if (value === null) return 'null';
+	return typeof value;
+}
+
+function distance(a, b) {
+	const rows = Array.from({length: a.length + 1}, (_, i) => [
+		i,
+		...new Array(b.length).fill(0),
+	]);
+	for (let j = 0; j <= b.length; j++) rows[0][j] = j;
+	for (let i = 1; i <= a.length; i++) {
+		for (let j = 1; j <= b.length; j++) {
+			rows[i][j] = Math.min(
+				rows[i - 1][j] + 1,
+				rows[i][j - 1] + 1,
+				rows[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+			);
+		}
+	}
+	return rows[a.length][b.length];
+}
+
+function suggest(key, candidates) {
+	const ranked = candidates
+		.map(candidate => ({
+			candidate,
+			score: distance(key.toLowerCase(), candidate.toLowerCase()),
+		}))
+		.sort((a, b) => a.score - b.score);
+	const best = ranked[0];
+	if (best && best.score <= Math.max(2, Math.ceil(key.length / 3))) {
+		return ` Did you mean "${best.candidate}"?`;
+	}
+	return '';
+}
+
+function validate(value, schema, path, root) {
+	const resolved = deref(schema, root);
+	if (!resolved) return;
+
+	if (resolved.type && typeOf(value) !== resolved.type) {
+		error(path, `expected ${resolved.type}, got ${typeOf(value)}`);
+		return;
+	}
+
+	if (resolved.enum && !resolved.enum.includes(value)) {
+		error(
+			path,
+			`"${value}" is not a supported value. Allowed: ${resolved.enum
+				.map(v => `"${v}"`)
+				.join(', ')}`,
+		);
+		return;
+	}
+
+	if (resolved.type === 'number' && resolved.exclusiveMinimum !== undefined) {
+		if (!(value > resolved.exclusiveMinimum)) {
+			error(path, `must be greater than ${resolved.exclusiveMinimum}`);
+		}
+	}
+
+	if (resolved.type === 'array') {
+		if (resolved.minItems !== undefined && value.length < resolved.minItems) {
+			error(path, `needs at least ${resolved.minItems} item(s)`);
+		}
+		if (resolved.items) {
+			value.forEach((item, index) =>
+				validate(item, resolved.items, `${path}[${index}]`, root),
+			);
+		}
+		return;
+	}
+
+	if (resolved.type === 'object' || resolved.properties) {
+		const allowed = Object.keys(resolved.properties ?? {});
+
+		for (const key of resolved.required ?? []) {
+			if (!(key in value)) {
+				error(path, `missing required key "${key}"`);
+			}
+		}
+
+		for (const [key, child] of Object.entries(value)) {
+			const childPath = path ? `${path}.${key}` : key;
+			if (!allowed.includes(key)) {
+				if (resolved.additionalProperties === false) {
+					error(
+						childPath,
+						`unknown key — CCManager ignores it silently.${suggest(
+							key,
+							allowed,
+						)}`,
+					);
+				}
+				continue;
+			}
+			validate(child, resolved.properties[key], childPath, root);
+		}
+	}
+}
+
+/* ------------------------------------------------------------------ *
+ * Checks the schema cannot express
+ * ------------------------------------------------------------------ */
+
+// Which detection strategy each known assistant command needs, so that
+// CCManager reads idle/busy/waiting out of that CLI's output correctly.
+const STRATEGY_BY_COMMAND = {
+	claude: 'claude',
+	gemini: 'gemini',
+	codex: 'codex',
+	'cursor-agent': 'cursor',
+	copilot: 'github-copilot',
+	cline: 'cline',
+	opencode: 'opencode',
+	kimi: 'kimi',
+};
+
+function lintCommandPresets(config) {
+	const presetsConfig = config.commandPresets;
+	if (!presetsConfig || typeof presetsConfig !== 'object') return;
+	const presets = Array.isArray(presetsConfig.presets)
+		? presetsConfig.presets
+		: [];
+
+	const seen = new Map();
+	presets.forEach((preset, index) => {
+		if (!preset || typeof preset !== 'object') return;
+		const path = `commandPresets.presets[${index}]`;
+
+		if (typeof preset.id === 'string') {
+			if (seen.has(preset.id)) {
+				error(
+					`${path}.id`,
+					`duplicate id "${preset.id}" (also used by preset ${seen.get(
+						preset.id,
+					)})`,
+				);
+			}
+			seen.set(preset.id, index);
+		}
+
+		for (const key of ['args', 'fallbackArgs']) {
+			const list = preset[key];
+			if (!Array.isArray(list)) continue;
+			list.forEach((argument, argIndex) => {
+				if (typeof argument === 'string' && /\s/.test(argument.trim())) {
+					warn(
+						`${path}.${key}[${argIndex}]`,
+						`"${argument}" is passed as one argv entry, spaces included. Split it: ${JSON.stringify(
+							argument.trim().split(/\s+/),
+						)}`,
+					);
+				}
+			});
+		}
+
+		const expected = STRATEGY_BY_COMMAND[basename(preset.command ?? '')];
+		const actual = preset.detectionStrategy ?? 'claude';
+		if (expected && expected !== actual) {
+			warn(
+				`${path}.detectionStrategy`,
+				`command "${preset.command}" reports its state differently from "${actual}". Set "detectionStrategy": "${expected}" or session status will be wrong.`,
+			);
+		}
+	});
+
+	if (typeof presetsConfig.defaultPresetId === 'string' && presets.length > 0) {
+		if (!seen.has(presetsConfig.defaultPresetId)) {
+			error(
+				'commandPresets.defaultPresetId',
+				`"${presetsConfig.defaultPresetId}" matches no preset in this file. CCManager falls back to the first preset.`,
+			);
+		}
+	}
+}
+
+function lintShortcuts(config) {
+	const shortcuts = config.shortcuts;
+	if (!shortcuts || typeof shortcuts !== 'object') return;
+
+	for (const [name, shortcut] of Object.entries(shortcuts)) {
+		if (!shortcut || typeof shortcut !== 'object') continue;
+		const path = `shortcuts.${name}`;
+
+		if (shortcut.alt === true || shortcut.shift === true) {
+			error(
+				path,
+				'alt and shift are never matched at runtime — such a shortcut can never fire. Use ctrl, or "escape".',
+			);
+		}
+
+		if (typeof shortcut.key === 'string' && shortcut.key !== 'escape') {
+			if (shortcut.key.length !== 1) {
+				error(
+					path,
+					`key "${shortcut.key}" is neither a single character nor "escape".`,
+				);
+			}
+			if (shortcut.ctrl !== true) {
+				error(
+					path,
+					'non-escape shortcuts need "ctrl": true. Without it the binding either never fires or swallows a plain keystroke.',
+				);
+			}
+			if (['c', 'd', '['].includes(shortcut.key.toLowerCase())) {
+				warn(
+					path,
+					`Ctrl+${shortcut.key.toUpperCase()} is used by the terminal itself; pick another key.`,
+				);
+			}
+		}
+	}
+}
+
+function lintHooks(config) {
+	for (const group of ['statusHooks', 'worktreeHooks']) {
+		const hooks = config[group];
+		if (!hooks || typeof hooks !== 'object') continue;
+		for (const [name, hook] of Object.entries(hooks)) {
+			if (!hook || typeof hook !== 'object') continue;
+			if (hook.enabled === false) {
+				warn(
+					`${group}.${name}`,
+					'"enabled": false — the command is stored but never runs.',
+				);
+			}
+		}
+	}
+}
+
+function lintWorktree(config) {
+	const worktree = config.worktree;
+	if (!worktree || typeof worktree !== 'object') return;
+
+	const pattern = worktree.autoDirectoryPattern;
+	if (typeof pattern === 'string' && !/\{branch\}/.test(pattern)) {
+		error(
+			'worktree.autoDirectoryPattern',
+			'contains no {branch} placeholder, so every worktree resolves to the same directory and creation fails after the first.',
+		);
+	}
+	if (typeof pattern === 'string' && worktree.autoDirectory !== true) {
+		warn(
+			'worktree.autoDirectoryPattern',
+			'is only used when "autoDirectory": true is also set (here or in the global config).',
+		);
+	}
+}
+
+function lintAutoApproval(config) {
+	const autoApproval = config.autoApproval;
+	if (!autoApproval || typeof autoApproval !== 'object') return;
+
+	if (autoApproval.enabled === true && !autoApproval.customCommand) {
+		warn(
+			'autoApproval',
+			'the built-in check shells out to the `claude` CLI; it must be on PATH, or set "customCommand".',
+		);
+	}
+	if (typeof autoApproval.timeout === 'number' && autoApproval.timeout > 600) {
+		warn(
+			'autoApproval.timeout',
+			`${autoApproval.timeout} seconds — the session stays blocked that long on a hung check.`,
+		);
+	}
+}
+
+function lintLocation(configPath) {
+	if (basename(configPath) !== '.ccmanager.json') return;
+
+	const gitPath = join(dirname(configPath), '.git');
+	if (!existsSync(gitPath)) {
+		warn(
+			configPath,
+			'no .git here — CCManager only reads `.ccmanager.json` from the git repository root.',
+		);
+		return;
+	}
+	if (statSync(gitPath).isDirectory()) return;
+
+	// A `.git` file means a linked worktree or a submodule. CCManager resolves
+	// a linked worktree back to the main repository root
+	// (src/utils/gitUtils.ts, getGitRepositoryRoot), so a config placed inside
+	// the worktree is never read; a submodule keeps its own root.
+	const gitdir = readFileSync(gitPath, 'utf-8');
+	if (gitdir.includes('.git/worktrees/')) {
+		error(
+			configPath,
+			'this is a linked worktree. CCManager reads the main repository\'s `.ccmanager.json` instead, so this file has no effect — move it to the main checkout.',
+		);
+	}
+}
+
+/* ------------------------------------------------------------------ */
+
+const configPath = resolve(process.argv[2] ?? '.ccmanager.json');
+
+if (!existsSync(configPath)) {
+	console.error(`No config file at ${configPath}`);
+	process.exit(1);
+}
+
+const raw = readFileSync(configPath, 'utf-8');
+let config;
+try {
+	config = JSON.parse(raw);
+} catch (parseError) {
+	console.error(`${configPath}`);
+	console.error(`  ERROR  invalid JSON: ${parseError.message}`);
+	console.error(
+		'  CCManager drops the whole file when it cannot parse it — every setting in it is currently inactive.',
+	);
+	process.exit(1);
+}
+
+if (typeOf(config) !== 'object') {
+	console.error(`${configPath}`);
+	console.error(`  ERROR  top level must be a JSON object`);
+	process.exit(1);
+}
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf-8'));
+validate(config, schema, '', schema);
+lintCommandPresets(config);
+lintShortcuts(config);
+lintHooks(config);
+lintWorktree(config);
+lintAutoApproval(config);
+lintLocation(configPath);
+
+console.log(configPath);
+for (const {path, message} of errors) {
+	console.log(`  ERROR  ${path || '<root>'}: ${message}`);
+}
+for (const {path, message} of warnings) {
+	console.log(`  WARN   ${path || '<root>'}: ${message}`);
+}
+if (errors.length === 0 && warnings.length === 0) {
+	console.log('  OK     no problems found');
+}
+
+process.exit(errors.length > 0 ? 1 : 0);

--- a/plugins/ccmanager-config/validate-examples.test.ts
+++ b/plugins/ccmanager-config/validate-examples.test.ts
@@ -1,0 +1,135 @@
+import {describe, it, expect} from 'vitest';
+import {execFileSync} from 'child_process';
+import {readFileSync, writeFileSync, mkdtempSync, readdirSync} from 'fs';
+import {tmpdir} from 'os';
+import {join, dirname} from 'path';
+import {fileURLToPath} from 'url';
+
+/**
+ * Guards the ccmanager-config skill: every configuration example it ships must
+ * still pass the validator it ships, so the two cannot drift apart as the
+ * config schema changes.
+ */
+
+const pluginRoot = dirname(fileURLToPath(import.meta.url));
+const skillRoot = join(pluginRoot, 'skills', 'ccmanager-config');
+const validator = join(skillRoot, 'scripts', 'validate-ccmanager-config.mjs');
+
+// Documents carrying config examples. SKILL.md deliberately carries none — it
+// routes to these instead.
+const docs = [
+	join(skillRoot, 'references', 'config-reference.md'),
+	join(skillRoot, 'references', 'recipes.md'),
+	join(pluginRoot, 'README.md'),
+];
+
+function runValidator(config: string): {status: number; output: string} {
+	const dir = mkdtempSync(join(tmpdir(), 'ccmanager-config-'));
+	const file = join(dir, 'config.json');
+	writeFileSync(file, config);
+	try {
+		const output = execFileSync('node', [validator, file], {encoding: 'utf-8'});
+		return {status: 0, output};
+	} catch (error) {
+		const failure = error as {status: number; stdout: string; stderr: string};
+		return {
+			status: failure.status,
+			output: `${failure.stdout ?? ''}${failure.stderr ?? ''}`,
+		};
+	}
+}
+
+function jsonBlocks(doc: string): string[] {
+	const text = readFileSync(doc, 'utf-8');
+	return [...text.matchAll(/```json\n([\s\S]*?)```/g)].map(match => match[1]!);
+}
+
+describe('ccmanager-config skill', () => {
+	it('ships a skill entrypoint with the frontmatter both CLIs require', () => {
+		const skill = readFileSync(join(skillRoot, 'SKILL.md'), 'utf-8');
+		expect(skill.startsWith('---\n')).toBe(true);
+		expect(skill).toMatch(/^name: ccmanager-config$/m);
+		expect(skill).toMatch(/^description: /m);
+	});
+
+	it('is listed in the marketplace manifest', () => {
+		const marketplace = JSON.parse(
+			readFileSync(
+				join(pluginRoot, '..', '..', '.claude-plugin', 'marketplace.json'),
+				'utf-8',
+			),
+		) as {plugins: Array<{name: string; source: string}>};
+		expect(
+			marketplace.plugins.some(
+				plugin =>
+					plugin.name === 'ccmanager-config' &&
+					plugin.source === './plugins/ccmanager-config',
+			),
+		).toBe(true);
+	});
+
+	for (const doc of docs) {
+		const blocks = jsonBlocks(doc);
+		it(`has at least one example in ${doc.slice(pluginRoot.length + 1)}`, () => {
+			expect(blocks.length).toBeGreaterThan(0);
+		});
+
+		blocks.forEach((block, index) => {
+			it(`validates example ${index} in ${doc.slice(pluginRoot.length + 1)}`, () => {
+				const {status, output} = runValidator(block);
+				expect(output).not.toMatch(/ERROR/);
+				expect(status).toBe(0);
+			});
+		});
+	}
+
+	it('reports the silent failures CCManager itself hides', () => {
+		const {status, output} = runValidator(
+			JSON.stringify({
+				worktree: {autoDirectory: true, copySesionData: true},
+				statusHooks: {idle: {command: 'true'}},
+				commandPresets: {
+					presets: [{id: 'a', name: 'A', command: 'codex'}],
+					defaultPresetId: 'missing',
+				},
+			}),
+		);
+
+		expect(status).toBe(1);
+		// unknown key, with a suggestion
+		expect(output).toMatch(/copySesionData.*copySessionData/);
+		// hook that would never run
+		expect(output).toMatch(/statusHooks\.idle.*enabled/);
+		// preset id that resolves to nothing
+		expect(output).toMatch(/defaultPresetId/);
+		// detection strategy that does not match the command
+		expect(output).toMatch(/detectionStrategy.*codex/);
+	});
+
+	it('rejects a config file placed inside a linked worktree', () => {
+		const dir = mkdtempSync(join(tmpdir(), 'ccmanager-config-wt-'));
+		writeFileSync(join(dir, '.git'), 'gitdir: /repo/.git/worktrees/feature\n');
+		writeFileSync(join(dir, '.ccmanager.json'), '{}');
+
+		let status = 0;
+		let output = '';
+		try {
+			output = execFileSync('node', [validator, join(dir, '.ccmanager.json')], {
+				encoding: 'utf-8',
+			});
+		} catch (error) {
+			const failure = error as {status: number; stdout: string};
+			status = failure.status;
+			output = failure.stdout ?? '';
+		}
+
+		expect(status).toBe(1);
+		expect(output).toMatch(/linked worktree/);
+	});
+
+	it('keeps the schema and the validator in the same directory tree', () => {
+		expect(readdirSync(join(skillRoot, 'schema'))).toContain(
+			'ccmanager.schema.json',
+		);
+	});
+});


### PR DESCRIPTION
## Why

CCManager stays silent when its configuration is wrong. An unparseable `.ccmanager.json` is discarded whole (`ProjectConfigManager.loadProjectConfig` swallows the parse error), and keys it does not know are never read — so a typo is indistinguishable from a feature that does not work. Getting a config right today means reading the TypeScript types.

This adds an agent skill that carries the schema and can check a file for exactly those silent failures, so `.ccmanager.json` can be written or repaired by asking for it in plain language.

## What

`plugins/ccmanager-config/` is a plugin holding one skill: the procedure in `SKILL.md`, a per-key reference, goal-oriented recipes, a JSON Schema covering both config files, and a dependency-free validator. The plugin README describes the layout.

Beyond schema shape, the validator reports the mistakes JSON cannot express: an unknown key (with a did-you-mean), a `defaultPresetId` matching no preset, duplicate preset ids, an `args` entry holding several tokens in one string, a `detectionStrategy` contradicting `command`, a shortcut that can never fire, a hook left disabled, an `autoDirectoryPattern` without `{branch}`, and a `.ccmanager.json` placed inside a linked worktree — which CCManager resolves back to the main checkout, so the file is never read.

`.claude-plugin/marketplace.json` at the repository root turns this repo into a plugin marketplace. Codex accepts Claude's plugin manifests, so one set of files installs from either CLI; the commands are in the READMEs.

## Incidental doc fixes

Three claims in `docs/` that the source contradicts, corrected because the skill would otherwise contradict the documentation:

- `docs/project-config.md` showed a `command` key. No config reader reads it; `commandPresets` is the supported shape.
- `docs/auto-approval.md` stated a fixed 60 s timeout. It is `autoApproval.timeout`, defaulting to `DEFAULT_TIMEOUT_SECONDS` (120).
- `docs/worktree-auto-directory.md` listed `{branch-name}` as a placeholder. The substitution regex matches word characters only, so a dashed placeholder is left in the path verbatim.

## Verification

- `bun run lint`, `bun run typecheck`: pass.
- `bun run test`: passes, including the new `validate-examples.test.ts`, which runs the shipped validator over every configuration example in the skill so the docs and the validator cannot drift apart. Six pre-existing `*.submodule.test.*` suites fail locally because the sandbox blocks `git config --global`; they are unrelated to this change and untouched by it.
- Installed the plugin end-to-end with both `claude plugin install` and `codex plugin add` against throwaway config homes: the skill is discovered by both, with every file copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)